### PR TITLE
fix(permissions): wire image/profile report mutations (were gateway-denied)

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -227,6 +227,9 @@ const permissionList = shield({
       reportEvent: and(isAuthenticated, or(isChannelOwner, canReport)),
       reportWikiEdit: and(isAuthenticated, or(isChannelOwner, canReport)),
       reportChannel: and(isAuthenticated, canReport), // Channel reports require mod profile, no channel owner shortcut
+      reportImage: and(isAuthenticated, or(isChannelOwner, canReport)), // mirrors reportComment/reportDiscussion (channel-scoped image content)
+      reportChannelImage: and(isAuthenticated, canReport), // server-scoped, but canReport resolves the channel from channelUniqueName (like reportChannel)
+      reportProfilePicture: and(isAuthenticated, isAdmin), // server-scoped, no channel to scope canReport to
       lockChannel: and(isAuthenticated, or(isAdmin, canLockChannel)),
       unlockChannel: and(isAuthenticated, or(isAdmin, canLockChannel)),
       suspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),

--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -112,3 +112,38 @@ for (const mutation of unmappedGenerated) {
     assert.equal(result.data, null);
   });
 }
+
+// The image/profile report mutations are now wired (previously absent from
+// permissions.ts and thus hitting the default deny). Each is gated
+// `and(isAuthenticated, ...)`, so an unauthenticated request must fail with the
+// not-authenticated error — NOT the "Not Authorised!" default-deny fallback.
+// This distinguishes "wired but unauthenticated" from "still default-denied".
+const authGatedReports: Array<{ name: string; op: string }> = [
+  {
+    name: "reportImage",
+    op: `mutation { reportImage(imageId: "i", reportText: "t", selectedForumRules: [], selectedServerRules: []) { id } }`,
+  },
+  {
+    name: "reportChannelImage",
+    op: `mutation { reportChannelImage(channelUniqueName: "c", imageType: ICON, reportText: "t", selectedServerRules: []) { id } }`,
+  },
+  {
+    name: "reportProfilePicture",
+    op: `mutation { reportProfilePicture(username: "u", reportText: "t", selectedServerRules: []) { id } }`,
+  },
+];
+
+for (const { name, op } of authGatedReports) {
+  test(`${name} is wired (unauthenticated -> notAuthenticated, not default-deny)`, async () => {
+    const result = await execUnauthenticated(op);
+
+    assert.ok(result.errors && result.errors.length > 0, `${name} should error`);
+    assert.equal(
+      result.errors[0].message,
+      ERROR_MESSAGES.channel.notAuthenticated,
+      `${name} should be auth-gated, got: ${result.errors[0].message}`
+    );
+    // Issue is nullable, so a denied field nulls itself (rather than all of data).
+    assert.equal((result.data as Record<string, unknown> | null)?.[name], null);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a real authorization gap: **`reportImage`, `reportChannelImage`, and `reportProfilePicture` were never wired into `permissions.ts`**, so they fell under the `Mutation: { "*": deny }` default and were rejected at the gateway. They have full resolvers and GraphQL signatures and aren't called internally anywhere — so moderators could not report images, channel images, or profile pictures through the API at all.

Surfaced while building the image-moderation integration tests (#25).

## Gates

Mirroring the analogous report mutations, accounting for each one's scope:

| Mutation | Gate | Rationale |
|---|---|---|
| `reportImage` | `and(isAuthenticated, or(isChannelOwner, canReport))` | channel-scoped image content, like `reportComment`/`reportDiscussion` |
| `reportChannelImage` | `and(isAuthenticated, canReport)` | takes `channelUniqueName`, so `canReport` resolves the channel — like `reportChannel` |
| `reportProfilePicture` | `and(isAuthenticated, isAdmin)` | server-scoped with no channel; `canReport` can't apply, so admin-gated |

## Tests

Offline auth-wiring tests (no DB needed — graphql-shield denies before resolution) asserting each mutation, when called unauthenticated, now fails with the **not-authenticated** error rather than the `"Not Authorised!"` default-deny fallback — i.e. proving they're actually wired with `isAuthenticated`, not just still denied.

558/558 unit tests pass, `tsc` clean.

## Note
`reportImage` supports a server-scoped path (no `channelUniqueName`), which `canReport` (channel-based) can't satisfy — so server-scoped image reports without a channel would still be denied. If that path is used in practice, it'd need a server-level gate too; flag if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
