### PR TITLE
fix: exclude feedback comments from sitewide discussion comment count

### DIFF
--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -61,6 +61,7 @@ UNWIND discussionChannels AS dc
 OPTIONAL MATCH (dc)-[:UPVOTED_DISCUSSION]->(upvoter:User)
 OPTIONAL MATCH (dc)<-[:SUPER_UPVOTED_DISCUSSION]-(superUpvoter:User)
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
+WHERE c.isFeedbackComment IS NULL OR c.isFeedbackComment = false
 WITH d, dc, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
 WITH d, COLLECT({dc: dc, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
 

--- a/ts_emitted/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/ts_emitted/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -60,6 +60,7 @@ WITH d, COLLECT(dc) AS discussionChannels, totalCount
 UNWIND discussionChannels AS dc
 OPTIONAL MATCH (dc)-[:UPVOTED_DISCUSSION]->(upvoter:User)
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
+WHERE c.isFeedbackComment IS NULL OR c.isFeedbackComment = false
 WITH d, dc, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
 WITH d, COLLECT({dc: dc, upvotedByUsers: upvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
 


### PR DESCRIPTION
## Problem

On the sitewide discussion list (and its right-pane preview), the comment count shown for a discussion was **inflated** compared to the discussion detail page. For example, a discussion with one real comment and one feedback comment showed **2 comments** in the list but **1 comment** on the detail page.

## Cause

`getSiteWideDiscussionsQuery.cypher` computes `commentsCount` by matching every comment contained by a discussion channel:

```cypher
OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
... COUNT(DISTINCT c) AS commentsCount ...
```

This includes **feedback comments** (`isFeedbackComment = true`), which the detail page excludes. The count is baked into the resolver result, so the GraphQL `where` filter on `CommentsAggregate` has no effect.

## Fix

Filter the `CONTAINS_COMMENT` match to non-feedback comments before counting:

```cypher
OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
WHERE c.isFeedbackComment IS NULL OR c.isFeedbackComment = false
```

This matches the filter the discussion detail page already uses (`isFeedbackComment` null or false), so list/preview counts are now consistent with the detail view.

## Verification

Against a discussion with one real comment + one feedback comment, the resolver now returns `commentsCount = 1` (was `2`), matching the detail page.

## Notes

- A sibling resolver (`getDiscussionChannelsQuery.cypher`, the per-forum discussion list) has the same overcounting pattern and is **not** included here — it's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)