### PR TITLE
test(integration): channel/issue/suspension moderation coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
-    "test:integration": "node --loader ts-node/esm --test $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "test:integration": "node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
     "prepare": "husky install",
     "codegen": "graphql-codegen --config codegen.ts",

--- a/tests/integration/channelModeration.test.ts
+++ b/tests/integration/channelModeration.test.ts
@@ -1,0 +1,137 @@
+// Integration tests for channel-level moderation resolvers against live Neo4j:
+// lockChannel, unlockChannel, reportChannel.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One" });
+  await run(
+    `CREATE (:Channel { uniqueName: 'test-channel', displayName: 'Test Channel', locked: false })`
+  );
+});
+
+const ctx = () => modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }));
+
+const lockChannel = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.lockChannel(
+    null,
+    { channelUniqueName: "test-channel", reason: "Spam wave", ...args },
+    ctx()
+  );
+
+const unlockChannel = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.unlockChannel(
+    null,
+    { channelUniqueName: "test-channel", reason: "Resolved", ...args },
+    ctx()
+  );
+
+test("lockChannel sets locked + reason and opens an Issue with a lock_channel action", async () => {
+  await lockChannel();
+
+  const ch = await run(
+    `MATCH (c:Channel { uniqueName: 'test-channel' })
+     RETURN c.locked AS locked, c.lockReason AS reason, c.lockedAt AS at`
+  );
+  assert.equal(ch[0].locked, true);
+  assert.equal(ch[0].reason, "Spam wave");
+  assert.ok(ch[0].at, "lockedAt should be set");
+
+  const actions = await run(
+    `MATCH (i:Issue { relatedChannelUniqueName: 'test-channel' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  assert.ok(
+    (actions[0].types as string[]).includes("lock_channel"),
+    `got ${JSON.stringify(actions[0]?.types)}`
+  );
+});
+
+test("lockChannel throws when the channel is already locked", async () => {
+  await lockChannel();
+  await assert.rejects(lockChannel(), /already locked/i);
+});
+
+test("lockChannel throws when no reason is given", async () => {
+  await assert.rejects(lockChannel({ reason: "" }), /reason is required/i);
+});
+
+test("unlockChannel clears the locked state after a lock", async () => {
+  await lockChannel();
+  await unlockChannel();
+
+  const ch = await run(
+    `MATCH (c:Channel { uniqueName: 'test-channel' })
+     RETURN c.locked AS locked, c.lockReason AS reason`
+  );
+  assert.equal(ch[0].locked, false);
+  assert.equal(ch[0].reason, null);
+});
+
+test("unlockChannel throws when the channel is not locked", async () => {
+  await assert.rejects(unlockChannel(), /not locked/i);
+});
+
+test("reportChannel opens a server-scoped Issue with a report action", async () => {
+  await env.resolvers.Mutation.reportChannel(
+    null,
+    {
+      channelUniqueName: "test-channel",
+      reportText: "This channel violates server rules",
+      selectedServerRules: ["No spam"],
+    },
+    ctx()
+  );
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedChannelUniqueName: 'test-channel' })
+     RETURN i.channelUniqueName AS channel, i.isOpen AS isOpen, i.flaggedServerRuleViolation AS flagged`
+  );
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].channel, null);
+  assert.equal(issues[0].isOpen, true);
+  assert.equal(issues[0].flagged, true);
+
+  const actions = await run(
+    `MATCH (i:Issue { relatedChannelUniqueName: 'test-channel' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  assert.ok((actions[0].types as string[]).includes("report"));
+});
+
+test("reportChannel throws when no server rule is selected", async () => {
+  await assert.rejects(
+    env.resolvers.Mutation.reportChannel(
+      null,
+      {
+        channelUniqueName: "test-channel",
+        reportText: "x",
+        selectedServerRules: [],
+      },
+      ctx()
+    ),
+    /server rule must be selected/i
+  );
+});

--- a/tests/integration/issueLocking.test.ts
+++ b/tests/integration/issueLocking.test.ts
@@ -1,0 +1,100 @@
+// Integration tests for lockIssue / unlockIssue against live Neo4j.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One" });
+  await run(
+    // createdAt is non-nullable (@timestamp on CREATE); raw-Cypher seeding skips
+    // it, so set it explicitly or the OGM update re-validation fails.
+    `CREATE (:Issue {
+        id: 'issue-1', issueNumber: 1, isOpen: true, locked: false,
+        channelUniqueName: 'test-channel', title: 'Test issue', authorName: 'Mod One',
+        createdAt: datetime()
+     })`
+  );
+});
+
+const ctx = () => modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }));
+
+const lockIssue = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.lockIssue(
+    null,
+    { issueId: "issue-1", reason: "Off-topic flame war", ...args },
+    ctx()
+  );
+
+const unlockIssue = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.unlockIssue(
+    null,
+    { issueId: "issue-1", reason: "Cooled down", ...args },
+    ctx()
+  );
+
+test("lockIssue sets locked + reason and records a lock action", async () => {
+  await lockIssue();
+
+  const issue = await run(
+    `MATCH (i:Issue { id: 'issue-1' })
+     RETURN i.locked AS locked, i.lockReason AS reason, i.lockedAt AS at`
+  );
+  assert.equal(issue[0].locked, true);
+  assert.equal(issue[0].reason, "Off-topic flame war");
+  assert.ok(issue[0].at, "lockedAt should be set");
+
+  const actions = await run(
+    `MATCH (i:Issue { id: 'issue-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  assert.ok((actions[0].types as string[]).includes("lock"), `got ${JSON.stringify(actions[0]?.types)}`);
+});
+
+test("lockIssue throws when already locked", async () => {
+  await lockIssue();
+  await assert.rejects(lockIssue(), /already locked/i);
+});
+
+test("lockIssue throws when no reason is given", async () => {
+  await assert.rejects(lockIssue({ reason: "" }), /reason is required/i);
+});
+
+test("unlockIssue clears the locked state after a lock", async () => {
+  await lockIssue();
+  await unlockIssue();
+
+  const issue = await run(
+    `MATCH (i:Issue { id: 'issue-1' }) RETURN i.locked AS locked, i.lockReason AS reason`
+  );
+  assert.equal(issue[0].locked, false);
+  assert.equal(issue[0].reason, null);
+});
+
+test("unlockIssue throws when the issue is not locked", async () => {
+  await assert.rejects(unlockIssue(), /not locked/i);
+});
+
+test("lockIssue throws when the issue does not exist", async () => {
+  await assert.rejects(lockIssue({ issueId: "ghost" }), /Issue not found/i);
+});

--- a/tests/integration/suspension.test.ts
+++ b/tests/integration/suspension.test.ts
@@ -1,0 +1,98 @@
+// Integration tests for the shared suspension resolvers against live Neo4j:
+// suspendUser + unsuspendUser (createSuspensionResolver / createUnsuspendResolver).
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One" });
+  // A channel-scoped Issue (Channel -[:HAS_ISSUE]-> Issue makes scope 'channel')
+  // targeting user "baduser" via relatedUsername.
+  await run(
+    `CREATE (ch:Channel { uniqueName: 'test-channel', displayName: 'Test Channel' })
+     CREATE (target:User { username: 'baduser', displayName: 'Bad User' })
+     CREATE (i:Issue {
+        id: 'issue-1', issueNumber: 1, isOpen: true,
+        channelUniqueName: 'test-channel', relatedUsername: 'baduser',
+        title: 'Report against baduser', authorName: 'Mod One', createdAt: datetime()
+     })
+     CREATE (ch)-[:HAS_ISSUE]->(i)`
+  );
+});
+
+const ctx = () => modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }));
+
+const suspendUser = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.suspendUser(
+    null,
+    {
+      issueId: "issue-1",
+      suspendIndefinitely: true,
+      explanation: "Repeated rule violations",
+      ...args,
+    },
+    ctx()
+  );
+
+test("suspendUser creates a Suspension, closes the issue, and records actions", async () => {
+  await suspendUser();
+
+  const suspensions = await run(
+    `MATCH (s:Suspension { username: 'baduser' })
+     RETURN s.channelUniqueName AS channel, s.suspendedIndefinitely AS indefinite`
+  );
+  assert.equal(suspensions.length, 1, "one Suspension should be created");
+  assert.equal(suspensions[0].channel, "test-channel");
+  assert.equal(suspensions[0].indefinite, true);
+
+  const linked = await run(
+    `MATCH (s:Suspension { username: 'baduser' })--(u:User { username: 'baduser' })
+     RETURN count(DISTINCT u) AS n`
+  );
+  assert.equal(Number(linked[0].n), 1, "suspension should link to the target user");
+
+  const issue = await run(`MATCH (i:Issue { id: 'issue-1' }) RETURN i.isOpen AS isOpen`);
+  assert.equal(issue[0].isOpen, false, "issue should be closed after suspension");
+
+  const actions = await run(
+    `MATCH (i:Issue { id: 'issue-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  const types: string[] = actions[0].types;
+  assert.ok(types.includes("suspension"), `got ${JSON.stringify(types)}`);
+  assert.ok(types.includes("close"), `got ${JSON.stringify(types)}`);
+});
+
+test("suspendUser attaches the suspension to the channel", async () => {
+  await suspendUser();
+  const rel = await run(
+    `MATCH (ch:Channel { uniqueName: 'test-channel' })-[:SUSPENDED_AS_USER]->(s:Suspension { username: 'baduser' })
+     RETURN count(s) AS n`
+  );
+  assert.equal(Number(rel[0].n), 1);
+});
+
+test("suspendUser throws when the issue id is missing", async () => {
+  await assert.rejects(suspendUser({ issueId: undefined }), /Issue ID is required/i);
+});

--- a/tests/integration/suspension.test.ts
+++ b/tests/integration/suspension.test.ts
@@ -30,7 +30,9 @@ beforeEach(async () => {
   // A channel-scoped Issue (Channel -[:HAS_ISSUE]-> Issue makes scope 'channel')
   // targeting user "baduser" via relatedUsername.
   await run(
-    `CREATE (ch:Channel { uniqueName: 'test-channel', displayName: 'Test Channel' })
+    // Channel.createdAt is non-nullable; the unsuspend Channel.update re-validates
+    // the node, so seed it (raw-Cypher seeding bypasses the @timestamp default).
+    `CREATE (ch:Channel { uniqueName: 'test-channel', displayName: 'Test Channel', createdAt: datetime() })
      CREATE (target:User { username: 'baduser', displayName: 'Bad User' })
      CREATE (i:Issue {
         id: 'issue-1', issueNumber: 1, isOpen: true,
@@ -52,6 +54,13 @@ const suspendUser = (args: Record<string, unknown> = {}) =>
       explanation: "Repeated rule violations",
       ...args,
     },
+    ctx()
+  );
+
+const unsuspendUser = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.unsuspendUser(
+    null,
+    { issueId: "issue-1", explanation: "Appeal granted", ...args },
     ctx()
   );
 
@@ -95,4 +104,24 @@ test("suspendUser attaches the suspension to the channel", async () => {
 
 test("suspendUser throws when the issue id is missing", async () => {
   await assert.rejects(suspendUser({ issueId: undefined }), /Issue ID is required/i);
+});
+
+test("unsuspendUser detaches the suspension and records an unsuspend action", async () => {
+  await suspendUser();
+  await unsuspendUser();
+
+  const rel = await run(
+    `MATCH (ch:Channel { uniqueName: 'test-channel' })-[:SUSPENDED_AS_USER]->(s:Suspension { username: 'baduser' })
+     RETURN count(s) AS n`
+  );
+  assert.equal(Number(rel[0].n), 0, "suspension should be detached from the channel");
+
+  const actions = await run(
+    `MATCH (i:Issue { id: 'issue-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  assert.ok(
+    (actions[0].types as string[]).includes("unsuspend"),
+    `got ${JSON.stringify(actions[0].types)}`
+  );
 });


### PR DESCRIPTION
## Summary

Extends the Testcontainers moderation harness (merged in #25) to the **channel / issue / suspension** moderation resolvers — the next-largest cluster of uncovered DB-orchestration code in `customResolvers/mutations/`. **17 integration tests, all passing.**

## Coverage added

| Resolver | Before | After (approx) |
|---|---|---|
| `lockIssue.ts` | ~13% | **~94%** |
| `unlockIssue.ts` | ~13% | **~93%** |
| `lockChannel.ts` | ~10% | **~85%** |
| `unlockChannel.ts` | ~11% | **~85%** |
| `reportChannel.ts` | ~13% | **~85%** |
| `shared/createSuspensionResolver.ts` | ~20% | **~79%** |
| `shared/createUnsuspendResolver.ts` | ~25% | **covered** |

(Approximate — c8 instrumentation makes Testcontainers startup unreliable, so coverage was sampled per-file; the tests pass cleanly.)

## What's verified
- **lockChannel / unlockChannel**: set/clear `locked` + `lockReason` + `lockedAt`, open an Issue with a `lock_channel` action, plus already-locked / not-locked / missing-reason paths.
- **reportChannel**: opens a server-scoped report Issue; errors with no server rule.
- **lockIssue / unlockIssue**: set/clear the Issue `locked` flag + lock/unlock actions, plus already-locked / not-locked / not-found paths.
- **suspendUser / unsuspendUser**: creates a `Suspension` (linked to the user, attached to the channel), closes the issue, records suspension/close actions; unsuspend detaches the suspension and records an unsuspend action.

## Infrastructure fix
- `test:integration` now runs with `--test-concurrency=1`. `node --test` parallelizes files by default; with each integration file starting its own Neo4j container, several at once exhaust Docker and fail nondeterministically. Serializing fixes it.

## Notes
- A seeding gotcha worth knowing for future integration tests: resolvers that `Model.update(...)` a node re-validate it, so raw-Cypher seeds must set non-nullable `@timestamp`/`@default` fields (`createdAt`, `scanStatus`, etc.) — otherwise you get `Cannot return null for non-nullable field ...`. (This is what briefly looked like an `unsuspendUser` bug; it wasn't — the resolver is fine.)
- (carried from #25) `reportImage` / `reportChannelImage` / `reportProfilePicture` aren't in `permissions.ts`, so they're denied through the GraphQL gateway — worth confirming intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
