### PR TITLE
test(integration): share one Neo4j container across files (~3x faster)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "test": "node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
-    "test:integration": "node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "test:integration": "TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
-    "coverage:integration": "c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "prepare": "husky install",
     "codegen": "node --loader ts-node/esm build_scripts/generateTypes.ts",
     "tsc": "tsc",

--- a/tests/integration/imageModerationHarness.ts
+++ b/tests/integration/imageModerationHarness.ts
@@ -19,6 +19,10 @@ import getCustomResolvers from "../../customResolvers.js";
 let container: StartedNeo4jContainer | undefined;
 let driver: Driver | undefined;
 
+// See neo4jHarness.ts: when TESTCONTAINERS_REUSE_ENABLE=true, all integration
+// files share one Neo4j container instead of each starting its own (~30-40s).
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
+
 export interface ImageModEnv {
   driver: Driver;
   ogm: any;
@@ -26,7 +30,9 @@ export interface ImageModEnv {
 }
 
 export async function startImageModEnv(): Promise<ImageModEnv> {
-  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  let builder = new Neo4jContainer("neo4j:5-community").withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   process.env.NEO4J_URI = container.getBoltUri();
   process.env.NEO4J_USER = container.getUsername();
   process.env.NEO4J_PASSWORD = container.getPassword();
@@ -45,7 +51,8 @@ export async function startImageModEnv(): Promise<ImageModEnv> {
 
 export async function stopImageModEnv(): Promise<void> {
   await driver?.close();
-  await container?.stop();
+  // With reuse the container is shared — never stop it here (see neo4jHarness).
+  if (!REUSE) await container?.stop();
   driver = undefined;
   container = undefined;
 }

--- a/tests/integration/neo4jHarness.ts
+++ b/tests/integration/neo4jHarness.ts
@@ -18,10 +18,19 @@ const NEO4J_IMAGE = process.env.NEO4J_TEST_IMAGE || "neo4j:5-community";
 let container: StartedNeo4jContainer | undefined;
 let driver: Driver | undefined;
 
+// When TESTCONTAINERS_REUSE_ENABLE=true, every integration test file shares a
+// single Neo4j container (identical config => same reuse hash) instead of each
+// starting its own. A Neo4j+APOC start is ~30-40s; with ~26 files that's the
+// bulk of the suite's wall time. Tests run serially and reset the graph in
+// beforeEach, so sharing one container is safe.
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
+
 export async function startNeo4j(): Promise<Driver> {
   // Enable APOC — the app's OGM-generated queries (e.g. suspension date
   // formatting) depend on apoc.* procedures.
-  container = await new Neo4jContainer(NEO4J_IMAGE).withApoc().start();
+  let builder = new Neo4jContainer(NEO4J_IMAGE).withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   driver = neo4j.driver(
     container.getBoltUri(),
     neo4j.auth.basic(container.getUsername(), container.getPassword())
@@ -33,7 +42,10 @@ export async function startNeo4j(): Promise<Driver> {
 
 export async function stopNeo4j(): Promise<void> {
   await driver?.close();
-  await container?.stop();
+  // With reuse, the container is shared across files — never stop it here, or
+  // the first file to finish would tear it down for the others. It is left
+  // running (Ryuk skips reusable containers); CI reaps it with the runner.
+  if (!REUSE) await container?.stop();
   driver = undefined;
   container = undefined;
 }


### PR DESCRIPTION
## Problem

The integration suite takes **~30 min** in CI. Profiling showed the cost is **container churn**, not the tests: each of the ~26 integration test files spins up and tears down its **own** Neo4j+APOC container in `before`/`after`. A single cold start measures **~40s**, and teardown is costly too.

## Change

Enable **Testcontainers reuse** so all integration files share **one** Neo4j container:
- Both harnesses (`neo4jHarness.ts`, `imageModerationHarness.ts`) call `.withReuse()` and skip `container.stop()` when reuse is on (the first file to finish would otherwise tear it down for the rest).
- Enabled via `TESTCONTAINERS_REUSE_ENABLE=true` on the `test:integration` and `coverage:integration` scripts.

Identical container config ⇒ same reuse hash ⇒ the first file pays the cold start, the rest attach in ~0s.

**Safe because:** integration tests run serially (`--test-concurrency=1`) and reset the graph in `beforeEach`. The behavior is gated on the env var, so the default path (one container per file, stopped in `after`) is unchanged for anyone running without it.

## Measured impact

Verified locally that reuse returns the *same* container in ~0s, and timed end-to-end on 2 files:

| | 2 files |
|---|---|
| Before (own container each) | **236s** |
| After (shared container) | **80s** — ~3× |

Across all 26 files this should take the integration job from **~30 min → roughly ~10 min**.

**Local bonus:** the container now persists *between* `npm run test:integration` runs, so repeat local runs skip the cold start entirely (`docker rm -f` to clear it).

## Notes
- No production code touched — test harness + npm scripts only.
- CI's `coverage:integration` script carries the env var, so the workflow picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)