### PR TITLE
ci: report integration-test coverage to Codecov (merge unit + integration)

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -30,11 +30,12 @@ jobs:
       - name: Run unit tests with coverage
         run: npm run coverage
 
-      - name: Upload coverage to Codecov
+      - name: Upload unit coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          flags: unit
           fail_ci_if_error: false
           verbose: true
 
@@ -57,6 +58,18 @@ jobs:
         run: npm ci
 
       # Testcontainers manages the Neo4j container itself via the Docker daemon
-      # that is available on GitHub-hosted Ubuntu runners.
-      - name: Run Cypher integration tests against live Neo4j
-        run: npm run test:integration
+      # that is available on GitHub-hosted Ubuntu runners. Run under c8 so the
+      # resolver coverage these tests provide is reported too.
+      - name: Run integration tests against live Neo4j (with coverage)
+        run: npm run coverage:integration
+
+      # Uploaded under the `integration` flag; Codecov merges it with the unit
+      # upload so a line covered by either suite counts as covered.
+      - name: Upload integration coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: integration
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,17 @@ coverage:
         # every normal PR, so coverage is informational only for now.
         informational: true
 
+# Coverage is uploaded from two CI jobs under separate flags and merged by
+# Codecov: `unit` (fast `npm test`) and `integration` (Testcontainers Neo4j).
+# A line covered by either suite counts as covered for the project total.
+# carryforward keeps the last known coverage for a flag if a run doesn't upload
+# it (e.g. a flaky container run), so it doesn't spuriously drop the total.
+flags:
+  unit:
+    carryforward: true
+  integration:
+    carryforward: true
+
 # Comment settings for PR coverage reports
 comment:
   layout: "reach,diff,flags,files"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
     "test:integration": "node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
+    "coverage:integration": "c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "prepare": "husky install",
     "codegen": "graphql-codegen --config codegen.ts",
     "tsc": "tsc",


### PR DESCRIPTION
## Summary

Makes the integration-test coverage actually count toward the reported number. Until now the CI integration job ran the Testcontainers suite with **no coverage instrumentation**, so every resolver it exercises — image moderation, channel/issue/suspension, super-upvote, plugin-enable, download-labels — was tested but **invisible to Codecov** (those files still showed ~10%).

## Change
- New `coverage:integration` script: runs the integration suite under `c8` → `lcov`.
- CI: the integration job now runs `coverage:integration` and uploads its lcov under the **`integration`** flag; the unit upload is tagged **`unit`**.
- `codecov.yml`: declares both flags with `carryforward`. Codecov merges the two uploads — a line covered by **either** suite counts — and carryforward keeps the last known value if a flaky container run skips an upload.

No job restructuring or shared temp dir needed; Codecov does the merge.

## Expected impact
The integration suite already exercises ~3,000–3,500 statements (resolvers at ~80–90%) that currently count as ~0% in the report. Folding them in should move the **reported** project coverage from ~45% to roughly **54–55%** — entirely from tests already written, no new tests.

## Verification
Ran `c8` over one integration file locally; the produced `lcov.info` records the resolver it covers (e.g. `customResolvers/mutations/reportImage.ts` at 312/364 lines). The full integration lcov in CI will carry all such resolvers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
