### PR TITLE
feat: undo super upvote

### DIFF
--- a/customResolvers.ts
+++ b/customResolvers.ts
@@ -124,6 +124,7 @@ import createDownloadableFileUrlResolver from './customResolvers/fields/download
 import updateDownloadLabels from './customResolvers/mutations/updateDownloadLabels.js';
 
 import createScratchpadEntry from './customResolvers/mutations/createScratchpadEntry.js';
+import undoSuperUpvote from './customResolvers/mutations/undoSuperUpvote.js';
 import updateScratchpadEntryVisibility from './customResolvers/mutations/updateScratchpadEntryVisibility.js';
 import deleteScratchpadEntry from './customResolvers/mutations/deleteScratchpadEntry.js';
 
@@ -204,8 +205,15 @@ export default function (driver: any) {
     DiscussionChannel: {
       SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
     },
+    DiscussionChannelListItem: {
+      SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
+      UpvotedByUsers: emptyArrayFallback('UpvotedByUsers'),
+    },
     Comment: {
       SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
+    },
+    ScratchpadEntry: {
+      superUpvotedByUsers: (parent: any) => parent.superUpvotedByUsers || [],
     },
     Album: {
       Images: emptyArrayFallback('Images'),
@@ -705,6 +713,12 @@ export default function (driver: any) {
         Comment,
         DiscussionChannel,
         User,
+        driver,
+      }),
+      undoSuperUpvote: undoSuperUpvote({
+        Comment,
+        DiscussionChannel,
+        ScratchpadEntry,
         driver,
       }),
       updateScratchpadEntryVisibility: updateScratchpadEntryVisibility({

--- a/customResolvers/cypher/getCommentRepliesQuery.cypher
+++ b/customResolvers/cypher/getCommentRepliesQuery.cypher
@@ -5,6 +5,7 @@ OPTIONAL MATCH (child)<-[:AUTHORED_COMMENT]-(author:User)
 OPTIONAL MATCH (author)-[:HAS_SERVER_ROLE]->(serverRole:ServerRole)
 OPTIONAL MATCH (author)-[:HAS_CHANNEL_ROLE]->(channelRole:ChannelRole)
 OPTIONAL MATCH (child)<-[:UPVOTED_COMMENT]-(upvoter:User)
+OPTIONAL MATCH (child)<-[:SUPER_UPVOTED_COMMENT]-(superUpvoter:User)
 OPTIONAL MATCH (child)-[:HAS_VERSION]->(pastVersion:TextVersion)<-[:AUTHORED_VERSION]-(pastVersionAuthor:User)
 OPTIONAL MATCH (favUser:User { username: $loggedInUsername })-[:DEFAULT_FAVORITES_COMMENTS]->(child)
 
@@ -13,6 +14,7 @@ WITH parentComment, child, author,
      COLLECT(DISTINCT serverRole) AS serverRoles,
      COLLECT(DISTINCT channelRole) AS channelRoles,
      COLLECT(DISTINCT upvoter) AS UpvotedByUsers,
+     COLLECT(DISTINCT superUpvoter) AS SuperUpvotedByUsers,
      COUNT(DISTINCT favUser) > 0 AS isFavoritedByUser,
      COLLECT(DISTINCT CASE WHEN pastVersion IS NOT NULL THEN {
        id: pastVersion.id,
@@ -25,39 +27,39 @@ WITH parentComment, child, author,
 
 // Get the count of grandchild comments separately
 OPTIONAL MATCH (child)<-[:IS_REPLY_TO]-(grandchild:Comment)
-WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, PastVersions, isFavoritedByUser,
+WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, SuperUpvotedByUsers, PastVersions, isFavoritedByUser,
      COUNT(DISTINCT grandchild) AS GrandchildCommentsCount
 
 // Match feedback comments
 OPTIONAL MATCH (child)<-[:HAS_FEEDBACK_COMMENT]-(feedbackComment:Comment)<-[:AUTHORED_COMMENT]-(feedbackAuthor:ModerationProfile)
-WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, PastVersions, GrandchildCommentsCount, isFavoritedByUser,
+WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, SuperUpvotedByUsers, PastVersions, GrandchildCommentsCount, isFavoritedByUser,
      COLLECT(DISTINCT CASE WHEN feedbackComment IS NOT NULL THEN {id: feedbackComment.id} END) AS FeedbackComments,
      COLLECT(DISTINCT feedbackAuthor) AS FeedbackAuthors
 
 // Filter for specific moderator feedback
-WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, 
-     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions, 
+WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, SuperUpvotedByUsers,
+     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
      GrandchildCommentsCount, FeedbackComments, FeedbackAuthors, isFavoritedByUser,
      CASE WHEN $modName IS NOT NULL THEN [comment IN FeedbackComments WHERE ANY(author IN FeedbackAuthors WHERE author.displayName = $modName)] ELSE [] END AS FilteredFeedbackComments
 
 // Calculations for the sorting formulae
 WITH parentComment, child, author, serverRoles, channelRoles, GrandchildCommentsCount, FilteredFeedbackComments, isFavoritedByUser,
-     UpvotedByUsers, FilteredPastVersions,
-     duration.between(child.createdAt, datetime()).months + 
+     UpvotedByUsers, SuperUpvotedByUsers, FilteredPastVersions,
+     duration.between(child.createdAt, datetime()).months +
      duration.between(child.createdAt, datetime()).days / 30.0 AS ageInMonths,
      CASE WHEN coalesce(child.weightedVotesCount, 0) < 0 THEN 0 ELSE coalesce(child.weightedVotesCount, 0) END AS weightedVotesCount
 
-WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, ageInMonths, weightedVotesCount,
+WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, SuperUpvotedByUsers, ageInMonths, weightedVotesCount,
      GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
      10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH parentComment, child, author, UpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
+WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
      serverRoles, channelRoles
 
-WITH parentComment, child, author, UpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
+WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
      [role IN serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRoles
 
-WITH parentComment, child, author, UpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, serverRoles, isFavoritedByUser,
+WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, serverRoles, isFavoritedByUser,
      [role IN channelRoles | {showModTag: role.showModTag}] AS channelRoles
 
 // Structure the return data
@@ -87,6 +89,7 @@ RETURN {
     UpvotedByUsersAggregate: {
         count: SIZE(UpvotedByUsers)
     },
+    SuperUpvotedByUsers: [user IN SuperUpvotedByUsers | user{.*, createdAt: toString(user.createdAt)}],
     ChildCommentsAggregate: {
         count: GrandchildCommentsCount
     },

--- a/customResolvers/cypher/getCommentsQuery.cypher
+++ b/customResolvers/cypher/getCommentsQuery.cypher
@@ -8,19 +8,21 @@ OPTIONAL MATCH (author)-[:HAS_CHANNEL_ROLE]->(channelRole:ChannelRole)
 OPTIONAL MATCH (c)-[:IS_REPLY_TO]->(parent:Comment)
 OPTIONAL MATCH (c)<-[:IS_REPLY_TO]-(child:Comment)
 OPTIONAL MATCH (c)<-[:UPVOTED_COMMENT]-(upvoter:User)
+OPTIONAL MATCH (c)<-[:SUPER_UPVOTED_COMMENT]-(superUpvoter:User)
 OPTIONAL MATCH (c)-[:HAS_VERSION]->(pastVersion:TextVersion)<-[:AUTHORED_VERSION]-(pastVersionAuthor:User)
 OPTIONAL MATCH (favUser:User { username: $loggedInUsername })-[:DEFAULT_FAVORITES_COMMENTS]->(c)
 
-WITH c, author, serverRole, channelRole, parent, child, upvoter, $modName AS modName, pastVersion, pastVersionAuthor, favUser
+WITH c, author, serverRole, channelRole, parent, child, upvoter, superUpvoter, $modName AS modName, pastVersion, pastVersionAuthor, favUser
 
 OPTIONAL MATCH (c)<-[:HAS_FEEDBACK_COMMENT]-(feedbackComment:Comment)<-[:AUTHORED_COMMENT]-(feedbackAuthor:ModerationProfile)
 
-WITH c, author, serverRole, channelRole, parent, child, upvoter, modName, feedbackComment, feedbackAuthor, pastVersion, pastVersionAuthor, favUser,
+WITH c, author, serverRole, channelRole, parent, child, upvoter, superUpvoter, modName, feedbackComment, feedbackAuthor, pastVersion, pastVersionAuthor, favUser,
      CASE WHEN modName IS NOT NULL AND feedbackAuthor.displayName = modName THEN feedbackComment
           ELSE NULL END AS filteredFeedbackComment
 
 WITH c, author, serverRole, channelRole, parent,
-     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers, 
+     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers,
+     COLLECT(DISTINCT superUpvoter{.*, createdAt: toString(superUpvoter.createdAt)}) AS SuperUpvotedByUsers,
      COLLECT(DISTINCT parent.id) AS parentIds,
      COLLECT(DISTINCT filteredFeedbackComment {id: feedbackComment.id}) AS FeedbackComments,
      COLLECT(DISTINCT CASE WHEN child IS NOT NULL THEN {id: child.id, text: child.text} ELSE null END) AS NonFilteredChildComments,
@@ -34,30 +36,30 @@ WITH c, author, serverRole, channelRole, parent,
      } ELSE null END) AS PastVersions,
      COUNT(DISTINCT favUser) > 0 AS isFavoritedByUser,
      // Compute the age in months from the createdAt timestamp.
-     duration.between(c.createdAt, datetime()).months + 
+     duration.between(c.createdAt, datetime()).months +
      duration.between(c.createdAt, datetime()).days / 30.0 AS ageInMonths,
      CASE WHEN coalesce(c.weightedVotesCount, 0) < 0 THEN 0 ELSE coalesce(c.weightedVotesCount, 0) END AS weightedVotesCount
 
-WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, parentIds, weightedVotesCount, ageInMonths, isFavoritedByUser,
+WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, weightedVotesCount, ageInMonths, isFavoritedByUser,
     [comment IN NonFilteredChildComments WHERE comment.id IS NOT NULL] AS ChildComments,
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
     FeedbackComments
 
-WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, isFavoritedByUser,
+WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, isFavoritedByUser,
     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
 // Collect distinct server roles which should be attached to the comment author.
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
      COLLECT(DISTINCT serverRole) AS serverRoles, channelRole
 
 // Each serverRole should include: {showAdminTag: role.showAdminTag}
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
         [role IN serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRole
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
      COLLECT(DISTINCT channelRole) AS channelRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
         [role IN channelRoles | {showModTag: role.showModTag}] AS channelRoles
 
 RETURN {
@@ -85,6 +87,7 @@ RETURN {
     UpvotedByUsersAggregate: {
         count: SIZE(UpvotedByUsers)
     },
+    SuperUpvotedByUsers: SuperUpvotedByUsers,
     ChildComments: CASE WHEN SIZE(ChildComments) > 0 THEN ChildComments ELSE [] END,
     ChildCommentsAggregate: {
         count: SIZE(ChildComments)

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -113,42 +113,49 @@ WITH dc, d, author, serverRole, channelRole, tagsText,
 
 // Filter for logged-in user's upvote
 OPTIONAL MATCH (loggedInUser:User {username: loggedInUsername})-[:UPVOTED_DISCUSSION]->(dc)
-WITH dc, d, author, serverRole, channelRole, tagsText, 
-     CASE 
+// Filter for logged-in user's super upvote
+OPTIONAL MATCH (loggedInSuperUpvoter:User {username: loggedInUsername})-[:SUPER_UPVOTED_DISCUSSION]->(dc)
+WITH dc, d, author, serverRole, channelRole, tagsText,
+     CASE
          WHEN loggedInUsername = "" THEN []
          WHEN loggedInUser IS NOT NULL THEN [{username: loggedInUser.username}]
          ELSE []
      END AS loggedInUserUpvote,
+     CASE
+         WHEN loggedInUsername = "" THEN []
+         WHEN loggedInSuperUpvoter IS NOT NULL THEN [{username: loggedInSuperUpvoter.username}]
+         ELSE []
+     END AS loggedInUserSuperUpvote,
      totalUpvoters,
      totalCount,
      CASE WHEN coalesce(dc.weightedVotesCount, 0.0) < 0 THEN 0.0 ELSE coalesce(dc.weightedVotesCount, 0.0) END AS weightedVotesCount
 
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
-WITH dc, d, author, serverRole, channelRole, COLLECT(c) AS comments, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, totalCount,
-     duration.between(dc.createdAt, datetime()).months + 
+WITH dc, d, author, serverRole, channelRole, COLLECT(c) AS comments, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, totalCount,
+     duration.between(dc.createdAt, datetime()).months +
      duration.between(dc.createdAt, datetime()).days / 30.0 AS ageInMonths
 
-WITH dc, d, author, serverRole, channelRole, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, comments, totalCount,
+WITH dc, d, author, serverRole, channelRole, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, totalCount,
      10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
+WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
      COLLECT(DISTINCT serverRole) AS serverRoles, channelRole
 
-WITH dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRole, totalCount
+WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRole, totalCount
 
-WITH dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
-     [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, 
+WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
+     [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles,
      [role in COLLECT(DISTINCT channelRole) | {showModTag: role.showModTag}] AS channelRoles
 
 // Sort based on individual elements, not the collection
-ORDER BY 
+ORDER BY
     CASE WHEN $sortOption = "new" THEN dc.createdAt END DESC,
     CASE WHEN $sortOption = "top" THEN weightedVotesCount END DESC,
     CASE WHEN $sortOption = "hot" THEN hotRank END DESC,
     dc.createdAt DESC
 
 // Apply pagination
-WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRoles
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRoles
 SKIP toInteger($offset)
 LIMIT toInteger($limit)
 
@@ -158,7 +165,7 @@ WHERE image.id IS NOT NULL
   AND (image.archived IS NULL OR image.archived = false)
   AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
-WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters,
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
      weightedVotesCount, comments, hotRank, serverRoles, channelRoles,
      album,
      [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
@@ -172,7 +179,7 @@ WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters,
 
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)
-WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters,
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
      weightedVotesCount, comments, hotRank, serverRoles, channelRoles, album, albumImages,
      CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null WHEN favUser IS NOT NULL THEN true ELSE false END AS isFavorited
 
@@ -191,8 +198,9 @@ RETURN {
     },
     UpvotedByUsers: [up in loggedInUserUpvote | { username: up.username }],
     UpvotedByUsersAggregate: {
-        count: totalUpvoters 
+        count: totalUpvoters
     },
+    SuperUpvotedByUsers: [sup in loggedInUserSuperUpvote | { username: sup.username }],
     Discussion: {
         id: d.id,
         title: d.title,

--- a/customResolvers/cypher/getEventCommentsQuery.cypher
+++ b/customResolvers/cypher/getEventCommentsQuery.cypher
@@ -7,11 +7,13 @@ OPTIONAL MATCH (author)-[:HAS_CHANNEL_ROLE]->(channelRole:ChannelRole)
 OPTIONAL MATCH (c)-[:IS_REPLY_TO]->(parent:Comment)
 OPTIONAL MATCH (c)<-[:IS_REPLY_TO]-(child:Comment)
 OPTIONAL MATCH (c)<-[:UPVOTED_COMMENT]-(upvoter:User)
+OPTIONAL MATCH (c)<-[:SUPER_UPVOTED_COMMENT]-(superUpvoter:User)
 OPTIONAL MATCH (c)-[:HAS_VERSION]->(pastVersion:TextVersion)<-[:AUTHORED_VERSION]-(pastVersionAuthor:User)
 OPTIONAL MATCH (favUser:User { username: $loggedInUsername })-[:DEFAULT_FAVORITES_COMMENTS]->(c)
 
 WITH c, author, parent, serverRole, channelRole, pastVersion, pastVersionAuthor, favUser,
-     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers, 
+     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers,
+     COLLECT(DISTINCT superUpvoter{.*, createdAt: toString(superUpvoter.createdAt)}) AS SuperUpvotedByUsers,
      COLLECT(DISTINCT parent.id) AS parentIds,
      COLLECT(DISTINCT CASE WHEN child IS NOT NULL THEN {id: child.id, text: child.text} ELSE null END) AS NonFilteredChildComments,
      COLLECT(DISTINCT CASE WHEN pastVersion IS NOT NULL THEN {
@@ -24,28 +26,28 @@ WITH c, author, parent, serverRole, channelRole, pastVersion, pastVersionAuthor,
      } ELSE null END) AS PastVersions,
      COUNT(DISTINCT favUser) > 0 AS isFavoritedByUser,
      // Compute the age in months from the createdAt timestamp.
-     duration.between(c.createdAt, datetime()).months + 
+     duration.between(c.createdAt, datetime()).months +
      duration.between(c.createdAt, datetime()).days / 30.0 AS ageInMonths,
      CASE WHEN coalesce(c.weightedVotesCount, 0) < 0 THEN 0 ELSE coalesce(c.weightedVotesCount, 0) END AS weightedVotesCount
 
-WITH c, author, parent, UpvotedByUsers, parentIds, weightedVotesCount, serverRole, channelRole, PastVersions, isFavoritedByUser,
-    [comment IN NonFilteredChildComments WHERE comment IS NOT NULL] AS ChildComments, 
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, weightedVotesCount, serverRole, channelRole, PastVersions, isFavoritedByUser,
+    [comment IN NonFilteredChildComments WHERE comment IS NOT NULL] AS ChildComments,
     CASE WHEN ageInMonths IS NULL THEN 0 ELSE ageInMonths END AS ageInMonths
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, weightedVotesCount, serverRole, channelRole, ageInMonths, PastVersions, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, serverRole, channelRole, ageInMonths, PastVersions, isFavoritedByUser,
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
     serverRole, COLLECT(DISTINCT channelRole) AS channelRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
     channelRoles, COLLECT(DISTINCT serverRole) AS serverRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
-    [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRoles 
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
+    [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
     serverRoles, [role in channelRoles | {showModTag: role.showModTag}] AS channelRoles
 
 RETURN {
@@ -72,6 +74,7 @@ RETURN {
     UpvotedByUsersAggregate: {
         count: SIZE(UpvotedByUsers)
     },
+    SuperUpvotedByUsers: SuperUpvotedByUsers,
     ChildComments: CASE WHEN SIZE(ChildComments) > 0 THEN ChildComments ELSE [] END,
     ChildCommentsAggregate: {
         count: SIZE(ChildComments)

--- a/customResolvers/cypher/getNewCommentsQuery.cypher
+++ b/customResolvers/cypher/getNewCommentsQuery.cypher
@@ -8,19 +8,21 @@ OPTIONAL MATCH (author)-[:HAS_CHANNEL_ROLE]->(channelRole:ChannelRole)
 OPTIONAL MATCH (c)-[:IS_REPLY_TO]->(parent:Comment)
 OPTIONAL MATCH (c)<-[:IS_REPLY_TO]-(child:Comment)
 OPTIONAL MATCH (c)<-[:UPVOTED_COMMENT]-(upvoter:User)
+OPTIONAL MATCH (c)<-[:SUPER_UPVOTED_COMMENT]-(superUpvoter:User)
 OPTIONAL MATCH (c)-[:HAS_VERSION]->(pastVersion:TextVersion)<-[:AUTHORED_VERSION]-(pastVersionAuthor:User)
 OPTIONAL MATCH (favUser:User { username: $loggedInUsername })-[:DEFAULT_FAVORITES_COMMENTS]->(c)
 
-WITH c, author, serverRole, channelRole, parent, child, upvoter, $modName AS modName, pastVersion, pastVersionAuthor, favUser
+WITH c, author, serverRole, channelRole, parent, child, upvoter, superUpvoter, $modName AS modName, pastVersion, pastVersionAuthor, favUser
 
 OPTIONAL MATCH (c)<-[:HAS_FEEDBACK_COMMENT]-(feedbackComment:Comment)<-[:AUTHORED_COMMENT]-(feedbackAuthor:ModerationProfile)
 
-WITH c, author, serverRole, channelRole, parent, child, upvoter, modName, feedbackComment, feedbackAuthor, pastVersion, pastVersionAuthor, favUser,
+WITH c, author, serverRole, channelRole, parent, child, upvoter, superUpvoter, modName, feedbackComment, feedbackAuthor, pastVersion, pastVersionAuthor, favUser,
      CASE WHEN modName IS NOT NULL AND feedbackAuthor.displayName = modName THEN feedbackComment
           ELSE NULL END AS filteredFeedbackComment
 
 WITH c, author, serverRole, channelRole, parent,
-     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers, 
+     COLLECT(DISTINCT upvoter{.*, createdAt: toString(upvoter.createdAt)}) AS UpvotedByUsers,
+     COLLECT(DISTINCT superUpvoter{.*, createdAt: toString(superUpvoter.createdAt)}) AS SuperUpvotedByUsers,
      COLLECT(DISTINCT parent.id) AS parentIds,
      COLLECT(DISTINCT filteredFeedbackComment {id: feedbackComment.id}) AS FeedbackComments,
      COLLECT(DISTINCT CASE WHEN child IS NOT NULL THEN {id: child.id, text: child.text} ELSE null END) AS NonFilteredChildComments,
@@ -34,24 +36,24 @@ WITH c, author, serverRole, channelRole, parent,
      } ELSE null END) AS PastVersions,
      COUNT(DISTINCT favUser) > 0 AS isFavoritedByUser
 
-WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, parentIds, isFavoritedByUser,
+WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
     [comment IN NonFilteredChildComments WHERE comment.id IS NOT NULL] AS ChildComments,
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
     FeedbackComments
 
-WITH c, author, channelRole, parent, UpvotedByUsers, parentIds, isFavoritedByUser,
+WITH c, author, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
     ChildComments, FilteredPastVersions, FeedbackComments,
     COLLECT(DISTINCT serverRole) AS serverRoles
 
-WITH c, author, channelRole, parent, UpvotedByUsers, parentIds, isFavoritedByUser,
+WITH c, author, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
     ChildComments, FilteredPastVersions, FeedbackComments,
     [role IN serverRoles | {showAdminTag: role.showAdminTag}] as serverRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
     ChildComments, FilteredPastVersions, FeedbackComments, serverRoles,
     COLLECT(DISTINCT channelRole) AS channelRoles
 
-WITH c, author, parent, UpvotedByUsers, parentIds, isFavoritedByUser,
+WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
     ChildComments, FilteredPastVersions, FeedbackComments, serverRoles,
     [role IN channelRoles | {showModTag: role.showModTag}] as channelRoles
 
@@ -78,6 +80,7 @@ RETURN {
     UpvotedByUsersAggregate: {
         count: SIZE(UpvotedByUsers)
     },
+    SuperUpvotedByUsers: SuperUpvotedByUsers,
     ChildComments: CASE WHEN SIZE(ChildComments) > 0 THEN ChildComments ELSE [] END,
     ChildCommentsAggregate: {
         count: SIZE(ChildComments)

--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -59,9 +59,10 @@ WITH d, COLLECT(dc) AS discussionChannels, totalCount
 // Unwind the discussion channels to work with them individually for fetching related data
 UNWIND discussionChannels AS dc
 OPTIONAL MATCH (dc)-[:UPVOTED_DISCUSSION]->(upvoter:User)
+OPTIONAL MATCH (dc)<-[:SUPER_UPVOTED_DISCUSSION]-(superUpvoter:User)
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
-WITH d, dc, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
-WITH d, COLLECT({dc: dc, upvotedByUsers: upvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
+WITH d, dc, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
+WITH d, COLLECT({dc: dc, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
 
 // Now, you can proceed with calculating the score and other aggregations at the discussion level
 WITH d, channelData, totalCount,
@@ -74,6 +75,7 @@ WITH d, score, totalCount,
         channelUniqueName: channel.dc.channelUniqueName,
         discussionId: channel.dc.discussionId,
         UpvotedByUsers: [up in channel.upvotedByUsers | { username: up.username }],
+        SuperUpvotedByUsers: [sup in channel.superUpvotedByUsers | { username: sup.username }],
         CommentsAggregate: {
             count: channel.commentsCount
         }

--- a/customResolvers/mutations/createScratchpadEntry.ts
+++ b/customResolvers/mutations/createScratchpadEntry.ts
@@ -170,7 +170,23 @@ const createScratchpadEntryResolver = (input: Input) => {
 
       await tx.commit();
 
-      // Return the created entry with author info
+      // Fetch the updated SuperUpvotedByUsers for cache update
+      let superUpvotedByUsers: any[] = [];
+      if (sourceType === 'comment') {
+        const result = await Comment.find({
+          where: { id: sourceId },
+          selectionSet: `{ SuperUpvotedByUsers { username } }`,
+        });
+        superUpvotedByUsers = result[0]?.SuperUpvotedByUsers || [];
+      } else {
+        const result = await DiscussionChannel.find({
+          where: { id: sourceId },
+          selectionSet: `{ SuperUpvotedByUsers { username } }`,
+        });
+        superUpvotedByUsers = result[0]?.SuperUpvotedByUsers || [];
+      }
+
+      // Return the created entry with author info and updated super upvoted users
       return {
         id: createdEntry.id,
         createdAt: createdEntry.createdAt,
@@ -185,6 +201,7 @@ const createScratchpadEntryResolver = (input: Input) => {
         Recipient: {
           username: recipientUsername,
         },
+        superUpvotedByUsers,
       };
     } catch (e) {
       if (tx) {

--- a/customResolvers/mutations/undoSuperUpvote.ts
+++ b/customResolvers/mutations/undoSuperUpvote.ts
@@ -1,0 +1,157 @@
+type Input = {
+  Comment: any;
+  DiscussionChannel: any;
+  ScratchpadEntry: any;
+  driver: any;
+};
+
+type Args = {
+  sourceType: 'comment' | 'discussion';
+  sourceId: string;
+};
+
+const undoSuperUpvoteResolver = (input: Input) => {
+  const { Comment, DiscussionChannel, ScratchpadEntry, driver } = input;
+
+  return async (parent: any, args: Args, context: any, resolveInfo: any) => {
+    const { sourceType, sourceId } = args;
+
+    // Get logged in user from context
+    const loggedInUsername = context.user?.username;
+    if (!loggedInUsername) {
+      throw new Error('You must be logged in to undo a super upvote');
+    }
+
+    if (!sourceType || !sourceId) {
+      throw new Error('sourceType and sourceId are required');
+    }
+
+    if (sourceType !== 'comment' && sourceType !== 'discussion') {
+      throw new Error('sourceType must be "comment" or "discussion"');
+    }
+
+    const session = driver.session();
+    const tx = session.beginTransaction();
+
+    try {
+      // 1. Verify the user has super upvoted this content
+      let hasSuperUpvoted = false;
+
+      if (sourceType === 'comment') {
+        const commentResult = await Comment.find({
+          where: { id: sourceId },
+          selectionSet: `{
+            id
+            SuperUpvotedByUsers { username }
+          }`,
+        });
+
+        if (commentResult.length === 0) {
+          throw new Error('Comment not found');
+        }
+
+        const comment = commentResult[0];
+        hasSuperUpvoted = comment.SuperUpvotedByUsers?.some((u: any) => u.username === loggedInUsername) || false;
+      } else {
+        // sourceType === 'discussion'
+        const dcResult = await DiscussionChannel.find({
+          where: { id: sourceId },
+          selectionSet: `{
+            id
+            SuperUpvotedByUsers { username }
+          }`,
+        });
+
+        if (dcResult.length === 0) {
+          throw new Error('Discussion not found');
+        }
+
+        const dc = dcResult[0];
+        hasSuperUpvoted = dc.SuperUpvotedByUsers?.some((u: any) => u.username === loggedInUsername) || false;
+      }
+
+      if (!hasSuperUpvoted) {
+        throw new Error('You have not super upvoted this content');
+      }
+
+      // 2. Remove the SUPER_UPVOTED relationship
+      if (sourceType === 'comment') {
+        const undoSuperUpvoteQuery = `
+          MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_COMMENT]->(c:Comment { id: $sourceId })
+          DELETE r
+          SET c.weightedVotesCount = coalesce(c.weightedVotesCount, 1) - 1
+          RETURN c
+        `;
+        await tx.run(undoSuperUpvoteQuery, { sourceId, username: loggedInUsername });
+      } else {
+        const undoSuperUpvoteQuery = `
+          MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_DISCUSSION]->(dc:DiscussionChannel { id: $sourceId })
+          DELETE r
+          SET dc.weightedVotesCount = coalesce(dc.weightedVotesCount, 1) - 1
+          RETURN dc
+        `;
+        await tx.run(undoSuperUpvoteQuery, { sourceId, username: loggedInUsername });
+      }
+
+      // 3. Delete the associated scratchpad entry
+      await ScratchpadEntry.delete({
+        where: {
+          sourceType,
+          sourceId,
+          Author: { username: loggedInUsername },
+        },
+      });
+
+      await tx.commit();
+
+      // Fetch and return the updated source with SuperUpvotedByUsers for cache update
+      let updatedSource = null;
+      if (sourceType === 'comment') {
+        const result = await Comment.find({
+          where: { id: sourceId },
+          selectionSet: `{
+            id
+            SuperUpvotedByUsers { username }
+          }`,
+        });
+        updatedSource = result[0];
+      } else {
+        const result = await DiscussionChannel.find({
+          where: { id: sourceId },
+          selectionSet: `{
+            id
+            SuperUpvotedByUsers { username }
+          }`,
+        });
+        updatedSource = result[0];
+      }
+
+      return {
+        success: true,
+        message: 'Super upvote removed successfully',
+        sourceId,
+        sourceType,
+        superUpvotedByUsers: updatedSource?.SuperUpvotedByUsers || [],
+      };
+    } catch (e) {
+      if (tx) {
+        try {
+          await tx.rollback();
+        } catch (rollbackError) {
+          console.error('Failed to rollback transaction', rollbackError);
+        }
+      }
+      throw e;
+    } finally {
+      if (session) {
+        try {
+          await session.close();
+        } catch (sessionCloseError) {
+          console.error('Failed to close session', sessionCloseError);
+        }
+      }
+    }
+  };
+};
+
+export default undoSuperUpvoteResolver;

--- a/customResolvers/queries/getCommentSection.ts
+++ b/customResolvers/queries/getCommentSection.ts
@@ -54,6 +54,9 @@ const discussionChannelSelectionSet = `
     UpvotedByUsersAggregate {
         count
     }
+    SuperUpvotedByUsers {
+        username
+    }
     Answers {
         id
         text

--- a/permissions.ts
+++ b/permissions.ts
@@ -168,6 +168,9 @@ const permissionList = shield({
       undoUpvoteDiscussionChannel: and(isAuthenticated, canUpvoteDiscussion), // We are intentionally reusing the same rule for undoing an upvote as for upvoting.
       // Any user who can upvote a discussion can undo their upvote. The undo upvote resolver
       // checks if the user has upvoted the discussion and if so, removes the upvote.
+
+      createScratchpadEntry: and(isAuthenticated, allow), // Super upvote - any authenticated user can send a thank-you note
+      undoSuperUpvote: and(isAuthenticated, allow), // Undo super upvote - any authenticated user can undo their super upvote
       
       createIssue: and(isAuthenticated, issueIsValid),
       createIssues: and(isAuthenticated, issueIsValid),

--- a/ts_emitted/customResolvers.js
+++ b/ts_emitted/customResolvers.js
@@ -107,8 +107,10 @@ import createAlbumsWithOwner from './customResolvers/mutations/createAlbumsWithO
 import createDownloadableFileUrlResolver from './customResolvers/fields/downloadableFileUrl.js';
 import updateDownloadLabels from './customResolvers/mutations/updateDownloadLabels.js';
 import createScratchpadEntry from './customResolvers/mutations/createScratchpadEntry.js';
+import undoSuperUpvote from './customResolvers/mutations/undoSuperUpvote.js';
 import updateScratchpadEntryVisibility from './customResolvers/mutations/updateScratchpadEntryVisibility.js';
 import deleteScratchpadEntry from './customResolvers/mutations/deleteScratchpadEntry.js';
+import emptyArrayFallback from './customResolvers/fields/emptyArrayFallback.js';
 const { OGM } = pkg;
 export default function (driver) {
     const ogm = new OGM({
@@ -177,6 +179,39 @@ export default function (driver) {
         },
         DownloadableFile: {
             url: createDownloadableFileUrlResolver(),
+        },
+        DiscussionChannel: {
+            SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
+        },
+        DiscussionChannelListItem: {
+            SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
+            UpvotedByUsers: emptyArrayFallback('UpvotedByUsers'),
+        },
+        Comment: {
+            SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
+        },
+        ScratchpadEntry: {
+            superUpvotedByUsers: (parent) => parent.superUpvotedByUsers || [],
+        },
+        Album: {
+            Images: emptyArrayFallback('Images'),
+        },
+        Channel: {
+            Moderators: emptyArrayFallback('Moderators'),
+            Admins: emptyArrayFallback('Admins'),
+            Bots: emptyArrayFallback('Bots'),
+            Tags: emptyArrayFallback('Tags'),
+            PendingOwnerInvites: emptyArrayFallback('PendingOwnerInvites'),
+            PendingModInvites: emptyArrayFallback('PendingModInvites'),
+            RelatedChannels: emptyArrayFallback('RelatedChannels'),
+            PinnedDiscussionChannels: emptyArrayFallback('PinnedDiscussionChannels'),
+            PinnedWikiPages: emptyArrayFallback('PinnedWikiPages'),
+            InCollections: emptyArrayFallback('InCollections'),
+            EventChannels: emptyArrayFallback('EventChannels'),
+            DiscussionChannels: emptyArrayFallback('DiscussionChannels'),
+            Comments: emptyArrayFallback('Comments'),
+            SuspendedUsers: emptyArrayFallback('SuspendedUsers'),
+            SuspendedMods: emptyArrayFallback('SuspendedMods'),
         },
         Query: {
             getSiteWideDiscussionList: getSiteWideDiscussionList({
@@ -654,6 +689,12 @@ export default function (driver) {
                 Comment,
                 DiscussionChannel,
                 User,
+                driver,
+            }),
+            undoSuperUpvote: undoSuperUpvote({
+                Comment,
+                DiscussionChannel,
+                ScratchpadEntry,
                 driver,
             }),
             updateScratchpadEntryVisibility: updateScratchpadEntryVisibility({

--- a/ts_emitted/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/ts_emitted/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -155,16 +155,20 @@ LIMIT toInteger($limit)
 OPTIONAL MATCH (d)-[:HAS_ALBUM]->(album:Album)
 OPTIONAL MATCH (album)-[:HAS_IMAGE]->(image:Image)
 WHERE image.id IS NOT NULL
+  AND (image.archived IS NULL OR image.archived = false)
+  AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, totalUpvoters,
      weightedVotesCount, comments, hotRank, serverRoles, channelRoles,
      album,
-     COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
+     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
          id: image.id,
          url: image.url,
          alt: image.alt,
-         caption: image.caption
-     } END) AS albumImages
+         caption: image.caption,
+         archived: image.archived,
+         permanentlyRemoved: image.permanentlyRemoved
+     } END) WHERE img IS NOT NULL] AS albumImages
 
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)

--- a/ts_emitted/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/ts_emitted/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -143,14 +143,18 @@ LIMIT toInteger($limit)
 OPTIONAL MATCH (d)-[:HAS_ALBUM]->(album:Album)
 OPTIONAL MATCH (album)-[:HAS_IMAGE]->(image:Image)
 WHERE image.id IS NOT NULL
+  AND (image.archived IS NULL OR image.archived = false)
+  AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
 WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRoles, album,
-     COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
+     [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
          id: image.id,
          url: image.url,
          alt: image.alt,
-         caption: image.caption
-     } END) AS albumImages
+         caption: image.caption,
+         archived: image.archived,
+         permanentlyRemoved: image.permanentlyRemoved
+     } END) WHERE img IS NOT NULL] AS albumImages
 
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)

--- a/ts_emitted/customResolvers/queries/getSiteWideDiscussionList.js
+++ b/ts_emitted/customResolvers/queries/getSiteWideDiscussionList.js
@@ -74,9 +74,7 @@ const getResolver = (input) => {
                     if (topRecord) {
                         totalCount = topRecord.get("totalCount");
                     }
-                    let topDiscussions = topDiscussionsResult.records.map((record) => {
-                        return record.get("discussion");
-                    });
+                    let topDiscussions = topDiscussionsResult.records.map((record) => record.get("discussion"));
                     return {
                         discussions: topDiscussions,
                         aggregateDiscussionCount: totalCount,
@@ -104,9 +102,7 @@ const getResolver = (input) => {
                     if (hotRecord) {
                         totalCount = hotRecord.get("totalCount");
                     }
-                    let hotDiscussions = hotDiscussionsResult.records.map((record) => {
-                        return record.get("discussion");
-                    });
+                    let hotDiscussions = hotDiscussionsResult.records.map((record) => record.get("discussion"));
                     return {
                         discussions: hotDiscussions,
                         aggregateDiscussionCount: totalCount,

--- a/ts_emitted/permissions.js
+++ b/ts_emitted/permissions.js
@@ -103,6 +103,8 @@ const permissionList = shield({
         undoUpvoteDiscussionChannel: and(isAuthenticated, canUpvoteDiscussion), // We are intentionally reusing the same rule for undoing an upvote as for upvoting.
         // Any user who can upvote a discussion can undo their upvote. The undo upvote resolver
         // checks if the user has upvoted the discussion and if so, removes the upvote.
+        createScratchpadEntry: and(isAuthenticated, allow), // Super upvote - any authenticated user can send a thank-you note
+        undoSuperUpvote: and(isAuthenticated, allow), // Undo super upvote - any authenticated user can undo their super upvote
         createIssue: and(isAuthenticated, issueIsValid),
         createIssues: and(isAuthenticated, issueIsValid),
         deleteIssues: and(isAuthenticated, allow), // canDeleteIssues,

--- a/ts_emitted/typeDefs.js
+++ b/ts_emitted/typeDefs.js
@@ -316,6 +316,9 @@ const typeDefinitions = gql `
     # Relationships
     Author: User! @relationship(type: "WROTE_SCRATCHPAD_ENTRY", direction: IN)
     Recipient: User! @relationship(type: "HAS_SCRATCHPAD_ENTRY", direction: IN)
+
+    # For cache updates after super upvoting (not a DB field)
+    superUpvotedByUsers: [User!]
   }
 
   type TextVersion {
@@ -1075,6 +1078,10 @@ const typeDefinitions = gql `
       sourceId: String!
       sourceChannelUniqueName: String
     ): ScratchpadEntry
+    undoSuperUpvote(
+      sourceType: String!
+      sourceId: String!
+    ): UndoSuperUpvoteResult
     updateScratchpadEntryVisibility(
       scratchpadEntryId: ID!
       isPublic: Boolean!
@@ -1382,6 +1389,7 @@ const typeDefinitions = gql `
     weightedVotesCount: Float
     CommentsAggregate: CommentAggregateResult
     UpvotedByUsers: [User!]!
+    SuperUpvotedByUsers: [User!]!
     UpvotedByUsersAggregate: UserAggregateResult
     Discussion: Discussion
     Channel: Channel
@@ -1392,6 +1400,14 @@ const typeDefinitions = gql `
     success: Boolean!
     deletedCount: Int!
     message: String
+  }
+
+  type UndoSuperUpvoteResult {
+    success: Boolean!
+    message: String
+    sourceId: String
+    sourceType: String
+    superUpvotedByUsers: [User!]
   }
 
   type CommentAggregateResult {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -317,6 +317,9 @@ const typeDefinitions = gql`
     # Relationships
     Author: User! @relationship(type: "WROTE_SCRATCHPAD_ENTRY", direction: IN)
     Recipient: User! @relationship(type: "HAS_SCRATCHPAD_ENTRY", direction: IN)
+
+    # For cache updates after super upvoting (not a DB field)
+    superUpvotedByUsers: [User!]
   }
 
   type TextVersion {
@@ -1076,6 +1079,10 @@ const typeDefinitions = gql`
       sourceId: String!
       sourceChannelUniqueName: String
     ): ScratchpadEntry
+    undoSuperUpvote(
+      sourceType: String!
+      sourceId: String!
+    ): UndoSuperUpvoteResult
     updateScratchpadEntryVisibility(
       scratchpadEntryId: ID!
       isPublic: Boolean!
@@ -1394,6 +1401,14 @@ const typeDefinitions = gql`
     success: Boolean!
     deletedCount: Int!
     message: String
+  }
+
+  type UndoSuperUpvoteResult {
+    success: Boolean!
+    message: String
+    sourceId: String
+    sourceType: String
+    superUpvotedByUsers: [User!]
   }
 
   type CommentAggregateResult {


### PR DESCRIPTION
**Draft for re-review — may be closed.** Recovering work that exists on the local/deployed `main` line but was never merged to GitHub `main`.

## What this is

Cherry-pick of commit `791d947` ("implement super upvote functionality with undo support") onto current `origin/main`. It adds the `undoSuperUpvote` mutation and supporting wiring:

- `customResolvers/mutations/undoSuperUpvote.ts` (new, ~157 lines)
- `typeDefs.ts`, `permissions.ts`, `customResolvers.ts` registration
- `customResolvers/mutations/createScratchpadEntry.ts`, `getCommentSection` query, and several cypher query updates
- corresponding compiled `ts_emitted/` output

`isFavorited` (a separate unmerged commit) is intentionally **not** included here.

## Why it exists

`origin/main` has the super-upvote base (schema + mutations) but is missing the **undo** support, which the frontend calls (`UNDO_SUPER_UPVOTE`). The work was committed locally and deployed but the PR never landed on GitHub, so `origin/main` diverged from what's actually running.

## Status / caveats

- ✅ Type-checks against current `origin/main` (`npm run tsc`, exit 0).
- ⚠️ **Needs re-review before merge.** Part of this commit may have been working around an auth-related bug that may no longer reproduce after the server-session auth migration now on `main`. Confirm the undo flow still behaves correctly (and that nothing here is now redundant) before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)