### PR TITLE
fix: send discussion-mention emails + enforce user input validation

### DIFF
--- a/customResolvers/mutations/createEmailAndUser.test.ts
+++ b/customResolvers/mutations/createEmailAndUser.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUsersWithEmails } from "./createEmailAndUser.js";
+
+// Validation runs before any DB access, so these stubs are never reached.
+const stubModel = () =>
+  ({
+    find: async () => [],
+    create: async () => ({ users: [{ username: "x" }] }),
+  }) as any;
+
+test("rejects a username with invalid characters", async () => {
+  await assert.rejects(
+    createUsersWithEmails(stubModel(), stubModel(), "a@b.com", "bad name"),
+    /letters, numbers, and underscores/
+  );
+});
+
+test("rejects an over-length username", async () => {
+  await assert.rejects(
+    createUsersWithEmails(stubModel(), stubModel(), "a@b.com", "a".repeat(51)),
+    /cannot exceed/
+  );
+});
+
+test("rejects a missing username before validation", async () => {
+  await assert.rejects(
+    createUsersWithEmails(stubModel(), stubModel(), "a@b.com", ""),
+    /required/
+  );
+});
+
+test("still reserves bot- usernames", async () => {
+  await assert.rejects(
+    createUsersWithEmails(stubModel(), stubModel(), "a@b.com", "bot-evil"),
+    /reserved/
+  );
+});

--- a/customResolvers/mutations/createEmailAndUser.ts
+++ b/customResolvers/mutations/createEmailAndUser.ts
@@ -1,5 +1,6 @@
 import { EmailModel, UserModel, UserCreateInput } from "../../ogm_types.js";
 import { generateSlug } from "random-word-slugs";
+import { validateUserInput } from "../../rules/validation/userIsValid.js";
 
 type Args = {
   emailAddress: string;
@@ -25,6 +26,14 @@ export const createUsersWithEmails = async (
   }
   if (username.toLowerCase().startsWith("bot-")) {
     throw new Error("Usernames starting with \"bot-\" are reserved");
+  }
+
+  // Enforce username format/length rules at registration. The standard
+  // createUsers mutation (which createUserInputIsValid guards) is denied, so
+  // this custom registration path is where create-side validation must live.
+  const usernameValidation = validateUserInput({ username, isEditMode: false });
+  if (usernameValidation !== true) {
+    throw new Error(usernameValidation);
   }
 
   // Check if the user already exists

--- a/customResolvers/mutations/shared/emailUtils.ts
+++ b/customResolvers/mutations/shared/emailUtils.ts
@@ -320,6 +320,33 @@ ${commentUrl}
   };
 };
 
+export const createDiscussionMentionNotificationEmail = (
+  mentionerLabel: string,
+  discussionTitle: string,
+  discussionUrl: string
+): EmailContent => {
+  const subject = `${mentionerLabel} mentioned you in a discussion`;
+  const plainText = `
+${mentionerLabel} mentioned you in the discussion "${discussionTitle}".
+
+View the discussion at:
+${discussionUrl}
+`;
+
+  const html = `
+<p><strong>${mentionerLabel}</strong> mentioned you in the discussion "<strong>${discussionTitle}</strong>".</p>
+<p>
+  <a href="${discussionUrl}">View the discussion</a>
+</p>
+`;
+
+  return {
+    subject,
+    plainText,
+    html,
+  };
+};
+
 export const createSeriesUpdateNotificationEmail = (
   eventTitle: string,
   summaryLines: string[],

--- a/hooks/userMentionNotificationHook.test.ts
+++ b/hooks/userMentionNotificationHook.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { notifyCommentMentions } from "./userMentionNotificationHook.js";
+import {
+  notifyCommentMentions,
+  notifyDiscussionMentions,
+} from "./userMentionNotificationHook.js";
 
 const buildContext = (users: any[]) => {
   const createdNotifications: Array<{ username: string; text: string }> = [];
@@ -165,4 +168,99 @@ test("notifyCommentMentions ignores self-mentions and dedupes mixed syntax", asy
   assert.deepEqual(createdNotifications.map((item) => item.username), ["cluse"]);
   assert.equal(sendEmailCalls.length, 1);
   assert.equal(sendEmailCalls[0]?.to, "cluse@example.com");
+});
+
+const baseDiscussion = {
+  id: "discussion-1",
+  title: "Phoenix Meetup",
+  body: "Hello @cluse",
+  Author: { username: "alice", displayName: "Alice" },
+  DiscussionChannels: [{ channelUniqueName: "phoenix" }],
+};
+
+const discussionDeps = (
+  createdNotifications: Array<{ username: string; text: string }>,
+  sendEmailCalls: any[]
+) => ({
+  async createInAppNotification(input: any) {
+    createdNotifications.push({ username: input.username, text: input.text });
+    return true;
+  },
+  async sendEmail(message: any) {
+    sendEmailCalls.push(message);
+    return true;
+  },
+});
+
+test("notifyDiscussionMentions notifies a newly mentioned user", async () => {
+  process.env.FRONTEND_URL = "https://example.com";
+  const sendEmailCalls: any[] = [];
+  const { context, createdNotifications } = buildContext([
+    {
+      username: "cluse",
+      notifyWhenTagged: true,
+      Email: { address: "cluse@example.com" },
+    },
+  ]);
+
+  await notifyDiscussionMentions({
+    context,
+    discussion: baseDiscussion,
+    previousText: null,
+    nextText: "Hello @cluse",
+    dependencies: discussionDeps(createdNotifications, sendEmailCalls),
+  });
+
+  assert.deepEqual(
+    createdNotifications.map((item) => item.username),
+    ["cluse"]
+  );
+  assert.equal(sendEmailCalls.length, 1);
+  assert.equal(sendEmailCalls[0].to, "cluse@example.com");
+  assert.match(sendEmailCalls[0].subject, /mentioned you/i);
+});
+
+test("notifyDiscussionMentions does not email when notifyWhenTagged is disabled", async () => {
+  process.env.FRONTEND_URL = "https://example.com";
+  const sendEmailCalls: any[] = [];
+  const { context, createdNotifications } = buildContext([
+    {
+      username: "cluse",
+      notifyWhenTagged: false,
+      Email: { address: "cluse@example.com" },
+    },
+  ]);
+
+  await notifyDiscussionMentions({
+    context,
+    discussion: baseDiscussion,
+    previousText: null,
+    nextText: "Hello @cluse",
+    dependencies: discussionDeps(createdNotifications, sendEmailCalls),
+  });
+
+  assert.equal(sendEmailCalls.length, 0);
+});
+
+test("notifyDiscussionMentions ignores mentions already present before the edit", async () => {
+  process.env.FRONTEND_URL = "https://example.com";
+  const sendEmailCalls: any[] = [];
+  const { context, createdNotifications } = buildContext([
+    {
+      username: "cluse",
+      notifyWhenTagged: true,
+      Email: { address: "cluse@example.com" },
+    },
+  ]);
+
+  await notifyDiscussionMentions({
+    context,
+    discussion: baseDiscussion,
+    previousText: "Hello @cluse",
+    nextText: "Hello @cluse again",
+    dependencies: discussionDeps(createdNotifications, sendEmailCalls),
+  });
+
+  assert.equal(sendEmailCalls.length, 0);
+  assert.equal(createdNotifications.length, 0);
 });

--- a/hooks/userMentionNotificationHook.ts
+++ b/hooks/userMentionNotificationHook.ts
@@ -11,7 +11,10 @@ import {
   MentionContextComment,
   CommentSnapshot,
 } from '../utils/buildCommentMentionContext.js';
-import { createCommentMentionNotificationEmail } from '../customResolvers/mutations/shared/emailUtils.js';
+import {
+  createCommentMentionNotificationEmail,
+  createDiscussionMentionNotificationEmail,
+} from '../customResolvers/mutations/shared/emailUtils.js';
 
 // Re-export for consumers
 export { getNewMentionUsernames } from '../utils/getNewMentionUsernames.js';
@@ -37,6 +40,7 @@ type NotifyMentionsInput = {
     createInAppNotification?: typeof createInAppNotification;
     sendEmail?: typeof sendEmail;
     createCommentMentionNotificationEmail?: typeof createCommentMentionNotificationEmail;
+    createDiscussionMentionNotificationEmail?: typeof createDiscussionMentionNotificationEmail;
   };
 };
 
@@ -203,6 +207,9 @@ export const notifyNewUserMentions = async ({
     const createCommentMentionNotificationEmailFn =
       dependencies?.createCommentMentionNotificationEmail ||
       createCommentMentionNotificationEmail;
+    const createDiscussionMentionNotificationEmailFn =
+      dependencies?.createDiscussionMentionNotificationEmail ||
+      createDiscussionMentionNotificationEmail;
     const newMentions = getNewMentionUsernames(previousText, nextText);
     if (!newMentions.length) return;
 
@@ -238,26 +245,38 @@ export const notifyNewUserMentions = async ({
         text: notificationText,
       });
 
-      if (
-        mentionContext.type === 'comment' &&
-        notificationUrl &&
-        user.notifyWhenTagged &&
-        user.email
-      ) {
-        const contentTitle = mentionContext.event?.title || mentionContext.discussion?.title || 'discussion';
-        const emailContent = createCommentMentionNotificationEmailFn(
-          mentionContext.authorLabel,
-          contentTitle,
-          notificationUrl,
-          Boolean(mentionContext.event)
-        );
+      if (notificationUrl && user.notifyWhenTagged && user.email) {
+        let emailContent:
+          | ReturnType<typeof createCommentMentionNotificationEmail>
+          | null = null;
 
-        await sendEmailFn({
-          to: user.email,
-          subject: emailContent.subject,
-          text: emailContent.plainText,
-          html: emailContent.html,
-        });
+        if (mentionContext.type === 'comment') {
+          const contentTitle =
+            mentionContext.event?.title ||
+            mentionContext.discussion?.title ||
+            'discussion';
+          emailContent = createCommentMentionNotificationEmailFn(
+            mentionContext.authorLabel,
+            contentTitle,
+            notificationUrl,
+            Boolean(mentionContext.event)
+          );
+        } else if (mentionContext.type === 'discussion') {
+          emailContent = createDiscussionMentionNotificationEmailFn(
+            mentionContext.authorLabel,
+            mentionContext.title,
+            notificationUrl
+          );
+        }
+
+        if (emailContent) {
+          await sendEmailFn({
+            to: user.email,
+            subject: emailContent.subject,
+            text: emailContent.plainText,
+            html: emailContent.html,
+          });
+        }
       }
     }
   } catch (error) {

--- a/permissions.ts
+++ b/permissions.ts
@@ -29,6 +29,7 @@ const {
   updateCommentInputIsValid,
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
+  updateUserInputIsValid,
   canReport,
   canSuspendAndUnsuspendUser,
   canArchiveAndUnarchiveComment,
@@ -120,7 +121,7 @@ const permissionList = shield({
       deleteServerRoles: and(isAuthenticated, isAdmin),
       
       createEmailAndUser: allow, // Keep this as-is since this is for user registration
-      updateUsers: and(isAuthenticated, or(isAccountOwner, isAdmin)),
+      updateUsers: and(isAuthenticated, updateUserInputIsValid, or(isAccountOwner, isAdmin)),
       
       createChannels: and(isAuthenticated, createChannelInputIsValid, canCreateChannel),
       updateChannels: canEditWikiHomePage,// and(isAuthenticated, updateChannelInputIsValid, or(isChannelOwner, isAdmin)),

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -65,6 +65,7 @@ import {
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
 } from "./validation/downloadableFileIsValid.js";
+import { updateUserInputIsValid } from "./validation/userIsValid.js";
 import { getServerScopedMembership } from "./permission/getServerScopedMembership.js";
 
 export async function evaluateCanCreateChannelRule(ctx: any) {
@@ -798,6 +799,7 @@ const ruleList = {
   updateEventInputIsValid,
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
+  updateUserInputIsValid,
   hasChannelPermission,
   isAdmin,
   isAccountOwner,


### PR DESCRIPTION
## Summary

Wires up two pieces of validation/notification logic that existed but were never connected — surfaced while triaging knip's "unused export" output. Both are real behavior gaps, each with tests.

## 1. Discussion mentions never sent email (bug fix)

`notifyDiscussionMentions` *was* wired into `discussionMentionsMiddleware` and created in-app notifications, but `notifyNewUserMentions` only sent an **email** when `mentionContext.type === 'comment'`. So `@`-mentioning someone in a discussion notified them in-app but never emailed them.

- Adds `createDiscussionMentionNotificationEmail`
- Generalizes the email branch to handle comment **and** discussion mentions
- Tests: emails a tagged user, respects `notifyWhenTagged`, only fires for newly-added mentions

> Note: knip flagged `notifyDiscussionMentions` as "unused" only because it skips the gitignored `middleware/` folder that imports it. It was wired — just not emailing.

## 2. User input validation was never enforced (bug fix)

`createUserInputIsValid` / `updateUserInputIsValid` existed but weren't referenced anywhere.

- `updateUsers` now runs `updateUserInputIsValid` (username format/length, bio/display-name length) — matching how channel/discussion/event updates already validate.
- `createEmailAndUser` (the live registration mutation) now validates the username via the tested `validateUserInput`. The standard `createUsers` mutation that `createUserInputIsValid` guards is denied (`Mutation: { "*": deny }`), so registration is where create-side validation must live.
- Tests: registration rejects invalid-character / over-length / missing usernames and still reserves `bot-` names.

## Verification
- **562/562 unit tests pass**, `tsc` clean.

## Follow-ups (not in this PR)
- Correction: `services/plugin/{comment,channel,download}Trigger.ts` are the **live** plugin-trigger implementation (consumed by `createDiscussionWithChannelConnections`, `triggerDownloadableFilePluginRuns`, and `commentPluginPipelineMiddleware`); `services/pluginRunner.ts` is just an `export *` compat shim. An earlier note here wrongly called them an unwired duplicate — they are not dead and must not be deleted.
- `createUserInputIsValid` (the shield rule) is now redundant — its target `createUsers` is denied and registration validates directly. Can be removed, or kept if `createUsers` is ever enabled. Your call.
- knip currently skips the gitignored `middleware/` folder (false positives for middleware-only-used exports). Worth running knip with `--no-gitignore` or un-ignoring `middleware/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
