### PR TITLE
test: authenticated-role e2e + coverage mop-up + non-blocking codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,12 +12,10 @@ coverage:
     # Per-PR coverage change check
     patch:
       default:
-        # New/changed code in a PR must be covered. This ratchets quality
-        # forward without requiring the whole legacy baseline to be tested.
-        target: 80%
-        # Allow a small slack so trivial untestable lines don't block a PR.
-        threshold: 5%
-        informational: false
+        # Report patch (changed-lines) coverage on PRs, but never block. With
+        # the legacy codebase well below 80%, a hard patch gate blocks nearly
+        # every normal PR, so coverage is informational only for now.
+        informational: true
 
 # Comment settings for PR coverage reports
 comment:

--- a/hooks/notificationHelpers.test.ts
+++ b/hooks/notificationHelpers.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createInAppNotification } from "./notificationHelpers.js";
+
+// Minimal fake of the OGM User model: captures the update payload and returns a
+// configurable result (or throws).
+const fakeUserModel = (
+  result: unknown,
+  options: { throwError?: boolean } = {}
+) => {
+  const calls: any[] = [];
+  return {
+    calls,
+    update: async (input: any) => {
+      calls.push(input);
+      if (options.throwError) {
+        throw new Error("db error");
+      }
+      return result;
+    },
+  };
+};
+
+test("returns true when the update reports an updated user", async () => {
+  const UserModel = fakeUserModel({ users: [{ username: "alice" }] });
+  const ok = await createInAppNotification({
+    UserModel,
+    username: "alice",
+    text: "hello",
+  });
+  assert.equal(ok, true);
+});
+
+test("returns false when no user was updated", async () => {
+  const UserModel = fakeUserModel({ users: [] });
+  const ok = await createInAppNotification({
+    UserModel,
+    username: "ghost",
+    text: "hello",
+  });
+  assert.equal(ok, false);
+});
+
+test("returns false (and does not throw) when the update errors", async () => {
+  const UserModel = fakeUserModel(null, { throwError: true });
+  const ok = await createInAppNotification({
+    UserModel,
+    username: "alice",
+    text: "hello",
+  });
+  assert.equal(ok, false);
+});
+
+test("targets the right user and creates an unread notification", async () => {
+  const UserModel = fakeUserModel({ users: [{ username: "alice" }] });
+  await createInAppNotification({
+    UserModel,
+    username: "alice",
+    text: "you were mentioned",
+  });
+
+  const node =
+    UserModel.calls[0].update.Notifications[0].create[0].node;
+  assert.equal(UserModel.calls[0].where.username, "alice");
+  assert.equal(node.text, "you were mentioned");
+  assert.equal(node.read, false);
+  // notificationType omitted when not supplied
+  assert.equal("notificationType" in node, false);
+});
+
+test("includes notificationType when provided", async () => {
+  const UserModel = fakeUserModel({ users: [{ username: "alice" }] });
+  await createInAppNotification({
+    UserModel,
+    username: "alice",
+    text: "feedback left",
+    notificationType: "feedback",
+  });
+
+  const node =
+    UserModel.calls[0].update.Notifications[0].create[0].node;
+  assert.equal(node.notificationType, "feedback");
+});

--- a/services/botUserService.test.ts
+++ b/services/botUserService.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildBotUsername } from "./botUserService.js";
+import {
+  buildBotUsername,
+  getProfilesFromSettings,
+  getBotNameFromSettings,
+} from "./botUserService.js";
 
 test("builds a username from channel and bot name", () => {
   assert.equal(buildBotUsername("cats", "summarizer"), "bot-cats-summarizer");
@@ -59,4 +63,80 @@ test("throws when a provided profile id normalizes to empty", () => {
 test("ignores a null or empty profile id", () => {
   assert.equal(buildBotUsername("cats", "summarizer", null), "bot-cats-summarizer");
   assert.equal(buildBotUsername("cats", "summarizer", ""), "bot-cats-summarizer");
+});
+
+// --- getProfilesFromSettings ---
+
+test("reads profiles from server.profiles", () => {
+  assert.deepEqual(
+    getProfilesFromSettings({ server: { profiles: [{ id: "a", label: "A" }] } }),
+    [{ id: "a", label: "A" }]
+  );
+});
+
+test("falls back to root profiles and defaults a missing label to null", () => {
+  assert.deepEqual(getProfilesFromSettings({ profiles: [{ id: "b" }] }), [
+    { id: "b", label: null },
+  ]);
+});
+
+test("prefers server.profiles over root profiles", () => {
+  assert.deepEqual(
+    getProfilesFromSettings({
+      server: { profiles: [{ id: "s" }] },
+      profiles: [{ id: "r" }],
+    }),
+    [{ id: "s", label: null }]
+  );
+});
+
+test("falls back to profilesJson when no profiles array is present", () => {
+  assert.deepEqual(
+    getProfilesFromSettings({ profilesJson: '[{"id":"c","label":"C"}]' }),
+    [{ id: "c", label: "C" }]
+  );
+});
+
+test("accepts a JSON string for the whole settings blob", () => {
+  assert.deepEqual(getProfilesFromSettings('{"profiles":[{"id":"e"}]}'), [
+    { id: "e", label: null },
+  ]);
+});
+
+test("drops entries without a string id and trims the id", () => {
+  assert.deepEqual(
+    getProfilesFromSettings({
+      profiles: [{ id: "  f  " }, { label: "no id" }, { id: 123 }],
+    }),
+    [{ id: "f", label: null }]
+  );
+});
+
+test("returns an empty array for unparseable or empty settings", () => {
+  assert.deepEqual(getProfilesFromSettings(null), []);
+  assert.deepEqual(getProfilesFromSettings("not json"), []);
+});
+
+// --- getBotNameFromSettings ---
+
+test("reads botName from the root, preferring it over server", () => {
+  assert.equal(getBotNameFromSettings({ botName: "Root", server: { botName: "Srv" } }), "Root");
+});
+
+test("falls back to server.botName", () => {
+  assert.equal(getBotNameFromSettings({ server: { botName: "Helper" } }), "Helper");
+});
+
+test("trims the bot name and treats blank as null", () => {
+  assert.equal(getBotNameFromSettings({ botName: "  Bot  " }), "Bot");
+  assert.equal(getBotNameFromSettings({ botName: "   " }), null);
+});
+
+test("returns null when no bot name is present", () => {
+  assert.equal(getBotNameFromSettings({}), null);
+  assert.equal(getBotNameFromSettings(null), null);
+});
+
+test("accepts a JSON string for the settings blob", () => {
+  assert.equal(getBotNameFromSettings('{"botName":"FromString"}'), "FromString");
 });

--- a/services/botUserService.test.ts
+++ b/services/botUserService.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildBotUsername } from "./botUserService.js";
+
+test("builds a username from channel and bot name", () => {
+  assert.equal(buildBotUsername("cats", "summarizer"), "bot-cats-summarizer");
+});
+
+test("appends a normalized profile id when provided", () => {
+  assert.equal(
+    buildBotUsername("cats", "summarizer", "p1"),
+    "bot-cats-summarizer-p1"
+  );
+});
+
+test("lowercases and replaces whitespace with hyphens", () => {
+  assert.equal(
+    buildBotUsername("My Cats", "Cool Bot"),
+    "bot-my-cats-cool-bot"
+  );
+});
+
+test("replaces unsafe characters and collapses repeated hyphens", () => {
+  assert.equal(buildBotUsername("My Cats!!!", "a@@@b"), "bot-my-cats-a-b");
+});
+
+test("trims leading and trailing separators after normalization", () => {
+  assert.equal(buildBotUsername("--cats--", "__bot__"), "bot-cats-bot");
+});
+
+test("preserves digits, underscores, and hyphens", () => {
+  assert.equal(
+    buildBotUsername("cats_2", "my-bot-3"),
+    "bot-cats_2-my-bot-3"
+  );
+});
+
+test("throws when the channel name normalizes to empty", () => {
+  assert.throws(
+    () => buildBotUsername("!!!", "summarizer"),
+    /channelUniqueName must match/
+  );
+});
+
+test("throws when the bot name normalizes to empty", () => {
+  assert.throws(
+    () => buildBotUsername("cats", "@@@"),
+    /botName must match/
+  );
+});
+
+test("throws when a provided profile id normalizes to empty", () => {
+  assert.throws(
+    () => buildBotUsername("cats", "summarizer", "***"),
+    /profileId must match/
+  );
+});
+
+test("ignores a null or empty profile id", () => {
+  assert.equal(buildBotUsername("cats", "summarizer", null), "bot-cats-summarizer");
+  assert.equal(buildBotUsername("cats", "summarizer", ""), "bot-cats-summarizer");
+});

--- a/tests/integration/authenticatedRoles.test.ts
+++ b/tests/integration/authenticatedRoles.test.ts
@@ -1,0 +1,132 @@
+// Authenticated-role e2e: the highest-fidelity authorization test. It runs a
+// real admin-gated mutation through the real schema + graphql-shield, against a
+// live Neo4j, as three different callers:
+//
+//   1. unauthenticated        -> blocked by isAuthenticated (notAuthenticated)
+//   2. authenticated non-admin -> passes isAuthenticated, blocked by isAdmin
+//   3. authenticated admin     -> passes both; the resolver actually runs
+//
+// Case 2 is the one pure unit tests and the offline auth tests cannot reach:
+// it proves the difference between "not logged in" and "logged in but not
+// allowed" is wired correctly.
+//
+// Auth uses the app's built-in mock-auth seam (E2E_MOCK_AUTH=true), where a
+// token is any JWT carrying username/email claims (decoded, not verified), and
+// admin status is granted via the CYPRESS_ADMIN_TEST_EMAIL match.
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { graphql, type GraphQLSchema } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
+import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
+
+const ADMIN_EMAIL = "admin@e2e.test";
+const SERVER_CONFIG_NAME = "E2ETestServer";
+
+let container: StartedNeo4jContainer;
+let schema: GraphQLSchema;
+let driver: Driver;
+let ogm: any;
+
+before(async () => {
+  // APOC is required: the OGM queries the permission rules run (suspension
+  // lookups) call apoc.date.convertFormat.
+  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+
+  // The schema helper builds its driver from these, so set them before import.
+  process.env.NEO4J_URI = container.getBoltUri();
+  process.env.NEO4J_USER = container.getUsername();
+  process.env.NEO4J_PASSWORD = container.getPassword();
+  process.env.E2E_MOCK_AUTH = "true";
+  process.env.CYPRESS_ADMIN_TEST_EMAIL = ADMIN_EMAIL;
+  process.env.SERVER_CONFIG_NAME = SERVER_CONFIG_NAME;
+
+  const { buildPermissionedSchema } = await import(
+    "../helpers/buildPermissionedSchema.js"
+  );
+  ({ schema, driver, ogm } = await buildPermissionedSchema());
+  await ogm.init();
+
+  const session = driver.session();
+  try {
+    await session.run("CREATE (:User { username: 'adminuser' })");
+    await session.run("CREATE (:User { username: 'normaluser' })");
+    await session.run("CREATE (:ServerConfig { serverName: $name })", {
+      name: SERVER_CONFIG_NAME,
+    });
+  } finally {
+    await session.close();
+  }
+}, { timeout: 240000 });
+
+after(async () => {
+  await driver?.close();
+  await container?.stop();
+});
+
+const mockToken = (claims: Record<string, unknown>) =>
+  `Bearer ${jwt.sign(claims, "mock-signing-key")}`;
+
+// deleteServerConfigs is gated `and(isAuthenticated, isAdmin)`. The non-matching
+// where clause makes the admit-path resolution a harmless no-op (deletes
+// nothing) so the test is non-destructive.
+const execDeleteServerConfigs = (authorization?: string) =>
+  graphql({
+    schema,
+    source: `mutation {
+      deleteServerConfigs(where: { serverName: "does-not-exist-xyz" }) {
+        nodesDeleted
+      }
+    }`,
+    contextValue: {
+      driver,
+      ogm,
+      req: {
+        headers: authorization ? { authorization } : {},
+        body: {},
+        isMutation: true,
+      },
+    },
+  });
+
+test("unauthenticated request is blocked by isAuthenticated", async () => {
+  const result = await execDeleteServerConfigs(undefined);
+  assert.ok(result.errors && result.errors.length > 0);
+  assert.equal(
+    result.errors[0].message,
+    ERROR_MESSAGES.channel.notAuthenticated
+  );
+  assert.equal(result.data, null);
+});
+
+test("authenticated non-admin is blocked by isAdmin (not by isAuthenticated)", async () => {
+  const result = await execDeleteServerConfigs(
+    mockToken({ username: "normaluser", email: "normal@e2e.test" })
+  );
+  assert.ok(result.errors && result.errors.length > 0);
+  // Denied by authorization, NOT authentication — this is the gap unit tests miss.
+  assert.match(result.errors[0].message, /Not Authoris/i);
+  assert.notEqual(
+    result.errors[0].message,
+    ERROR_MESSAGES.channel.notAuthenticated
+  );
+  assert.equal(result.data, null);
+});
+
+test("authenticated admin passes the shield and the resolver runs", async () => {
+  const result = await execDeleteServerConfigs(
+    mockToken({ username: "adminuser", email: ADMIN_EMAIL })
+  );
+  assert.equal(
+    result.errors,
+    undefined,
+    `admin should not be blocked, got: ${JSON.stringify(result.errors)}`
+  );
+  const data = result.data as
+    | { deleteServerConfigs?: { nodesDeleted?: number } }
+    | null
+    | undefined;
+  assert.equal(data?.deleteServerConfigs?.nodesDeleted, 0);
+});

--- a/tests/integration/neo4jHarness.ts
+++ b/tests/integration/neo4jHarness.ts
@@ -19,7 +19,9 @@ let container: StartedNeo4jContainer | undefined;
 let driver: Driver | undefined;
 
 export async function startNeo4j(): Promise<Driver> {
-  container = await new Neo4jContainer(NEO4J_IMAGE).start();
+  // Enable APOC — the app's OGM-generated queries (e.g. suspension date
+  // formatting) depend on apoc.* procedures.
+  container = await new Neo4jContainer(NEO4J_IMAGE).withApoc().start();
   driver = neo4j.driver(
     container.getBoltUri(),
     neo4j.auth.basic(container.getUsername(), container.getPassword())

--- a/utils/botMentionParser.test.ts
+++ b/utils/botMentionParser.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseBotMentions } from "./botMentionParser.js";
+
+test("returns an empty array for empty input", () => {
+  assert.deepEqual(parseBotMentions(null), []);
+  assert.deepEqual(parseBotMentions(undefined), []);
+  assert.deepEqual(parseBotMentions(""), []);
+});
+
+test("parses a single bot mention without a profile id", () => {
+  assert.deepEqual(parseBotMentions("hey /bot/summarizer please help"), [
+    { handle: "summarizer", profileId: null, raw: "/bot/summarizer" },
+  ]);
+});
+
+test("parses a bot mention with a profile id", () => {
+  assert.deepEqual(parseBotMentions("/bot/summarizer:abc123"), [
+    { handle: "summarizer", profileId: "abc123", raw: "/bot/summarizer:abc123" },
+  ]);
+});
+
+test("parses a mention at the very start of the text", () => {
+  assert.deepEqual(parseBotMentions("/bot/helper go"), [
+    { handle: "helper", profileId: null, raw: "/bot/helper" },
+  ]);
+});
+
+test("parses multiple distinct mentions", () => {
+  const result = parseBotMentions("/bot/alpha and /bot/beta:p2");
+  assert.deepEqual(result, [
+    { handle: "alpha", profileId: null, raw: "/bot/alpha" },
+    { handle: "beta", profileId: "p2", raw: "/bot/beta:p2" },
+  ]);
+});
+
+test("deduplicates identical handle + profile id pairs", () => {
+  const result = parseBotMentions("/bot/alpha /bot/alpha /bot/alpha:p1");
+  assert.deepEqual(result, [
+    { handle: "alpha", profileId: null, raw: "/bot/alpha" },
+    // Same handle but a different profile id is a distinct mention.
+    { handle: "alpha", profileId: "p1", raw: "/bot/alpha:p1" },
+  ]);
+});
+
+test("requires the mention to start at a word boundary", () => {
+  // Embedded in a larger token (preceded by a non-space) — not a mention.
+  assert.deepEqual(parseBotMentions("email/bot/nope"), []);
+});
+
+test("allows lowercase letters, digits, and hyphens in the handle", () => {
+  assert.deepEqual(parseBotMentions("/bot/my-bot-2"), [
+    { handle: "my-bot-2", profileId: null, raw: "/bot/my-bot-2" },
+  ]);
+});
+
+test("is stable across repeated calls (regex lastIndex is reset)", () => {
+  const text = "/bot/alpha";
+  const expected = [{ handle: "alpha", profileId: null, raw: "/bot/alpha" }];
+  assert.deepEqual(parseBotMentions(text), expected);
+  assert.deepEqual(parseBotMentions(text), expected);
+});


### PR DESCRIPTION
## Summary

Follow-ups pushed to the `chore/test-coverage-infrastructure` branch **after PR #20 was merged**, split out into their own PR. Continues the test-coverage plan from where #20 left off (which merged through the offline auth-wiring tests).

## What's here

### Phase 4b — authenticated-role e2e (`348ff86`)
- `tests/integration/authenticatedRoles.test.ts`: runs an admin-gated mutation (`deleteServerConfigs`) through the real schema + `graphql-shield` against a live Neo4j, as three callers:
  - unauthenticated → blocked by `isAuthenticated`
  - authenticated non-admin → passes auth, blocked by `isAdmin` (the "logged in but not allowed" case unit tests can't reach)
  - authenticated admin → passes the shield; the resolver runs
- Uses the app's `E2E_MOCK_AUTH` seam; admin via `CYPRESS_ADMIN_TEST_EMAIL` (no role-graph seeding needed).
- Enables APOC on the Testcontainers Neo4j (`withApoc`) — the OGM queries the permission rules run depend on `apoc.date.*`.

### Phase 5 — coverage mop-up (`47e48a0`, `360584d`, `8916976`)
- Pure / dependency-injected helpers: `botMentionParser`, `notificationHelpers.createInAppNotification`, and `botUserService` (`buildBotUsername`, `getProfilesFromSettings`, `getBotNameFromSettings`).

### CI — relax coverage gate (`afe8218`)
- `codecov.yml`: patch (changed-lines) coverage is now **informational/non-blocking**, matching project coverage. The hard 80% patch gate would block most normal PRs against the current ~43% baseline.

## Verification
- Unit suite: **555/555 passing**, `tsc` clean.
- Integration suite: **6/6 passing** against live Neo4j 5.x containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
