### PR TITLE
refactor(services): testable version-history handlers + complete comment tracking

### DIFF
--- a/services/commentVersionHistoryService.ts
+++ b/services/commentVersionHistoryService.ts
@@ -1,6 +1,86 @@
 import { execute, parse, subscribe } from 'graphql';
+import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
+
+export interface CommentUpdatePayload {
+  id: string;
+  text?: string | null;
+}
+
+export interface CommentPreviousValues {
+  text?: string | null;
+}
+
+/**
+ * Look up the username of a comment's author. The author may be a User
+ * (username) or a ModerationProfile (displayName). Returns null if the comment
+ * or its author cannot be found.
+ */
+export const getCommentAuthorUsername = async (
+  ogm: OGMLike,
+  commentId: string
+): Promise<string | null> => {
+  const CommentModel = ogm.model('Comment');
+  const comments = await CommentModel.find({
+    where: { id: commentId },
+    selectionSet: `{
+      id
+      CommentAuthor {
+        ... on User { username }
+        ... on ModerationProfile { displayName }
+      }
+    }`,
+  });
+  if (!comments.length) {
+    return null;
+  }
+  const author = comments[0].CommentAuthor;
+  return author?.username || author?.displayName || null;
+};
+
+/**
+ * Track a comment's text change by saving the PREVIOUS text as a TextVersion
+ * connected to PastVersions (so the edit history preserves what was replaced).
+ */
+export const trackCommentTextVersion = (
+  ogm: OGMLike,
+  commentId: string,
+  previousText: string,
+  username: string
+): Promise<string | null> =>
+  trackTextVersion(ogm, {
+    body: previousText,
+    username,
+    parentModelName: 'Comment',
+    parentId: commentId,
+    relationshipField: 'PastVersions',
+  });
+
+/**
+ * Handle a single comment update event: resolve the author, then save the
+ * previous text as a version. Callable core of the subscription handler,
+ * extracted so it can be tested directly.
+ */
+export const handleCommentUpdateEvent = async (
+  ogm: OGMLike,
+  updatedComment: CommentUpdatePayload,
+  previousValues: CommentPreviousValues | null | undefined
+): Promise<void> => {
+  const previousText = previousValues?.text;
+  if (!previousText || previousText === updatedComment.text) {
+    // Nothing meaningful changed; no version to record.
+    return;
+  }
+
+  const username = await getCommentAuthorUsername(ogm, updatedComment.id);
+  if (!username) {
+    console.log('Could not determine username from comment author');
+    return;
+  }
+
+  await trackCommentTextVersion(ogm, updatedComment.id, previousText, username);
+};
 
 /**
  * Comment Version History Service that listens to Comment update events
@@ -95,41 +175,12 @@ export class CommentVersionHistoryService {
         }
 
         const updatedComment = result.data.commentUpdated.updatedComment;
-        const commentId = updatedComment.id;
-        
-        console.log('Processing version history for updated comment:', commentId);
+        const previousValues = result.data.commentUpdated.previousValues;
+
+        console.log('Processing version history for updated comment:', updatedComment.id);
 
         try {
-          // Fetch the updated comment's text directly from the database
-          const CommentModel = this.ogm.model('Comment');
-          const comments = await CommentModel.find({
-            where: { id: commentId },
-            selectionSet: `{
-              id
-              text
-              CommentAuthor {
-                ... on User {
-                  username
-                }
-                ... on ModerationProfile {
-                  displayName
-                }
-              }
-            }`
-          });
-
-          if (!comments.length) {
-            console.log('Comment not found in database');
-            continue;
-          }
-
-          const comment = comments[0];
-          const username = comment.CommentAuthor?.username || comment.CommentAuthor?.displayName;
-
-          if (!username) {
-            console.log('Could not determine username from comment author');
-            continue;
-          }
+          await handleCommentUpdateEvent(this.ogm, updatedComment, previousValues);
         } catch (error) {
           console.error('Error processing comment version history:', error);
           // Continue processing other events even if one fails
@@ -143,95 +194,6 @@ export class CommentVersionHistoryService {
         console.log('Restarting comment version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
-    }
-  }
-
-  /**
-   * Track text version history for a comment
-   */
-  private async trackTextVersionHistory(commentId: string, previousText: string, username: string) {
-    // Get the OGM models
-    const CommentModel = this.ogm.model('Comment');
-    const TextVersionModel = this.ogm.model('TextVersion');
-    const UserModel = this.ogm.model('User');
-
-    console.log(`Tracking text version history for comment ${commentId}`);
-
-    // Skip if previous text or username is missing
-    if (!previousText) {
-      console.log('Previous text is empty, skipping version history');
-      return;
-    }
-
-    if (!username) {
-      console.log('Username is missing, cannot track author of the change');
-      return;
-    }
-
-    try {
-      // Fetch the current comment to get current version data
-      const comments = await CommentModel.find({
-        where: { id: commentId },
-        selectionSet: `{
-          id
-          text
-          PastVersions {
-            id
-            body
-            createdAt
-          }
-        }`
-      });
-
-      if (!comments.length) {
-        console.log('Comment not found');
-        return;
-      }
-
-      const comment = comments[0];
-
-      // Get user by username
-      const users = await UserModel.find({
-        where: { username },
-        selectionSet: `{ username }`
-      });
-
-      if (!users.length) {
-        console.log(`User not found with username: ${username}`);
-        return;
-      }
-
-      // Create new TextVersion for previous text
-      // The createdAt timestamp will be automatically set by @timestamp directive
-      const textVersionResult = await TextVersionModel.create({
-        input: [{
-          body: previousText,
-          Author: {
-            connect: { where: { username } }
-          }
-        }]
-      });
-
-      if (!textVersionResult.textVersions.length) {
-        console.log('Failed to create TextVersion');
-        return;
-      }
-
-      const textVersionId = textVersionResult.textVersions[0].id;
-
-      await CommentModel.update({
-        where: { id: commentId },
-        update: {
-          PastVersions: {
-            connect: [{ where: { id: textVersionId } }]
-          },
-        }
-      });
-
-      console.log(`Successfully added text version history for comment ${commentId}`);
-    } catch (error) {
-      console.error('Error tracking text version history:', error);
-      throw error;
     }
   }
 

--- a/services/discussionVersionHistoryService.ts
+++ b/services/discussionVersionHistoryService.ts
@@ -1,6 +1,112 @@
 import { execute, parse, subscribe } from 'graphql';
+import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
+
+export interface DiscussionUpdatePayload {
+  id: string;
+  title?: string | null;
+  body?: string | null;
+}
+
+export interface DiscussionPreviousValues {
+  title?: string | null;
+  body?: string | null;
+}
+
+/**
+ * Look up the username of a discussion's current Author. Returns null if the
+ * discussion or its author cannot be found.
+ */
+export const getDiscussionAuthorUsername = async (
+  ogm: OGMLike,
+  discussionId: string
+): Promise<string | null> => {
+  try {
+    const DiscussionModel = ogm.model('Discussion');
+    const discussions = await DiscussionModel.find({
+      where: { id: discussionId },
+      selectionSet: `{ Author { username } }`,
+    });
+    if (!discussions.length || !discussions[0].Author?.username) {
+      return null;
+    }
+    return discussions[0].Author.username;
+  } catch (error) {
+    console.error('Error getting current user username:', error);
+    return null;
+  }
+};
+
+/**
+ * Track a discussion's title change by saving the new title as a TextVersion
+ * connected to PastTitleVersions.
+ */
+export const trackDiscussionTitleVersion = (
+  ogm: OGMLike,
+  discussionId: string,
+  newTitle: string,
+  username: string
+): Promise<string | null> =>
+  trackTextVersion(ogm, {
+    body: newTitle,
+    username,
+    parentModelName: 'Discussion',
+    parentId: discussionId,
+    relationshipField: 'PastTitleVersions',
+  });
+
+/**
+ * Track a discussion's body change by saving the new body as a TextVersion
+ * connected to PastBodyVersions.
+ */
+export const trackDiscussionBodyVersion = (
+  ogm: OGMLike,
+  discussionId: string,
+  newBody: string,
+  username: string
+): Promise<string | null> =>
+  trackTextVersion(ogm, {
+    body: newBody,
+    username,
+    parentModelName: 'Discussion',
+    parentId: discussionId,
+    relationshipField: 'PastBodyVersions',
+  });
+
+/**
+ * Handle a single discussion update event: resolve the author, then record a
+ * version for whichever of title/body actually changed. This is the callable
+ * core of the subscription handler, extracted so it can be tested directly.
+ */
+export const handleDiscussionUpdateEvent = async (
+  ogm: OGMLike,
+  updatedDiscussion: DiscussionUpdatePayload,
+  previousValues: DiscussionPreviousValues | null | undefined
+): Promise<void> => {
+  const discussionId = updatedDiscussion.id;
+  const currentUsername = await getDiscussionAuthorUsername(ogm, discussionId);
+  if (!currentUsername) {
+    console.log('Could not determine current user, skipping version history');
+    return;
+  }
+
+  if (
+    previousValues?.title &&
+    previousValues.title !== updatedDiscussion.title &&
+    updatedDiscussion.title
+  ) {
+    await trackDiscussionTitleVersion(ogm, discussionId, updatedDiscussion.title, currentUsername);
+  }
+
+  if (
+    previousValues?.body &&
+    previousValues.body !== updatedDiscussion.body &&
+    updatedDiscussion.body
+  ) {
+    await trackDiscussionBodyVersion(ogm, discussionId, updatedDiscussion.body, currentUsername);
+  }
+};
 
 /**
  * Discussion Version History Service that listens to Discussion update events
@@ -93,36 +199,11 @@ export class DiscussionVersionHistoryService {
 
         const updatedDiscussion = result.data.discussionUpdated.updatedDiscussion;
         const previousValues = result.data.discussionUpdated.previousValues;
-        const discussionId = updatedDiscussion.id;
-        
-        console.log('Processing version history for updated discussion:', discussionId);
+
+        console.log('Processing version history for updated discussion:', updatedDiscussion.id);
 
         try {
-          // Get the current user who made the update
-          const currentUsername = await this.getCurrentUserUsername(discussionId);
-          
-          if (!currentUsername) {
-            console.log('Could not determine current user, skipping version history');
-            continue;
-          }
-
-          // Check if title has changed - save the NEW title as a version
-          if (previousValues?.title && previousValues.title !== updatedDiscussion.title) {
-            await this.trackTitleVersionHistory(
-              discussionId, 
-              updatedDiscussion.title,
-              currentUsername
-            );
-          }
-
-          // Check if body has changed - save the NEW body as a version
-          if (previousValues?.body && previousValues.body !== updatedDiscussion.body) {
-            await this.trackBodyVersionHistory(
-              discussionId, 
-              updatedDiscussion.body,
-              currentUsername
-            );
-          }
+          await handleDiscussionUpdateEvent(this.ogm, updatedDiscussion, previousValues);
         } catch (error) {
           console.error('Error processing discussion version history:', error);
           // Continue processing other events even if one fails
@@ -136,151 +217,6 @@ export class DiscussionVersionHistoryService {
         console.log('Restarting discussion version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
-    }
-  }
-
-  /**
-   * Get the current user who made the update from the Discussion's Author
-   */
-  private async getCurrentUserUsername(discussionId: string): Promise<string | null> {
-    try {
-      const DiscussionModel = this.ogm.model('Discussion');
-      const discussions = await DiscussionModel.find({
-        where: { id: discussionId },
-        selectionSet: `{
-          Author {
-            username
-          }
-        }`
-      });
-
-      if (!discussions.length || !discussions[0].Author?.username) {
-        return null;
-      }
-
-      return discussions[0].Author.username;
-    } catch (error) {
-      console.error('Error getting current user username:', error);
-      return null;
-    }
-  }
-
-  /**
-   * Track title version history for a discussion
-   */
-  private async trackTitleVersionHistory(discussionId: string, newTitle: string, username: string) {
-    // Get the OGM models
-    const DiscussionModel = this.ogm.model('Discussion');
-    const TextVersionModel = this.ogm.model('TextVersion');
-    const UserModel = this.ogm.model('User');
-
-    console.log(`Tracking title version history for discussion ${discussionId} by user ${username}`);
-    console.log(`New title: "${newTitle}"`);
-
-    try {
-      // Skip tracking if content is null or empty
-      if (!newTitle) {
-        console.log('New title is empty, skipping version history');
-        return;
-      }
-
-      // Get user by username
-      const users = await UserModel.find({
-        where: { username },
-        selectionSet: `{ username }`
-      });
-
-      if (!users.length) {
-        console.log('User not found:', username);
-        return;
-      }
-
-      // Create new TextVersion for the new title
-      // The createdAt timestamp will be automatically set by @timestamp directive
-      const textVersionResult = await TextVersionModel.create({
-        input: [{
-          body: newTitle,
-          Author: {
-            connect: { where: { node: { username } } }
-          }
-        }]
-      });
-
-      if (!textVersionResult.textVersions.length) {
-        console.log('Failed to create TextVersion');
-        return;
-      }
-
-      const textVersionId = textVersionResult.textVersions[0].id;
-
-      console.log(`Successfully added title version history for discussion ${discussionId}`);
-    } catch (error) {
-      console.error('Error tracking title version history:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Track body version history for a discussion
-   */
-  private async trackBodyVersionHistory(discussionId: string, newBody: string, username: string) {
-    // Get the OGM models
-    const DiscussionModel = this.ogm.model('Discussion');
-    const TextVersionModel = this.ogm.model('TextVersion');
-    const UserModel = this.ogm.model('User');
-
-    console.log(`Tracking body version history for discussion ${discussionId} by user ${username}`);
-
-    try {
-      // Skip tracking if content is null or empty
-      if (!newBody) {
-        console.log('New body is empty, skipping version history');
-        return;
-      }
-
-      // Get user by username
-      const users = await UserModel.find({
-        where: { username },
-        selectionSet: `{ username }`
-      });
-
-      if (!users.length) {
-        console.log('User not found:', username);
-        return;
-      }
-
-      // Create new TextVersion for the new body
-      // The createdAt timestamp will be automatically set by @timestamp directive
-      const textVersionResult = await TextVersionModel.create({
-        input: [{
-          body: newBody,
-          Author: {
-            connect: { where: { node: { username } } }
-          }
-        }]
-      });
-
-      if (!textVersionResult.textVersions.length) {
-        console.log('Failed to create TextVersion');
-        return;
-      }
-
-      const textVersionId = textVersionResult.textVersions[0].id;
-
-
-      await DiscussionModel.update({
-        where: { id: discussionId },
-        update: {
-          PastBodyVersions: {
-            connect: [{ where: { id: textVersionId } }]
-          },
-        }
-      });
-
-      console.log(`Successfully added body version history for discussion ${discussionId}`);
-    } catch (error) {
-      console.error('Error tracking body version history:', error);
-      throw error;
     }
   }
 

--- a/services/textVersionHistory.ts
+++ b/services/textVersionHistory.ts
@@ -1,0 +1,106 @@
+// Shared helpers for the version-history services (discussion / comment /
+// wikiPage). Creating a TextVersion authored by a user and connecting it to a
+// parent node is identical across all three; only the parent model and the
+// relationship field differ. These functions take the OGM directly so they can
+// be unit-tested against a live database without standing up a subscription.
+
+export interface OGMLike {
+  model(name: string): any;
+}
+
+export interface CreateTextVersionInput {
+  body: string;
+  username: string;
+  editReason?: string | null;
+}
+
+/**
+ * Create a TextVersion (body + optional editReason) authored by `username`.
+ * Returns the new TextVersion id, or null if the body is empty or the user
+ * does not exist (the caller treats null as "nothing to track").
+ */
+export const createAuthoredTextVersion = async (
+  ogm: OGMLike,
+  { body, username, editReason }: CreateTextVersionInput
+): Promise<string | null> => {
+  if (!body) {
+    return null;
+  }
+  if (!username) {
+    return null;
+  }
+
+  const UserModel = ogm.model("User");
+  const users = await UserModel.find({
+    where: { username },
+    selectionSet: `{ username }`,
+  });
+  if (!users.length) {
+    return null;
+  }
+
+  const TextVersionModel = ogm.model("TextVersion");
+  const input: { body: string; editReason?: string; Author: any } = {
+    body,
+    Author: {
+      connect: { where: { node: { username } } },
+    },
+  };
+  if (editReason) {
+    input.editReason = editReason;
+  }
+
+  const result = await TextVersionModel.create({ input: [input] });
+  return result.textVersions[0]?.id ?? null;
+};
+
+/**
+ * Connect an existing TextVersion to a parent node's relationship field
+ * (e.g. Discussion.PastBodyVersions, Comment.PastVersions).
+ */
+export const connectTextVersionToParent = async (
+  ogm: OGMLike,
+  params: {
+    parentModelName: string;
+    parentId: string;
+    relationshipField: string;
+    textVersionId: string;
+  }
+): Promise<void> => {
+  const { parentModelName, parentId, relationshipField, textVersionId } = params;
+  const ParentModel = ogm.model(parentModelName);
+  await ParentModel.update({
+    where: { id: parentId },
+    update: {
+      [relationshipField]: {
+        connect: [{ where: { node: { id: textVersionId } } }],
+      },
+    },
+  });
+};
+
+/**
+ * Create an authored TextVersion and connect it to a parent in one step.
+ * Returns the TextVersion id, or null if nothing was created.
+ */
+export const trackTextVersion = async (
+  ogm: OGMLike,
+  params: CreateTextVersionInput & {
+    parentModelName: string;
+    parentId: string;
+    relationshipField: string;
+  }
+): Promise<string | null> => {
+  const { parentModelName, parentId, relationshipField, ...versionInput } = params;
+  const textVersionId = await createAuthoredTextVersion(ogm, versionInput);
+  if (!textVersionId) {
+    return null;
+  }
+  await connectTextVersionToParent(ogm, {
+    parentModelName,
+    parentId,
+    relationshipField,
+    textVersionId,
+  });
+  return textVersionId;
+};

--- a/services/wikiPageVersionHistoryService.ts
+++ b/services/wikiPageVersionHistoryService.ts
@@ -1,7 +1,109 @@
 import { execute, parse, subscribe } from 'graphql';
-import type { TextVersionCreateInput } from "../src/generated/graphql.js";
+import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
+
+export interface WikiPageUpdatePayload {
+  id: string;
+  title?: string | null;
+  body?: string | null;
+  editReason?: string | null;
+}
+
+export interface WikiPagePreviousState {
+  title?: string | null;
+  body?: string | null;
+}
+
+/**
+ * Look up the username of a wikiPage's current VersionAuthor. Returns null if
+ * the wikiPage or its version author cannot be found.
+ */
+export const getWikiPageVersionAuthorUsername = async (
+  ogm: OGMLike,
+  wikiPageId: string
+): Promise<string | null> => {
+  try {
+    const WikiPageModel = ogm.model('WikiPage');
+    const wikiPages = await WikiPageModel.find({
+      where: { id: wikiPageId },
+      selectionSet: `{ VersionAuthor { username } }`,
+    });
+    if (!wikiPages.length || !wikiPages[0].VersionAuthor?.username) {
+      return null;
+    }
+    return wikiPages[0].VersionAuthor.username;
+  } catch (error) {
+    console.error('Error getting current user username:', error);
+    return null;
+  }
+};
+
+/**
+ * Track a wikiPage version by saving the given content as a TextVersion
+ * (with optional editReason) connected to PastVersions.
+ */
+export const trackWikiPageVersion = (
+  ogm: OGMLike,
+  wikiPageId: string,
+  content: string,
+  editReason: string | null | undefined,
+  username: string
+): Promise<string | null> =>
+  trackTextVersion(ogm, {
+    body: content,
+    editReason,
+    username,
+    parentModelName: 'WikiPage',
+    parentId: wikiPageId,
+    relationshipField: 'PastVersions',
+  });
+
+/**
+ * Handle a single wikiPage update event: resolve the version author, then
+ * record a version for whichever of title/body actually changed. Callable core
+ * of the subscription handler, extracted so it can be tested directly.
+ */
+export const handleWikiPageUpdateEvent = async (
+  ogm: OGMLike,
+  updatedWikiPage: WikiPageUpdatePayload,
+  previousState: WikiPagePreviousState | null | undefined
+): Promise<void> => {
+  const wikiPageId = updatedWikiPage.id;
+  const currentUsername = await getWikiPageVersionAuthorUsername(ogm, wikiPageId);
+  if (!currentUsername) {
+    console.log('Could not determine current user, skipping version history');
+    return;
+  }
+
+  if (
+    previousState?.title &&
+    previousState.title !== updatedWikiPage.title &&
+    updatedWikiPage.title
+  ) {
+    await trackWikiPageVersion(
+      ogm,
+      wikiPageId,
+      updatedWikiPage.title,
+      updatedWikiPage.editReason,
+      currentUsername
+    );
+  }
+
+  if (
+    previousState?.body &&
+    previousState.body !== updatedWikiPage.body &&
+    updatedWikiPage.body
+  ) {
+    await trackWikiPageVersion(
+      ogm,
+      wikiPageId,
+      updatedWikiPage.body,
+      updatedWikiPage.editReason,
+      currentUsername
+    );
+  }
+};
 
 /**
  * WikiPage Version History Service that listens to WikiPage update events
@@ -94,38 +196,11 @@ export class WikiPageVersionHistoryService {
 
         const updatedWikiPage = result.data.wikiPageUpdated.updatedWikiPage;
         const previousState = result.data.wikiPageUpdated.previousState;
-        const wikiPageId = updatedWikiPage.id;
-        
-        console.log('Processing version history for updated wikiPage:', wikiPageId);
+
+        console.log('Processing version history for updated wikiPage:', updatedWikiPage.id);
 
         try {
-          // Get the current user who made the update from the WikiPage's VersionAuthor
-          const currentUsername = await this.getCurrentUserUsername(wikiPageId);
-          
-          if (!currentUsername) {
-            console.log('Could not determine current user, skipping version history');
-            continue;
-          }
-
-          // Check if title has changed - save the NEW title as a version
-          if (previousState?.title && previousState.title !== updatedWikiPage.title) {
-            await this.trackVersionHistory(
-              wikiPageId, 
-              updatedWikiPage.title,
-              updatedWikiPage.editReason,
-              currentUsername
-            );
-          }
-
-          // Check if body has changed - save the NEW body as a version
-          if (previousState?.body && previousState.body !== updatedWikiPage.body) {
-            await this.trackVersionHistory(
-              wikiPageId, 
-              updatedWikiPage.body,
-              updatedWikiPage.editReason,
-              currentUsername
-            );
-          }
+          await handleWikiPageUpdateEvent(this.ogm, updatedWikiPage, previousState);
         } catch (error) {
           console.error('Error processing wikiPage version history:', error);
           // Continue processing other events even if one fails
@@ -139,112 +214,6 @@ export class WikiPageVersionHistoryService {
         console.log('Restarting wikiPage version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
-    }
-  }
-
-  /**
-   * Get the current user who made the update from the WikiPage's VersionAuthor
-   */
-  private async getCurrentUserUsername(wikiPageId: string): Promise<string | null> {
-    try {
-      const WikiPageModel = this.ogm.model('WikiPage');
-      const wikiPages = await WikiPageModel.find({
-        where: { id: wikiPageId },
-        selectionSet: `{
-          VersionAuthor {
-            username
-          }
-        }`
-      });
-
-      if (!wikiPages.length || !wikiPages[0].VersionAuthor?.username) {
-        return null;
-      }
-
-      return wikiPages[0].VersionAuthor.username;
-    } catch (error) {
-      console.error('Error getting current user username:', error);
-      return null;
-    }
-  }
-
-
-  /**
-   * Track version history for a wikiPage
-   */
-  private async trackVersionHistory(
-    wikiPageId: string,
-    content: string,
-    editReason: string | null | undefined,
-    username: string
-  ) {
-    // Get the OGM models
-    const WikiPageModel = this.ogm.model('WikiPage');
-    const TextVersionModel = this.ogm.model('TextVersion');
-    const UserModel = this.ogm.model('User');
-
-    console.log(`Tracking version history for wikiPage ${wikiPageId} by user ${username}`);
-
-    try {
-      // Skip tracking if content is null or empty
-      if (!content) {
-        console.log('Content is empty, skipping version history');
-        return;
-      }
-
-      // Get user by username
-      const users = await UserModel.find({
-        where: { username },
-        selectionSet: `{ username }`
-      });
-
-      if (!users.length) {
-        console.log('User not found:', username);
-        return;
-      }
-
-      // Create new TextVersion for the new content
-      // The createdAt timestamp will be automatically set by @timestamp directive
-      const textVersionInput: TextVersionCreateInput = {
-        body: content,
-        Author: {
-          connect: { where: { node: { username } } }
-        }
-      };
-
-      if (editReason) {
-        textVersionInput.editReason = editReason;
-      }
-
-      const textVersionResult = await TextVersionModel.create({
-        input: [textVersionInput]
-      });
-
-      if (!textVersionResult.textVersions.length) {
-        console.log('Failed to create TextVersion');
-        return;
-      }
-
-      const textVersionId = textVersionResult.textVersions[0].id;
-
-      // Update wikiPage to connect the new TextVersion
-      await WikiPageModel.update({
-        where: { id: wikiPageId },
-        update: {
-          PastVersions: {
-            connect: [{ 
-              where: { 
-                node: { id: textVersionId } 
-              } 
-            }]
-          }
-        }
-      });
-
-      console.log(`Successfully added version history for wikiPage ${wikiPageId}`);
-    } catch (error) {
-      console.error('Error tracking version history:', error);
-      throw error;
     }
   }
 

--- a/tests/integration/versionHistoryServices.test.ts
+++ b/tests/integration/versionHistoryServices.test.ts
@@ -1,0 +1,180 @@
+// Integration tests for the version-history services' callable handlers,
+// extracted from the subscription machinery so they can be exercised directly
+// against a live Neo4j container. Covers discussion, comment (newly completed),
+// and wikiPage version tracking plus the shared TextVersion helper.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleDiscussionUpdateEvent } from "../../services/discussionVersionHistoryService.js";
+import { handleCommentUpdateEvent } from "../../services/commentVersionHistoryService.js";
+import { handleWikiPageUpdateEvent } from "../../services/wikiPageVersionHistoryService.js";
+import { createAuthoredTextVersion } from "../../services/textVersionHistory.js";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+// --- Discussion version history ---
+
+test("handleDiscussionUpdateEvent records title and body versions authored by the discussion author", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice' })
+     CREATE (d:Discussion { id: 'd1', title: 'New Title', body: 'New body', createdAt: datetime() })
+     CREATE (alice)-[:POSTED_DISCUSSION]->(d)`
+  );
+
+  await handleDiscussionUpdateEvent(
+    env.ogm,
+    { id: "d1", title: "New Title", body: "New body" },
+    { title: "Old Title", body: "Old body" }
+  );
+
+  const titleV = await run(
+    `MATCH (:Discussion { id: 'd1' })-[:HAS_TITLE_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, u.username AS author`
+  );
+  assert.equal(titleV.length, 1, "a title version should be recorded");
+  assert.equal(titleV[0].body, "New Title");
+  assert.equal(titleV[0].author, "alice");
+
+  const bodyV = await run(
+    `MATCH (:Discussion { id: 'd1' })-[:HAS_BODY_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, u.username AS author`
+  );
+  assert.equal(bodyV.length, 1, "a body version should be recorded");
+  assert.equal(bodyV[0].body, "New body");
+  assert.equal(bodyV[0].author, "alice");
+});
+
+test("handleDiscussionUpdateEvent records nothing when title and body are unchanged", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice' })
+     CREATE (d:Discussion { id: 'd1', title: 'Same', body: 'Same body', createdAt: datetime() })
+     CREATE (alice)-[:POSTED_DISCUSSION]->(d)`
+  );
+
+  await handleDiscussionUpdateEvent(
+    env.ogm,
+    { id: "d1", title: "Same", body: "Same body" },
+    { title: "Same", body: "Same body" }
+  );
+
+  const versions = await run(`MATCH (tv:TextVersion) RETURN count(tv) AS n`);
+  assert.equal(Number(versions[0].n), 0, "no version should be recorded for an unchanged update");
+});
+
+test("handleDiscussionUpdateEvent skips tracking when the discussion has no author", async () => {
+  await run(`CREATE (:Discussion { id: 'd1', title: 'New Title', body: 'New body', createdAt: datetime() })`);
+
+  await handleDiscussionUpdateEvent(
+    env.ogm,
+    { id: "d1", title: "New Title", body: "New body" },
+    { title: "Old Title", body: "Old body" }
+  );
+
+  const versions = await run(`MATCH (tv:TextVersion) RETURN count(tv) AS n`);
+  assert.equal(Number(versions[0].n), 0, "no version when the author cannot be resolved");
+});
+
+// --- Comment version history (newly completed: previously never tracked) ---
+
+test("handleCommentUpdateEvent saves the previous text as a version authored by the comment author", async () => {
+  await run(
+    `CREATE (bob:User { username: 'bob' })
+     CREATE (c:Comment { id: 'c1', text: 'New text', isRootComment: true, createdAt: datetime() })
+     CREATE (bob)-[:AUTHORED_COMMENT]->(c)`
+  );
+
+  await handleCommentUpdateEvent(
+    env.ogm,
+    { id: "c1", text: "New text" },
+    { text: "Old text" }
+  );
+
+  const versions = await run(
+    `MATCH (:Comment { id: 'c1' })-[:HAS_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, u.username AS author`
+  );
+  assert.equal(versions.length, 1, "a version with the previous text should be recorded");
+  assert.equal(versions[0].body, "Old text", "the PREVIOUS text is preserved as history");
+  assert.equal(versions[0].author, "bob");
+});
+
+test("handleCommentUpdateEvent records nothing when text is unchanged", async () => {
+  await run(
+    `CREATE (bob:User { username: 'bob' })
+     CREATE (c:Comment { id: 'c1', text: 'Same', isRootComment: true, createdAt: datetime() })
+     CREATE (bob)-[:AUTHORED_COMMENT]->(c)`
+  );
+
+  await handleCommentUpdateEvent(env.ogm, { id: "c1", text: "Same" }, { text: "Same" });
+
+  const versions = await run(`MATCH (tv:TextVersion) RETURN count(tv) AS n`);
+  assert.equal(Number(versions[0].n), 0);
+});
+
+// --- WikiPage version history ---
+
+test("handleWikiPageUpdateEvent records title and body versions (with edit reason) for the version author", async () => {
+  await run(
+    `CREATE (carol:User { username: 'carol' })
+     CREATE (w:WikiPage { id: 'w1', title: 'New Title', body: 'New body', slug: 'page', createdAt: datetime() })
+     CREATE (carol)-[:AUTHORED_VERSION]->(w)`
+  );
+
+  await handleWikiPageUpdateEvent(
+    env.ogm,
+    { id: "w1", title: "New Title", body: "New body", editReason: "fixed typo" },
+    { title: "Old Title", body: "Old body" }
+  );
+
+  const versions = await run(
+    `MATCH (:WikiPage { id: 'w1' })-[:HAS_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, tv.editReason AS editReason, u.username AS author ORDER BY tv.body`
+  );
+  assert.equal(versions.length, 2, "title and body versions should both be recorded");
+  assert.deepEqual(
+    versions.map((v: any) => v.body).sort(),
+    ["New Title", "New body"].sort()
+  );
+  for (const v of versions) {
+    assert.equal(v.author, "carol");
+    assert.equal(v.editReason, "fixed typo");
+  }
+});
+
+// --- Shared helper ---
+
+test("createAuthoredTextVersion returns null when the author user does not exist", async () => {
+  const id = await createAuthoredTextVersion(env.ogm, {
+    body: "orphan",
+    username: "nobody",
+  });
+  assert.equal(id, null);
+
+  const versions = await run(`MATCH (tv:TextVersion) RETURN count(tv) AS n`);
+  assert.equal(Number(versions[0].n), 0, "no TextVersion should be created for a missing user");
+});
+
+test("createAuthoredTextVersion returns null for empty body", async () => {
+  await run(`CREATE (:User { username: 'dave' })`);
+  const id = await createAuthoredTextVersion(env.ogm, { body: "", username: "dave" });
+  assert.equal(id, null);
+});


### PR DESCRIPTION
## Summary

The discussion / comment / wikiPage version-history services kept all their tracking logic in **private methods reachable only through `start()` → GraphQL `subscribe()`**, so none of it was directly testable (this was the deferred item from #41). This PR extracts the per-event logic into exported, OGM-taking functions and has each class delegate to them. The subscription wiring (`start`/`stop`/restart-on-error) is unchanged.

A shared `services/textVersionHistory.ts` factors out the common "create an authored `TextVersion` and connect it to a parent" step, using the correct neo4j-graphql v5 `where: { node: { id } }` connect form.

## Bugs fixed along the way

- **`commentVersionHistoryService` never tracked anything.** `processCommentUpdateEvents` fetched the comment and its author but **never called `trackTextVersionHistory`** — comment edit history was silently dropped. It now saves the previous text as a `PastVersion`. (This is the "complete the service" part of the task.)
- **Discussion title tracking created orphan versions.** The title path created a `TextVersion` but never connected it to `PastTitleVersions`; it now connects.
- **Broken connect forms.** discussion/comment used `where: { id }` / `where: { username }` (missing the `node` wrapper) which the live driver rejects. Standardized on the working wikiPage form. Confirmed empirically against the container.

## Tests

`tests/integration/versionHistoryServices.test.ts` — 8 tests against a live Neo4j container:
- discussion: records title + body versions for the author; no-op when unchanged; skips when author unresolved
- comment: saves the **previous** text as a version (proves the completed tracking runs); no-op when unchanged
- wikiPage: records title + body versions with edit reason
- shared helper: null when the author user is missing / body is empty

All 565 unit tests + the new 8 integration tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)