### PR TITLE
fix: filter archived/removed images in Cypher queries

### DIFF
--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -155,15 +155,19 @@ LIMIT toInteger($limit)
 OPTIONAL MATCH (d)-[:HAS_ALBUM]->(album:Album)
 OPTIONAL MATCH (album)-[:HAS_IMAGE]->(image:Image)
 WHERE image.id IS NOT NULL
+  AND (image.archived IS NULL OR image.archived = false)
+  AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters,
      weightedVotesCount, comments, hotRank, serverRoles, channelRoles,
      album,
-     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL AND image.archived <> true AND image.permanentlyRemoved <> true THEN {
+     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
          id: image.id,
          url: image.url,
          alt: image.alt,
-         caption: image.caption
+         caption: image.caption,
+         archived: image.archived,
+         permanentlyRemoved: image.permanentlyRemoved
      } END) WHERE img IS NOT NULL] AS albumImages
 
 // Check if the logged-in user has favorited this discussion

--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -143,13 +143,17 @@ LIMIT toInteger($limit)
 OPTIONAL MATCH (d)-[:HAS_ALBUM]->(album:Album)
 OPTIONAL MATCH (album)-[:HAS_IMAGE]->(image:Image)
 WHERE image.id IS NOT NULL
+  AND (image.archived IS NULL OR image.archived = false)
+  AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
 WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRoles, album,
-     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL AND image.archived <> true AND image.permanentlyRemoved <> true THEN {
+     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
          id: image.id,
          url: image.url,
          alt: image.alt,
-         caption: image.caption
+         caption: image.caption,
+         archived: image.archived,
+         permanentlyRemoved: image.permanentlyRemoved
      } END) WHERE img IS NOT NULL] AS albumImages
 
 // Check if the logged-in user has favorited this discussion

--- a/customResolvers/fields/emptyArrayFallback.ts
+++ b/customResolvers/fields/emptyArrayFallback.ts
@@ -4,11 +4,24 @@
  * This fixes GraphQL errors where the schema defines a field as non-nullable array
  * (e.g., [User!]!) but the Neo4j OGM returns null when there are no relationships.
  *
+ * For custom Cypher queries that pre-populate relationship data, this resolver
+ * returns the pre-populated data directly, avoiding re-resolution by the OGM.
+ *
  * @param fieldName - The name of the field on the parent object
  * @returns A resolver function that returns the field value or an empty array
  */
 export default function emptyArrayFallback(fieldName: string) {
   return (parent: any) => {
-    return parent[fieldName] || [];
+    const value = parent?.[fieldName];
+
+    // If the value is an array (even empty), return it directly
+    // This ensures pre-populated data from Cypher queries is used
+    if (Array.isArray(value)) {
+      // Filter out null values that might come from Cypher COLLECT with CASE WHEN
+      return value.filter((item: any) => item !== null);
+    }
+
+    // Fallback to empty array for null/undefined
+    return [];
   };
 }

--- a/customResolvers/queries/getSiteWideDiscussionList.ts
+++ b/customResolvers/queries/getSiteWideDiscussionList.ts
@@ -112,9 +112,7 @@ const getResolver = (input: Input) => {
             totalCount = topRecord.get("totalCount");
           }
           let topDiscussions = topDiscussionsResult.records.map(
-            (record: any) => {
-              return record.get("discussion");
-            }
+            (record: any) => record.get("discussion")
           );
 
           return {
@@ -150,9 +148,7 @@ const getResolver = (input: Input) => {
             totalCount = hotRecord.get("totalCount");
           }
           let hotDiscussions = hotDiscussionsResult.records.map(
-            (record: any) => {
-              return record.get("discussion");
-            }
+            (record: any) => record.get("discussion")
           );
 
           return {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1383,6 +1383,7 @@ const typeDefinitions = gql`
     weightedVotesCount: Float
     CommentsAggregate: CommentAggregateResult
     UpvotedByUsers: [User!]!
+    SuperUpvotedByUsers: [User!]!
     UpvotedByUsersAggregate: UserAggregateResult
     Discussion: Discussion
     Channel: Channel


### PR DESCRIPTION
## Summary
- Add WHERE clause to filter out archived and permanentlyRemoved images in custom Cypher queries
- Filter out null values from COLLECT results in Cypher queries
- Update emptyArrayFallback resolver to handle null values in arrays
- Add SuperUpvotedByUsers field to DiscussionChannelListItem type

## Problem
Album images were not displaying because the Neo4j GraphQL library's `_NOT` filter doesn't handle null values correctly. Images with `archived: null` were being incorrectly excluded by the `archived_NOT: true` filter in OGM queries.

## Solution
- Updated Cypher queries to explicitly filter images with `(image.archived IS NULL OR image.archived = false)`
- Added null filtering to array results from COLLECT operations
- Note: Existing Image nodes with null values for archived/permanentlyRemoved should be updated to have explicit `false` values

## Test plan
- [x] Verified images now appear on /discussions page list view
- [x] Verified images appear when clicking "Expand" on individual discussions
- [x] Verified images appear in discussion detail sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)