### PR TITLE
fix(test): deflake tampered-ciphertext encryption test

### DIFF
--- a/services/plugin/encryption.test.ts
+++ b/services/plugin/encryption.test.ts
@@ -102,8 +102,12 @@ async function testDecryptTamperedCiphertext() {
   const encrypted = encryptSecret(plaintext);
   const parts = encrypted.split(":");
 
-  // Tamper with the encrypted data
-  const tamperedEncrypted = parts[2].replace(/[0-9a-f]/, "0");
+  // Tamper with the encrypted data by flipping the first hex char to a
+  // guaranteed-different value. (A naive replace(/[0-9a-f]/, "0") would be a
+  // no-op whenever the first char is already "0" — roughly 1 run in 16 — which
+  // made this test flaky since the IV/ciphertext is randomized each run.)
+  const tamperedFirstChar = parts[2][0] === "0" ? "1" : "0";
+  const tamperedEncrypted = tamperedFirstChar + parts[2].slice(1);
   const tamperedCiphertext = `${parts[0]}:${parts[1]}:${tamperedEncrypted}`;
 
   // This should throw because GCM authentication will fail


### PR DESCRIPTION
## Problem

Tests CI failed on the two most recent merges to `main` — [PR #11](https://github.com/gennit-project/multiforum-backend/pull/11) (the dependabot major-updates merge) and [PR #18](https://github.com/gennit-project/multiforum-backend/pull/18). Both failed with the same error:

```
AssertionError [ERR_ASSERTION]: Missing expected exception: Should throw error when ciphertext is tampered
```

## Root cause

This is a flaky test, not a regression from the dependency bumps. In `services/plugin/encryption.test.ts`, `testDecryptTamperedCiphertext` tampered with the ciphertext like this:

```ts
const tamperedEncrypted = parts[2].replace(/[0-9a-f]/, "0");
```

`replace` only rewrites the **first** hex character to `"0"`. When that character was already `"0"` — roughly 1 run in 16, since the IV and ciphertext are randomized on every run — the replace is a no-op. The "tampered" ciphertext is then identical to the original, decryption succeeds, and `assert.throws` fails because no exception is raised. Measured locally at ~5.5% failure per run.

## Fix

Flip the first hex char to a guaranteed-different value so the AES-GCM authentication check always fails as the test intends:

```ts
const tamperedFirstChar = parts[2][0] === "0" ? "1" : "0";
const tamperedEncrypted = tamperedFirstChar + parts[2].slice(1);
```

## Verification

- Ran the encryption test 40× consecutively — all pass (previously ~2 failures expected over 40 runs).
- `tsc --noEmit` passes.
- Full suite via the pre-push hook: 422 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)