### PR TITLE
fix(auth): accept the dedicated app API audience as a programmatic token

### DIFF
--- a/rules/permission/userDataHelperFunctions.ts
+++ b/rules/permission/userDataHelperFunctions.ts
@@ -331,13 +331,24 @@ export const setUserDataOnContext = async (
       // Check the audience of the token
       const audience = decoded?.aud;
 
+      // A token is accepted as "programmatic" (server-to-server / server-session)
+      // if its audience matches a recognized API. `aud` may be a string or an
+      // array, so match either form.
+      const audienceMatches = (target: string | undefined) =>
+        !!target &&
+        (audience === target ||
+          (Array.isArray(audience) && audience.includes(target)));
+      const isProgrammaticToken =
+        // Legacy: tokens minted for the Auth0 Management API.
+        audienceMatches("https://gennit.us.auth0.com/api/v2/") ||
+        // Dedicated app API (server-session SDK). Set AUTH0_AUDIENCE to the
+        // API identifier registered in Auth0, e.g. https://api.c0nduit.app
+        audienceMatches(process.env.AUTH0_AUDIENCE);
+
       if (audience === process.env.AUTH0_CLIENT_ID) {
         // UI-based token
         email = decoded?.email;
-      } else if (
-        Array.isArray(audience) &&
-        audience.includes("https://gennit.us.auth0.com/api/v2/")
-      ) {
+      } else if (isProgrammaticToken) {
         // Programmatic token
 
         // Check if userinfo is cached


### PR DESCRIPTION
## Why

`setUserDataOnContext` only recognized programmatic tokens whose audience was the Auth0 **Management API** (`https://gennit.us.auth0.com/api/v2/`). The new `@auth0/auth0-nuxt` server session mints access tokens for the **dedicated app API** audience instead, so those tokens fell through the audience checks and the email/user lookup failed.

This is the backend half that lets the Nuxt server resolve a user's app username/profile **server-side** from the session (the frontend's server-side `GET_EMAIL` lookup depends on it).

## What

- Accept either audience as a programmatic token:
  - the legacy Management API value, and
  - the app API identifier from `AUTH0_AUDIENCE` (e.g. `https://api.c0nduit.app`).
- The match handles `aud` as a string **or** an array.

## Notes

- Requires `AUTH0_AUDIENCE` to be set (to the API identifier registered in Auth0) in the backend environment.

## Verification

- `tsc` clean.
- Full backend test suite: **422 passed, 0 failed** (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)