### PR TITLE
feat: add isFavorited field to the Discussion type

### DIFF
--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -572,6 +572,18 @@ const typeDefinitions = gql`
     InCollections: [Collection!]! @relationship(type: "CONTAINS_DISCUSSION", direction: IN)
     bookmarkCount: Int! @cypher(statement: "MATCH (this)<-[:BOOKMARKED]-() RETURN count(*)", columnName: "bookmarkCount")
 
+    # Whether the given user has favorited this discussion (or download).
+    # Returns null when no username is provided.
+    isFavorited(username: String): Boolean @cypher(statement: """
+      OPTIONAL MATCH (favDiscussionUser:User {username: $username})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(this)
+      OPTIONAL MATCH (favDownloadUser:User {username: $username})-[:DEFAULT_FAVORITES_DOWNLOADS]->(this)
+      RETURN CASE
+        WHEN $username IS NULL OR $username = '' THEN null
+        WHEN favDiscussionUser IS NOT NULL OR favDownloadUser IS NOT NULL THEN true
+        ELSE false
+      END AS isFavorited
+    """, columnName: "isFavorited")
+
     # Shared collections
     SharedCollection: Collection @relationship(type: "SHARES_COLLECTION", direction: OUT)
   }


### PR DESCRIPTION
**Recovering deployed-but-unmerged work** — companion to #17.

Cherry-pick of `fe5c180` onto `origin/main`. Adds an `isFavorited(username: String): Boolean` `@cypher` field to the **Discussion** type, checking the user's `DEFAULT_FAVORITES_DISCUSSIONS` / `DEFAULT_FAVORITES_DOWNLOADS` relationships (returns null when no username is supplied).

## Why it exists

The field is **already deployed** (`heroku/main`) and the **frontend depends on it** — `graphQLData/collection/queries.ts` selects `isFavorited(username:)` on Discussion. It was committed locally and deployed but never landed on GitHub, so `origin/main` is behind production. Without it, those frontend queries fail with `GRAPHQL_VALIDATION_FAILED` (which is exactly the error this commit originally fixed).

## Status

- ✅ Type-checks against `origin/main` (`npm run tsc`, exit 0).
- Draft pending your review, like #17. Merging this + #17 brings `origin/main` level with what's actually deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)