### PR TITLE
test(integration): enableServerPlugin + updateDownloadLabels coverage

### DIFF
--- a/tests/integration/enableServerPlugin.test.ts
+++ b/tests/integration/enableServerPlugin.test.ts
@@ -1,0 +1,90 @@
+// Integration tests for enableServerPlugin against live Neo4j. The resolver
+// ignores context (no auth), finds an installed plugin version, and flips the
+// `enabled` edge property on the ServerConfig -[:INSTALLED]-> PluginVersion
+// relationship.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+const seedInstalledPlugin = (enabled: boolean) =>
+  run(
+    `CREATE (p:Plugin { id: 'plugin-1', name: 'test-plugin', displayName: 'Test Plugin' })
+     CREATE (pv:PluginVersion { id: 'pv-1', version: '1.0.0', entryPath: 'index.js', repoUrl: 'https://example.com/repo' })
+     CREATE (p)-[:HAS_VERSION]->(pv)
+     CREATE (sc:ServerConfig { serverName: 'test-server' })
+     CREATE (sc)-[:INSTALLED { enabled: $enabled }]->(pv)`,
+    { enabled }
+  );
+
+const enableServerPlugin = (args: Record<string, unknown>) =>
+  env.resolvers.Mutation.enableServerPlugin(null, args, {
+    driver: env.driver,
+    ogm: env.ogm,
+  });
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+const installedEnabledFlag = async () => {
+  const rows = await run(
+    `MATCH (:ServerConfig { serverName: 'test-server' })-[r:INSTALLED]->(:PluginVersion { version: '1.0.0' })
+     RETURN r.enabled AS enabled`
+  );
+  return rows[0]?.enabled;
+};
+
+test("enables an installed plugin version (flips the INSTALLED edge to true)", async () => {
+  await seedInstalledPlugin(false);
+
+  await enableServerPlugin({ pluginId: "test-plugin", version: "1.0.0", enabled: true });
+
+  assert.equal(await installedEnabledFlag(), true);
+});
+
+test("disables an enabled plugin version", async () => {
+  await seedInstalledPlugin(true);
+
+  await enableServerPlugin({ pluginId: "test-plugin", version: "1.0.0", enabled: false });
+
+  assert.equal(await installedEnabledFlag(), false);
+});
+
+test("throws when the plugin does not exist", async () => {
+  await seedInstalledPlugin(false);
+  await assert.rejects(
+    enableServerPlugin({ pluginId: "ghost", version: "1.0.0", enabled: true }),
+    /not found/i
+  );
+});
+
+test("throws when the version is installed nowhere", async () => {
+  // Plugin + version exist, but no INSTALLED edge from a ServerConfig.
+  await run(
+    `CREATE (p:Plugin { id: 'plugin-1', name: 'test-plugin' })
+     CREATE (pv:PluginVersion { id: 'pv-1', version: '1.0.0', entryPath: 'index.js', repoUrl: 'https://example.com/repo' })
+     CREATE (p)-[:HAS_VERSION]->(pv)
+     CREATE (:ServerConfig { serverName: 'test-server' })`
+  );
+  await assert.rejects(
+    enableServerPlugin({ pluginId: "test-plugin", version: "1.0.0", enabled: true }),
+    /not installed/i
+  );
+});

--- a/tests/integration/updateDownloadLabels.test.ts
+++ b/tests/integration/updateDownloadLabels.test.ts
@@ -1,0 +1,95 @@
+// Integration tests for updateDownloadLabels against live Neo4j. The resolver
+// resolves the acting user via setUserDataOnContext, checks discussion
+// ownership (or channel/server mod permission), then connects/disconnects
+// FilterOption labels on the DiscussionChannel and records LabelChangeHistory.
+// These tests exercise the owner path.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await run(
+    `CREATE (owner:User { username: 'test-owner', createdAt: datetime() })
+     CREATE (rando:User { username: 'rando', createdAt: datetime() })
+     CREATE (ch:Channel { uniqueName: 'test-channel', displayName: 'Test Channel', createdAt: datetime() })
+     CREATE (disc:Discussion { id: 'disc-1', title: 'Test Discussion', createdAt: datetime() })
+     CREATE (owner)-[:POSTED_DISCUSSION]->(disc)
+     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'disc-1', channelUniqueName: 'test-channel', createdAt: datetime() })
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(disc)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(ch)
+     CREATE (fg:FilterGroup { id: 'fg-1', key: 'size', displayName: 'Size', order: 1, mode: 'INCLUDE' })
+     CREATE (fo1:FilterOption { id: 'fo-1', value: 'small', displayName: 'Small', order: 1 })
+     CREATE (fo2:FilterOption { id: 'fo-2', value: 'large', displayName: 'Large', order: 2 })
+     CREATE (fg)-[:HAS_FILTER_OPTION]->(fo1)
+     CREATE (fg)-[:HAS_FILTER_OPTION]->(fo2)`
+  );
+});
+
+const asOwner = () => modContext(env, mockToken({ username: "test-owner", email: "owner@e2e.test" }));
+
+const updateLabels = (labelOptionIds: string[], context = asOwner()) =>
+  env.resolvers.Mutation.updateDownloadLabels(
+    null,
+    { discussionId: "disc-1", channelUniqueName: "test-channel", labelOptionIds },
+    context
+  );
+
+const connectedLabelValues = async () => {
+  const rows = await run(
+    `MATCH (:DiscussionChannel { id: 'dc-1' })-[:HAS_LABEL_OPTION]->(fo:FilterOption)
+     RETURN fo.value AS value ORDER BY fo.value`
+  );
+  return rows.map((r) => r.value);
+};
+
+test("owner adds download labels and records 'added' history", async () => {
+  await updateLabels(["fo-1", "fo-2"]);
+
+  assert.deepEqual(await connectedLabelValues(), ["large", "small"]);
+
+  const history = await run(
+    `MATCH (:DiscussionChannel { id: 'dc-1' })-[:HAS_LABEL_CHANGE]->(h:LabelChangeHistory { actionType: 'added' })
+     RETURN count(h) AS n`
+  );
+  assert.equal(Number(history[0].n), 2, "two 'added' history entries expected");
+});
+
+test("owner removing a label disconnects it and records 'removed' history", async () => {
+  await updateLabels(["fo-1"]);
+  await updateLabels([]); // remove all
+
+  assert.deepEqual(await connectedLabelValues(), []);
+
+  const removed = await run(
+    `MATCH (:DiscussionChannel { id: 'dc-1' })-[:HAS_LABEL_CHANGE]->(h:LabelChangeHistory { actionType: 'removed' })
+     RETURN count(h) AS n`
+  );
+  assert.ok(Number(removed[0].n) >= 1, "at least one 'removed' history entry expected");
+});
+
+test("a non-owner without mod permission is rejected", async () => {
+  await assert.rejects(
+    updateLabels(["fo-1"], modContext(env, mockToken({ username: "rando", email: "r@e2e.test" }))),
+    /don't have permission/i
+  );
+});


### PR DESCRIPTION
## Summary

Integration coverage for two more sizeable DB-only resolvers, via the existing Testcontainers harness. **7 tests, all passing.**

## Coverage

| Resolver | Before | After |
|---|---|---|
| `enableServerPlugin.ts` | ~11% | **~91%** |
| `updateDownloadLabels.ts` | ~11% | **~84%** |

## What's verified
- **enableServerPlugin**: enables/disables an installed plugin version by flipping the `enabled` property on the `ServerConfig -[:INSTALLED]-> PluginVersion` edge; error paths for plugin-not-found and not-installed.
- **updateDownloadLabels** (owner path): the discussion owner adds/removes download labels (`FilterOption` connections on the `DiscussionChannel`) and records `LabelChangeHistory`; a non-owner without mod permission is rejected. (The mod path that also writes a `ModerationAction` — lines ~327-353 — is the main uncovered remainder; it needs a seeded `ModerationProfile` + mod permission and could be a follow-up.)

## Notes
- The plugin-admin siblings `refreshPlugins`/`installPluginVersion` make external `fetch()` calls to a plugin registry, so they need an HTTP-mock harness rather than this DB harness — not covered here.
- Seeding gotcha reinforced: raw-Cypher seeds must satisfy non-nullable fields the OGM re-validates on update (`FilterOption.group`, `createdAt`, the `INSTALLED` edge's `enabled`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
