### PR TITLE
Structured logging: replace console.* with a leveled logger

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Generate GraphQL/OGM types
         run: npm run codegen
 
+      - name: Lint (enforces no console.* in runtime code)
+        run: npm run lint
+
       - name: Run TypeScript type checking
         run: npm run tsc
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run lint
 npm run tsc
 npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run lint
 npm run tsc
 npm test

--- a/customResolvers/mutations/acceptForumModInvite.ts
+++ b/customResolvers/mutations/acceptForumModInvite.ts
@@ -6,6 +6,7 @@ import type {
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   channelUniqueName: string;
@@ -120,7 +121,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/acceptForumOwnerInvite.ts
+++ b/customResolvers/mutations/acceptForumOwnerInvite.ts
@@ -5,6 +5,7 @@ import type {
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { logger } from "../../logger.js";
 type Args = {
   channelUniqueName: string;
 };
@@ -102,7 +103,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/acceptServerAdminInvite.ts
+++ b/customResolvers/mutations/acceptServerAdminInvite.ts
@@ -6,6 +6,7 @@ import type {
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   serverName: string;
@@ -109,7 +110,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/acceptServerModInvite.ts
+++ b/customResolvers/mutations/acceptServerModInvite.ts
@@ -7,6 +7,7 @@ import type {
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   serverName: string;
@@ -127,7 +128,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/addEmojiToComment.ts
+++ b/customResolvers/mutations/addEmojiToComment.ts
@@ -3,6 +3,7 @@ import { assertCommentEmojiEnabled } from "./channelPreferenceGuards.js";
 import type { CommentModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   commentId: string;
@@ -48,7 +49,7 @@ const getResolver = (input: Input) => {
         emoji: updatedEmojiJSON,
       };
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       throw e;
     }
   };

--- a/customResolvers/mutations/addEmojiToDiscussionChannel.ts
+++ b/customResolvers/mutations/addEmojiToDiscussionChannel.ts
@@ -3,6 +3,7 @@ import { assertDiscussionChannelEmojiEnabled } from "./channelPreferenceGuards.j
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionChannelId: string;
@@ -51,7 +52,7 @@ const getResolver = (input: Input) => {
         emoji: updatedEmojiJSON,
       };
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       throw e;
     }
   };

--- a/customResolvers/mutations/archiveComment.ts
+++ b/customResolvers/mutations/archiveComment.ts
@@ -23,6 +23,7 @@ import {
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
 import { notifyArchivedContentAuthor } from "../../hooks/archivedContentNotificationHook.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   commentId: string;
@@ -272,7 +273,7 @@ const getResolver = (input: Input) => {
         existingIssue = issueData.issues[0];
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error("Error creating issue for archiveComment:", errorMessage, error);
+        logger.error("Error creating issue for archiveComment:", errorMessage, error);
         throw new GraphQLError(`Failed to create issue for archived comment: ${errorMessage}`);
       }
     }

--- a/customResolvers/mutations/archiveDiscussion.ts
+++ b/customResolvers/mutations/archiveDiscussion.ts
@@ -23,6 +23,7 @@ import {
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
 import { notifyArchivedContentAuthor } from "../../hooks/archivedContentNotificationHook.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionId: string;
@@ -288,7 +289,7 @@ const getResolver = (input: Input) => {
       return existingIssue;
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error("Error updating discussionChannel for archiveDiscussion:", errorMessage, error);
+      logger.error("Error updating discussionChannel for archiveDiscussion:", errorMessage, error);
       throw new GraphQLError(`Failed to update discussion channel: ${errorMessage}`);
     }
   };

--- a/customResolvers/mutations/archiveEvent.ts
+++ b/customResolvers/mutations/archiveEvent.ts
@@ -22,6 +22,7 @@ import {
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
 import { notifyArchivedContentAuthor } from "../../hooks/archivedContentNotificationHook.js";
+import { logger } from "../../logger.js";
 import {
   checkChannelModPermissions,
   ModChannelPermission,
@@ -300,7 +301,7 @@ const getResolver = (input: Input) => {
       return existingIssue;
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error("Error updating eventChannel for archiveEvent:", errorMessage, error);
+      logger.error("Error updating eventChannel for archiveEvent:", errorMessage, error);
       throw new GraphQLError(`Failed to update event channel: ${errorMessage}`);
     }
   };

--- a/customResolvers/mutations/archiveImage.ts
+++ b/customResolvers/mutations/archiveImage.ts
@@ -18,6 +18,7 @@ import getNextIssueNumber from "./utils/getNextIssueNumber.js";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
 import { notifyArchivedContentAuthor } from "../../hooks/archivedContentNotificationHook.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   imageId: string;
@@ -301,7 +302,7 @@ const getResolver = (input: Input) => {
         existingIssueId = issueId;
         existingIssue = createResult.issues[0];
       } catch (error) {
-        console.error("Error creating image archive issue:", error);
+        logger.error("Error creating image archive issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -400,7 +401,7 @@ const getResolver = (input: Input) => {
         commentText: finalCommentText,
       });
     } catch (error) {
-      console.error("Error updating issue:", error);
+      logger.error("Error updating issue:", error);
       throw new GraphQLError("Error updating issue");
     }
 
@@ -458,7 +459,7 @@ const getResolver = (input: Input) => {
 
       return existingIssue;
     } catch (error) {
-      console.error("Error updating image:", error);
+      logger.error("Error updating image:", error);
       throw new GraphQLError("Error updating image");
     }
   };

--- a/customResolvers/mutations/becomeForumAdmin.ts
+++ b/customResolvers/mutations/becomeForumAdmin.ts
@@ -6,6 +6,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { channelHasZeroAdmins } from "../../rules/permission/channelHasZeroAdmins.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   channelUniqueName: string;
@@ -99,7 +100,7 @@ const getResolver = (input: Input) => {
 
       return true;
     } catch (e) {
-      console.error("Error in becomeForumAdmin:", e);
+      logger.error("Error in becomeForumAdmin:", e);
       throw new Error("Failed to become forum admin");
     }
   };

--- a/customResolvers/mutations/cancelInviteForumMod.ts
+++ b/customResolvers/mutations/cancelInviteForumMod.ts
@@ -1,6 +1,7 @@
 import type { ChannelUpdateInput, ChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -50,7 +51,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/cancelInviteForumOwner.ts
+++ b/customResolvers/mutations/cancelInviteForumOwner.ts
@@ -1,6 +1,7 @@
 import type { ChannelUpdateInput, ChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -48,7 +49,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error("Error updating channel:", e);
+      logger.error("Error updating channel:", e);
       return false;
     }    
   };

--- a/customResolvers/mutations/cancelInviteServerAdmin.ts
+++ b/customResolvers/mutations/cancelInviteServerAdmin.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../logger.js";
 import type {
   ServerConfigUpdateInput,
   ServerConfigModel,
@@ -51,7 +52,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/cancelInviteServerMod.ts
+++ b/customResolvers/mutations/cancelInviteServerMod.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../logger.js";
 import type {
   ServerConfigUpdateInput,
   ServerConfigModel,
@@ -51,7 +52,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/createAlbumsWithOwner.ts
+++ b/customResolvers/mutations/createAlbumsWithOwner.ts
@@ -3,6 +3,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { sanitizeAlbumCreateInput } from "./utils/ownershipSanitizers.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { AlbumCreateInput, AlbumModel, UserModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   input: AlbumCreateInput[];
@@ -71,7 +72,7 @@ const getResolver = (input: Input) => {
 
       return response;
     } catch (error: unknown) {
-      console.error("Error creating albums:", error);
+      logger.error("Error creating albums:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new GraphQLError(`Failed to create albums: ${message}`);
     }

--- a/customResolvers/mutations/createDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.ts
@@ -7,6 +7,7 @@ import { GraphQLError } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { sanitizeAlbumCreateNode } from "./utils/ownershipSanitizers.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 import type {
   DiscussionModel,
   ChannelModel,
@@ -207,13 +208,13 @@ export const createDiscussionsFromInput = async (
             } catch (pipelineError: unknown) {
               // Log pipeline errors but don't fail the discussion creation
               const message = pipelineError instanceof Error ? pipelineError.message : String(pipelineError);
-              console.error(`Channel pipeline error for ${channelUniqueName}:`, message);
+              logger.error(`Channel pipeline error for ${channelUniqueName}:`, message);
             }
           }
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : String(error);
           if (message.includes("Constraint validation failed")) {
-            console.warn(`Skipping duplicate DiscussionChannel: ${channelUniqueName}`);
+            logger.warn(`Skipping duplicate DiscussionChannel: ${channelUniqueName}`);
             continue;
           } else {
             throw error;
@@ -232,7 +233,7 @@ export const createDiscussionsFromInput = async (
       discussions.push(fetchedDiscussion[0]);
     }
   } catch (error: unknown) {
-    console.error("Error creating discussions:", error);
+    logger.error("Error creating discussions:", error);
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to create discussions: ${message}`);
   } finally {
@@ -267,7 +268,7 @@ const getResolver = (input: Input) => {
       );
       return discussions;
     } catch (error: unknown) {
-      console.error(error);
+      logger.error(error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`An error occurred while creating discussions: ${message}`);
     }

--- a/customResolvers/mutations/createEmailAndUser.ts
+++ b/customResolvers/mutations/createEmailAndUser.ts
@@ -3,6 +3,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
 import { generateSlug } from "random-word-slugs";
 import { validateUserInput } from "../../rules/validation/userIsValid.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   emailAddress: string;
@@ -141,7 +142,7 @@ const getCreateEmailAndUserResolver = (input: Input) => {
       const newUser = await createUsersWithEmails(User, Email, emailAddress, username);
       return newUser;
     } catch (e: unknown) {
-      console.error(e);
+      logger.error(e);
       const message = e instanceof Error ? e.message : String(e);
       throw new Error(
         `An error occurred while creating the user and linking the email: ${message}`

--- a/customResolvers/mutations/createEventSeriesWithChannelConnections.ts
+++ b/customResolvers/mutations/createEventSeriesWithChannelConnections.ts
@@ -2,6 +2,7 @@ import type { Driver } from "neo4j-driver";
 import { createEventChannelQuery } from "../cypher/cypherQueries.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventSeriesModel, EventModel, TagModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type DateOccurrence = {
   startTime: string;
@@ -297,7 +298,7 @@ const getResolver = (input: Input) => {
           } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             if (message.includes("Constraint validation failed")) {
-              console.warn(`Skipping duplicate EventChannel: ${channelUniqueName}`);
+              logger.warn(`Skipping duplicate EventChannel: ${channelUniqueName}`);
               continue;
             } else {
               throw error;
@@ -317,7 +318,7 @@ const getResolver = (input: Input) => {
       return fetchedEventSeries[0];
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error("Error creating event series:", message);
+      logger.error("Error creating event series:", message);
       throw new Error(`Failed to create event series: ${message}`);
     } finally {
       session.close();

--- a/customResolvers/mutations/createEventWithChannelConnections.ts
+++ b/customResolvers/mutations/createEventWithChannelConnections.ts
@@ -4,6 +4,7 @@ import { createEventChannelQuery } from "../cypher/cypherQueries.js";
 import { EventCreateInput } from "../../src/generated/graphql.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type EventCreateInputWithChannels = {
   eventCreateInput: EventCreateInput;
@@ -86,7 +87,7 @@ export const createEventsFromInput = async (
   try {
     for (const { eventCreateInput, channelConnections } of input) {
       if (!channelConnections || channelConnections.length === 0) {
-        console.warn("Skipping event creation: No channels provided");
+        logger.warn("Skipping event creation: No channels provided");
         continue;
       }
 
@@ -110,7 +111,7 @@ export const createEventsFromInput = async (
           } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             if (message.includes("Constraint validation failed")) {
-              console.warn(`Skipping duplicate EventChannel: ${channelUniqueName}`);
+              logger.warn(`Skipping duplicate EventChannel: ${channelUniqueName}`);
               continue;
             } else {
               throw error;
@@ -130,7 +131,7 @@ export const createEventsFromInput = async (
       } catch (error: unknown) {
         const err = error as { message?: string; code?: string; stack?: string; neo4jError?: unknown };
         const message = error instanceof Error ? error.message : String(error);
-        console.warn("Event creation error details:", {
+        logger.warn("Event creation error details:", {
           message: err.message,
           code: err.code,
           details: err.stack,
@@ -138,15 +139,15 @@ export const createEventsFromInput = async (
           fullError: JSON.stringify(error, Object.getOwnPropertyNames(error))
         });
         if (message.includes("Constraint validation failed")) {
-          console.warn("Constraint validation details:");
-          console.log('Input:', JSON.stringify(eventCreateInput, null, 2));
+          logger.warn("Constraint validation details:");
+          logger.info('Input:', JSON.stringify(eventCreateInput, null, 2));
           continue;
         }
       }
     }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error("Unexpected error during event creation:", message);
+    logger.error("Unexpected error during event creation:", message);
   } finally {
     session.close();
   }
@@ -168,7 +169,7 @@ const getResolver = (input: Input) => {
       const events = await createEventsFromInput(Event, driver, input, context);
       return events;
     } catch (error: unknown) {
-      console.error(error);
+      logger.error(error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`An error occurred while creating events: ${message}`);
     }

--- a/customResolvers/mutations/createImageWithUploader.ts
+++ b/customResolvers/mutations/createImageWithUploader.ts
@@ -3,6 +3,7 @@ import { setUserDataOnContext } from '../../rules/permission/userDataHelperFunct
 import { ERROR_MESSAGES } from '../../rules/errorMessages.js';
 import type { GraphQLContext } from '../../types/context.js';
 import type { ImageModel, UserModel } from '../../ogm_types.js';
+import { logger } from "../../logger.js";
 
 // Input type for image creation (excluding Uploader since we set it automatically)
 type ImageInput = {
@@ -122,7 +123,7 @@ const getResolver = (input: Input) => {
 
       return createdImage;
     } catch (error: unknown) {
-      console.error('Error creating image:', error);
+      logger.error('Error creating image:', error);
       const message = error instanceof Error ? error.message : String(error);
       throw new GraphQLError(`Failed to create image: ${message}`);
     }

--- a/customResolvers/mutations/createImagesWithUploader.ts
+++ b/customResolvers/mutations/createImagesWithUploader.ts
@@ -2,6 +2,7 @@ import { GraphQLError, type GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { ImageCreateInput, ImageModel, UserModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   input: ImageCreateInput[];
@@ -83,7 +84,7 @@ const getResolver = (input: Input) => {
 
       return response;
     } catch (error: unknown) {
-      console.error("Error creating images:", error);
+      logger.error("Error creating images:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new GraphQLError(`Failed to create images: ${message}`);
     }

--- a/customResolvers/mutations/createIssue.ts
+++ b/customResolvers/mutations/createIssue.ts
@@ -2,6 +2,7 @@ import type { IssueCreateInput, IssueModel } from "../../ogm_types.js";
 import type { Driver } from "neo4j-driver";
 import { GraphQLError } from "graphql";
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   input: IssueCreateInput;
@@ -45,7 +46,7 @@ const getResolver = (input: Input) => {
       }
       return issue;
     } catch (error: unknown) {
-      console.error("Error creating issue with number", error);
+      logger.error("Error creating issue with number", error);
       throw new GraphQLError("Error creating issue");
     }
   };

--- a/customResolvers/mutations/createScratchpadEntry.ts
+++ b/customResolvers/mutations/createScratchpadEntry.ts
@@ -2,6 +2,7 @@ import type { Driver } from 'neo4j-driver';
 import type { GraphQLResolveInfo } from 'graphql';
 import { createInAppNotification } from '../../hooks/notificationHelpers.js';
 import type { GraphQLContext } from '../../types/context.js';
+import { logger } from "../../logger.js";
 import type {
   ScratchpadEntryModel,
   CommentModel,
@@ -217,7 +218,7 @@ const createScratchpadEntryResolver = (input: Input) => {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error('Failed to rollback transaction', rollbackError);
+          logger.error('Failed to rollback transaction', rollbackError);
         }
       }
       throw e;
@@ -226,7 +227,7 @@ const createScratchpadEntryResolver = (input: Input) => {
         try {
           await session.close();
         } catch (sessionCloseError) {
-          console.error('Failed to close session', sessionCloseError);
+          logger.error('Failed to close session', sessionCloseError);
         }
       }
     }

--- a/customResolvers/mutations/createSignedStorageURL.ts
+++ b/customResolvers/mutations/createSignedStorageURL.ts
@@ -1,5 +1,6 @@
 import { Storage, GetSignedUrlConfig } from "@google-cloud/storage";
 import type { Ogm } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   filename: string;
@@ -101,7 +102,7 @@ export const validateFileType = async (
     if (error instanceof Error) {
       throw error;
     }
-    console.error("Error validating file type:", error);
+    logger.error("Error validating file type:", error);
     throw new Error("Failed to validate file type permissions");
   }
 };
@@ -183,7 +184,7 @@ const createSignedStorageURL = () => {
       .getSignedUrl(options);
 
     if (!url) {
-      console.error("No URL returned from getSignedUrl method");
+      logger.error("No URL returned from getSignedUrl method");
       return { url: "" };
     }
 

--- a/customResolvers/mutations/deleteEventInSeries.ts
+++ b/customResolvers/mutations/deleteEventInSeries.ts
@@ -2,6 +2,7 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel, EventSeriesModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Event: EventModel;
@@ -128,7 +129,7 @@ const getResolver = (input: Input) => {
         message: `Successfully deleted ${deletedCount} event(s)`,
       };
     } catch (error: unknown) {
-      console.error("Error deleting event in series:", error);
+      logger.error("Error deleting event in series:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to delete event in series. ${message}`);
     } finally {

--- a/customResolvers/mutations/dropDataForCypressTests.ts
+++ b/customResolvers/mutations/dropDataForCypressTests.ts
@@ -1,4 +1,5 @@
 import type { Driver } from "neo4j-driver";
+import { logger } from "../../logger.js";
 
 type Input = {
     driver: Driver;
@@ -65,11 +66,11 @@ async function runDeleteWithRetry(
 
             if (isRetriable && attempt < maxRetries) {
                 const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
-                console.warn(`Transient error on attempt ${attempt} for ${nodeLabel}. Retrying in ${delayMs}ms...`);
+                logger.warn(`Transient error on attempt ${attempt} for ${nodeLabel}. Retrying in ${delayMs}ms...`);
                 await delay(delayMs);
             } else {
                 // Log and continue - some node types may not exist or deletion may have partially completed
-                console.warn(`Error deleting ${nodeLabel}:`, error?.message || error);
+                logger.warn(`Error deleting ${nodeLabel}:`, error?.message || error);
                 return;
             }
         } finally {

--- a/customResolvers/mutations/enableServerPlugin.ts
+++ b/customResolvers/mutations/enableServerPlugin.ts
@@ -6,6 +6,7 @@ import type {
   ServerSecretModel
 } from '../../ogm_types.js'
 import type { GraphQLContext } from '../../types/context.js'
+import { logger } from "../../logger.js";
 
 type Input = {
   Plugin: PluginModel
@@ -177,7 +178,7 @@ const getResolver = (input: Input) => {
       }
 
     } catch (error: unknown) {
-      console.error('Error in enableServerPlugin resolver:', error)
+      logger.error('Error in enableServerPlugin resolver:', error)
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to ${enabled ? 'enable' : 'disable'} plugin: ${message}`)
     }

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -12,6 +12,7 @@ import type {
 import type { GraphQLResolveInfo } from 'graphql'
 import { parseManifestFromTarball } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
+import { logger } from "../../logger.js";
 
 type RegistryPlugin = {
   id: string
@@ -61,7 +62,7 @@ const getResolver = (input: Input) => {
       if (!registryUrl) {
         throw new Error('No plugin registry URL configured')
       }
-      console.log('Using plugin registry URL:', registryUrl)
+      logger.info('Using plugin registry URL:', registryUrl)
 
       // 2. Fetch and find plugin version in registry
       let registryData: PluginRegistry
@@ -144,7 +145,7 @@ const getResolver = (input: Input) => {
 
       if (existingDbVersions.length > 0) {
         const dbVersion = existingDbVersions[0]
-        console.log(`Found existing version in database: ${pluginSlug}@${version}`)
+        logger.info(`Found existing version in database: ${pluginSlug}@${version}`)
         // Use database URL but always use registry hash for verification
         registryVersion = {
           version: dbVersion.version,
@@ -155,10 +156,10 @@ const getResolver = (input: Input) => {
         registryVersion = registryVersionData
       }
 
-      console.log('Using version data:', JSON.stringify(registryVersion, null, 2))
+      logger.info('Using version data:', JSON.stringify(registryVersion, null, 2))
 
       // 3. Download and verify tarball integrity
-      console.log(`Downloading tarball from: ${registryVersion.tarballUrl}`)
+      logger.info(`Downloading tarball from: ${registryVersion.tarballUrl}`)
       
       let tarballBytes: Buffer
       if (registryVersion.tarballUrl.startsWith('gs://')) {
@@ -182,10 +183,10 @@ const getResolver = (input: Input) => {
 
       // 4. Verify integrity
       const actualSha256 = crypto.createHash('sha256').update(tarballBytes).digest('hex')
-      console.log('Tarball integrity check:')
-      console.log('  Expected SHA-256:', registryVersion.integritySha256)
-      console.log('  Actual SHA-256:  ', actualSha256)
-      console.log('  Tarball size:    ', tarballBytes.length, 'bytes')
+      logger.info('Tarball integrity check:')
+      logger.info('  Expected SHA-256:', registryVersion.integritySha256)
+      logger.info('  Actual SHA-256:  ', actualSha256)
+      logger.info('  Tarball size:    ', tarballBytes.length, 'bytes')
       if (actualSha256 !== registryVersion.integritySha256) {
         throw new Error(`Tarball integrity verification failed: SHA-256 mismatch. Expected: ${registryVersion.integritySha256}, Got: ${actualSha256}`)
       }
@@ -236,7 +237,7 @@ const getResolver = (input: Input) => {
       }
 
       if (!pluginRecord) {
-        console.log(`Creating new plugin record for ${artifacts.id}`)
+        logger.info(`Creating new plugin record for ${artifacts.id}`)
         const createResult = await Plugin.create({
           input: [
             ({
@@ -282,7 +283,7 @@ const getResolver = (input: Input) => {
       const readmeMarkdown = artifacts.readmeMarkdown ?? null
 
       if (!pluginVersion) {
-        console.log(`Creating new plugin version: ${pluginSlug}@${version}`)
+        logger.info(`Creating new plugin version: ${pluginSlug}@${version}`)
         const createResult = await PluginVersion.create({
           input: [
             ({
@@ -346,7 +347,7 @@ const getResolver = (input: Input) => {
       const isAlreadyInstalled = installedVersions[0]?.InstalledVersions?.length > 0
 
       if (!isAlreadyInstalled) {
-        console.log('Installing plugin version, serverName:', serverConfig.serverName, 'pluginVersion.id:', pluginVersion.id)
+        logger.info('Installing plugin version, serverName:', serverConfig.serverName, 'pluginVersion.id:', pluginVersion.id)
 
         await ServerConfig.update({
           where: { serverName: String(serverConfig.serverName) },
@@ -382,7 +383,7 @@ const getResolver = (input: Input) => {
       }
 
     } catch (error: unknown) {
-      console.error('Error in installPluginVersion resolver:', error)
+      logger.error('Error in installPluginVersion resolver:', error)
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to install plugin: ${message}`)
     }

--- a/customResolvers/mutations/inviteForumMod.ts
+++ b/customResolvers/mutations/inviteForumMod.ts
@@ -6,6 +6,7 @@ import type {
 import { sendEmailToUser, EmailContent } from "./shared/emailUtils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -95,7 +96,7 @@ ${process.env.FRONTEND_URL}/forums/${channelUniqueName}/accept-invite
 
       return emailSent;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/inviteForumOwner.ts
+++ b/customResolvers/mutations/inviteForumOwner.ts
@@ -6,6 +6,7 @@ import type {
 import { sendEmailToUser, EmailContent } from "./shared/emailUtils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -91,7 +92,7 @@ ${process.env.FRONTEND_URL}/forums/${channelUniqueName}/accept-invite
 
       return emailSent;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/inviteServerAdmin.ts
+++ b/customResolvers/mutations/inviteServerAdmin.ts
@@ -6,6 +6,7 @@ import type {
 import { sendEmailToUser, EmailContent } from "./shared/emailUtils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -92,7 +93,7 @@ ${process.env.FRONTEND_URL}/admin/accept-admin-invite
 
       return emailSent;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/inviteServerMod.ts
+++ b/customResolvers/mutations/inviteServerMod.ts
@@ -6,6 +6,7 @@ import type {
 import { sendEmailToUser, EmailContent } from "./shared/emailUtils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   inviteeUsername: string;
@@ -92,7 +93,7 @@ ${process.env.FRONTEND_URL}/admin/accept-mod-invite
 
       return emailSent;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/lockChannel.ts
+++ b/customResolvers/mutations/lockChannel.ts
@@ -11,6 +11,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { GraphQLError } from "graphql";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   channelUniqueName: string;
@@ -139,7 +140,7 @@ const getResolver = (input: Input) => {
             throw new GraphQLError("Error creating issue for channel lock");
           }
         } catch (error) {
-          console.error("Error creating issue for channel lock:", error);
+          logger.error("Error creating issue for channel lock:", error);
           throw new GraphQLError(
             `Error creating issue: ${(error as Error)?.message || "unknown error"}`
           );
@@ -210,7 +211,7 @@ const getResolver = (input: Input) => {
         update: issueUpdateInput,
       });
     } catch (error) {
-      console.error("Error updating issue with lock action:", error);
+      logger.error("Error updating issue with lock action:", error);
       // Continue even if issue update fails - the channel lock is more important
     }
 
@@ -278,19 +279,19 @@ const getResolver = (input: Input) => {
             }
           );
         } catch (notifyError) {
-          console.error("Error notifying channel admins:", notifyError);
+          logger.error("Error notifying channel admins:", notifyError);
           // Don't fail the mutation if notifications fail
         } finally {
           await session.close();
         }
       }
 
-      console.log(
+      logger.info(
         `✅ Channel ${channelUniqueName} locked by ${loggedInModName}`
       );
       return updatedChannel;
     } catch (error) {
-      console.error("Error locking channel:", error);
+      logger.error("Error locking channel:", error);
       throw new GraphQLError("Error locking channel");
     }
   };

--- a/customResolvers/mutations/lockIssue.ts
+++ b/customResolvers/mutations/lockIssue.ts
@@ -9,6 +9,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { GraphQLError } from "graphql";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   issueId: string;
@@ -188,10 +189,10 @@ const getResolver = (input: Input) => {
         commentText: reason,
       });
 
-      console.log(`✅ Issue ${existingIssue.issueNumber} locked by ${loggedInModName}`);
+      logger.info(`✅ Issue ${existingIssue.issueNumber} locked by ${loggedInModName}`);
       return updatedIssue;
     } catch (error) {
-      console.error("Error locking issue:", error);
+      logger.error("Error locking issue:", error);
       throw new GraphQLError("Error locking issue");
     }
   };

--- a/customResolvers/mutations/permanentlyRemoveImage.ts
+++ b/customResolvers/mutations/permanentlyRemoveImage.ts
@@ -16,6 +16,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { GraphQLError } from "graphql";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   imageId: string;
@@ -203,7 +204,7 @@ const getResolver = (input: Input) => {
         existingIssueId = issueId;
         existingIssue = createResult.issues[0];
       } catch (error) {
-        console.error("Error creating permanent removal issue:", error);
+        logger.error("Error creating permanent removal issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -298,7 +299,7 @@ const getResolver = (input: Input) => {
         commentText: explanation,
       });
     } catch (error) {
-      console.error("Error updating issue:", error);
+      logger.error("Error updating issue:", error);
       throw new GraphQLError("Error updating issue");
     }
 
@@ -346,7 +347,7 @@ const getResolver = (input: Input) => {
 
       return existingIssue;
     } catch (error) {
-      console.error("Error updating image:", error);
+      logger.error("Error updating image:", error);
       throw new GraphQLError("Error updating image");
     }
   };

--- a/customResolvers/mutations/refreshPlugins.ts
+++ b/customResolvers/mutations/refreshPlugins.ts
@@ -11,6 +11,7 @@ import { Storage } from '@google-cloud/storage'
 import type { GraphQLResolveInfo } from 'graphql'
 import { getManifestArtifacts } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
+import { logger } from "../../logger.js";
 
 type RegistryPlugin = {
   id: string
@@ -45,8 +46,8 @@ const getResolver = (input: Input) => {
         }`
       })
 
-      console.log('Found server configs:', serverConfigs.length)
-      console.log('Server config pluginRegistries:', serverConfigs[0]?.pluginRegistries)
+      logger.info('Found server configs:', serverConfigs.length)
+      logger.info('Server config pluginRegistries:', serverConfigs[0]?.pluginRegistries)
 
       if (!serverConfigs.length || !serverConfigs[0].pluginRegistries?.length) {
         throw new Error('No plugin registries configured')
@@ -57,7 +58,7 @@ const getResolver = (input: Input) => {
         throw new Error('No plugin registry URL configured')
       }
       
-      console.log(`Fetching plugin registry from: ${registryUrl}`)
+      logger.info(`Fetching plugin registry from: ${registryUrl}`)
 
       // Fetch registry data
       let registryData: PluginRegistry
@@ -69,7 +70,7 @@ const getResolver = (input: Input) => {
           const [bucketName, ...pathParts] = gsPath.split('/')
           const filePath = pathParts.join('/')
           
-          console.log(`Downloading from GCS bucket: ${bucketName}, file: ${filePath}`)
+          logger.info(`Downloading from GCS bucket: ${bucketName}, file: ${filePath}`)
           
           const bucket = storage.bucket(bucketName)
           const file = bucket.file(filePath)
@@ -85,20 +86,20 @@ const getResolver = (input: Input) => {
           registryData = await response.json()
         }
       } catch (error: unknown) {
-        console.error('Failed to fetch plugin registry:', error)
+        logger.error('Failed to fetch plugin registry:', error)
         const message = error instanceof Error ? error.message : String(error)
         throw new Error(
           `Failed to fetch plugin registry: ${message}`
         )
       }
 
-      console.log(`Registry updated at: ${registryData.updatedAt}`)
-      console.log(`Found ${registryData.plugins.length} plugins in registry`)
+      logger.info(`Registry updated at: ${registryData.updatedAt}`)
+      logger.info(`Found ${registryData.plugins.length} plugins in registry`)
 
       const updatedPlugins: any[] = []
 
       // First, find and fix any orphaned plugin versions that exist without Plugin connections
-      console.log('Checking for orphaned plugin versions...')
+      logger.info('Checking for orphaned plugin versions...')
       
       try {
         const allVersions = await PluginVersion.find({
@@ -109,7 +110,7 @@ const getResolver = (input: Input) => {
           }`
         })
 
-        console.log(`Found ${allVersions.length} total plugin versions in database`)
+        logger.info(`Found ${allVersions.length} total plugin versions in database`)
 
         // Check each version to see if it has a Plugin relationship
         for (const version of allVersions) {
@@ -129,13 +130,13 @@ const getResolver = (input: Input) => {
             })
 
             if (connectedPlugins.length === 0) {
-              console.log(`Found orphaned version: ${version.version} (${version.repoUrl})`)
+              logger.info(`Found orphaned version: ${version.version} (${version.repoUrl})`)
               
               // Try to match this version to a plugin from the registry
               for (const registryPlugin of registryData.plugins) {
                 const matchingVersion = registryPlugin.versions.find(v => v.tarballUrl === version.repoUrl)
                 if (matchingVersion) {
-                  console.log(`Attempting to connect orphaned version to plugin: ${registryPlugin.id}`)
+                  logger.info(`Attempting to connect orphaned version to plugin: ${registryPlugin.id}`)
                   
                   // Find or create the plugin
                   let plugins = await Plugin.find({
@@ -144,7 +145,7 @@ const getResolver = (input: Input) => {
 
                   let plugin = plugins[0]
                   if (!plugin) {
-                    console.log(`Creating plugin for orphaned version: ${registryPlugin.id}`)
+                    logger.info(`Creating plugin for orphaned version: ${registryPlugin.id}`)
                     const createResult = await Plugin.create({
                       input: [{ name: registryPlugin.id }]
                     })
@@ -161,23 +162,23 @@ const getResolver = (input: Input) => {
                     }
                   })
                   
-                  console.log(`Successfully connected orphaned version ${version.version} to plugin ${registryPlugin.id}`)
+                  logger.info(`Successfully connected orphaned version ${version.version} to plugin ${registryPlugin.id}`)
                   break
                 }
               }
             }
           } catch (versionError: unknown) {
             const message = versionError instanceof Error ? versionError.message : String(versionError)
-            console.warn(`Skipping version ${version.id} due to error:`, message)
+            logger.warn(`Skipping version ${version.id} due to error:`, message)
           }
         }
       } catch (orphanError: unknown) {
         const message = orphanError instanceof Error ? orphanError.message : String(orphanError)
-        console.warn('Error while checking orphaned versions:', message)
+        logger.warn('Error while checking orphaned versions:', message)
         // Continue with normal processing even if orphan check fails
       }
 
-      console.log('Finished checking orphaned versions, proceeding with registry processing...')
+      logger.info('Finished checking orphaned versions, proceeding with registry processing...')
 
 
 // Process each plugin in the registry
@@ -195,10 +196,10 @@ for (const registryPlugin of registryData.plugins) {
   for (const registryVersion of registryPlugin.versions) {
     try {
       const artifacts = await getManifestArtifacts(registryVersion.tarballUrl)
-      console.log(`Registry version: ${registryVersion.version}, Manifest version: ${artifacts.version}`)
+      logger.info(`Registry version: ${registryVersion.version}, Manifest version: ${artifacts.version}`)
 
       if (artifacts.id !== registryPlugin.id) {
-        console.warn(`Plugin ID mismatch: registry=${registryPlugin.id}, manifest=${artifacts.id}. Skipping.`)
+        logger.warn(`Plugin ID mismatch: registry=${registryPlugin.id}, manifest=${artifacts.id}. Skipping.`)
         continue
       }
 
@@ -238,7 +239,7 @@ for (const registryPlugin of registryData.plugins) {
       }
 
       if (!pluginRecord) {
-        console.log(`Creating new plugin: ${registryPlugin.id}`)
+        logger.info(`Creating new plugin: ${registryPlugin.id}`)
         const createResult = await Plugin.create({
           input: [
             ({
@@ -294,7 +295,7 @@ for (const registryPlugin of registryData.plugins) {
       const manifestJson = artifacts.manifest ? JSON.stringify(artifacts.manifest) : null
 
       if (existingVersions.length === 0) {
-        console.log(
+        logger.info(
           `Creating new plugin version: ${registryPlugin.id}@${artifacts.version} (registry: ${registryVersion.version})`
         )
         await PluginVersion.create({
@@ -320,7 +321,7 @@ for (const registryPlugin of registryData.plugins) {
         })
       } else {
         const existingVersion = existingVersions[0]
-        console.log(
+        logger.info(
           `Plugin version already exists: ${registryPlugin.id}@${artifacts.version}, ensuring connection`
         )
 
@@ -345,7 +346,7 @@ for (const registryPlugin of registryData.plugins) {
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
-      console.warn(`Failed to process version ${registryVersion.version} for plugin ${registryPlugin.id}:`, message)
+      logger.warn(`Failed to process version ${registryVersion.version} for plugin ${registryPlugin.id}:`, message)
       continue
     }
   }
@@ -355,7 +356,7 @@ for (const registryPlugin of registryData.plugins) {
   }
 }
 
-      console.log(`Successfully refreshed ${updatedPlugins.length} plugins`)
+      logger.info(`Successfully refreshed ${updatedPlugins.length} plugins`)
       
       // Before returning, make sure all plugins have their Versions relationship properly loaded
       const pluginsWithVersions = []
@@ -395,7 +396,7 @@ for (const registryPlugin of registryData.plugins) {
           }
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : String(error)
-          console.warn(`Could not load versions for plugin ${plugin.id}:`, message)
+          logger.warn(`Could not load versions for plugin ${plugin.id}:`, message)
           // Still include the plugin but with empty versions array
           pluginsWithVersions.push({
             ...plugin,
@@ -406,7 +407,7 @@ for (const registryPlugin of registryData.plugins) {
       
       return pluginsWithVersions
     } catch (error: unknown) {
-      console.error('Error in refreshPlugins resolver:', error)
+      logger.error('Error in refreshPlugins resolver:', error)
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to refresh plugins: ${message}`)
     }

--- a/customResolvers/mutations/removeEmojiFromComment.ts
+++ b/customResolvers/mutations/removeEmojiFromComment.ts
@@ -3,6 +3,7 @@ import { assertCommentEmojiEnabled } from "./channelPreferenceGuards.js";
 import type { CommentModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Input = {
   Comment: CommentModel;
@@ -46,7 +47,7 @@ const getRemoveEmojiResolver = (input: Input) => {
         emoji: updatedEmojiJSON,
       };
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       throw e;
     }
   };

--- a/customResolvers/mutations/removeEmojiFromDiscussionChannel.ts
+++ b/customResolvers/mutations/removeEmojiFromDiscussionChannel.ts
@@ -3,6 +3,7 @@ import { assertDiscussionChannelEmojiEnabled } from "./channelPreferenceGuards.j
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Input = {
   DiscussionChannel: DiscussionChannelModel;
@@ -49,7 +50,7 @@ const getRemoveEmojiResolver = (input: Input) => {
         emoji: updatedEmojiJSON,
       };
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       throw e;
     }
   };

--- a/customResolvers/mutations/removeForumMod.ts
+++ b/customResolvers/mutations/removeForumMod.ts
@@ -1,6 +1,7 @@
 import type { ChannelUpdateInput, UserModel, ChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   username: string;
@@ -66,7 +67,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/removeForumOwner.ts
+++ b/customResolvers/mutations/removeForumOwner.ts
@@ -1,6 +1,7 @@
 import type { ChannelUpdateInput, ChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { GraphQLResolveInfo } from "graphql";
+import { logger } from "../../logger.js";
 
 type Args = {
   username: string;
@@ -50,7 +51,7 @@ const getResolver = (input: Input) => {
       }
       return true;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
       return false;
     }
   };

--- a/customResolvers/mutations/reportChannel.ts
+++ b/customResolvers/mutations/reportChannel.ts
@@ -12,6 +12,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { GraphQLError } from "graphql";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   channelUniqueName: string;
@@ -217,7 +218,7 @@ const getResolver = (input: Input) => {
         }
         existingIssueId = issueId;
       } catch (error) {
-        console.error("Error creating channel report issue:", error);
+        logger.error("Error creating channel report issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -269,7 +270,7 @@ const getResolver = (input: Input) => {
       }
       return updateResult.issues[0];
     } catch (error) {
-      console.error("Error updating channel report issue:", error);
+      logger.error("Error updating channel report issue:", error);
       throw new GraphQLError("Error updating issue");
     }
   };

--- a/customResolvers/mutations/reportChannelImage.ts
+++ b/customResolvers/mutations/reportChannelImage.ts
@@ -12,6 +12,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { GraphQLError } from "graphql";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type ChannelImageType = "ICON" | "BANNER";
 
@@ -252,7 +253,7 @@ const getResolver = (input: Input) => {
         }
         existingIssueId = issueId;
       } catch (error) {
-        console.error("Error creating channel image report issue:", error);
+        logger.error("Error creating channel image report issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -306,7 +307,7 @@ const getResolver = (input: Input) => {
       }
       return updateResult.issues[0];
     } catch (error) {
-      console.error("Error updating channel image report issue:", error);
+      logger.error("Error updating channel image report issue:", error);
       throw new GraphQLError("Error updating issue");
     }
   };

--- a/customResolvers/mutations/reportDiscussion.ts
+++ b/customResolvers/mutations/reportDiscussion.ts
@@ -16,6 +16,7 @@ import {
   getIssueCreateInput,
 } from "./reportComment.js";
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionId: string;
@@ -190,7 +191,7 @@ const getResolver = (input: Input) => {
         }
         existingIssueId = issueId;
       } catch (error) {
-        console.error("Error creating issue:", {
+        logger.error("Error creating issue:", {
           error,
           issueCreateInput,
         });

--- a/customResolvers/mutations/reportImage.ts
+++ b/customResolvers/mutations/reportImage.ts
@@ -13,6 +13,7 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
 import getNextIssueNumber from "./utils/getNextIssueNumber.js";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   imageId: string;
@@ -302,7 +303,7 @@ const getResolver = (input: Input) => {
         }
         existingIssueId = issueId;
       } catch (error) {
-        console.error("Error creating image report issue:", error);
+        logger.error("Error creating image report issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -363,7 +364,7 @@ const getResolver = (input: Input) => {
       }
       return updateResult.issues[0];
     } catch (error) {
-      console.error("Error updating image report issue:", error);
+      logger.error("Error updating image report issue:", error);
       throw new GraphQLError("Error updating issue");
     }
   };

--- a/customResolvers/mutations/reportProfilePicture.ts
+++ b/customResolvers/mutations/reportProfilePicture.ts
@@ -12,6 +12,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
 import getNextServerIssueNumber from "./utils/getNextServerIssueNumber.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   username: string;
@@ -228,7 +229,7 @@ const getResolver = (input: Input) => {
         }
         existingIssueId = issueId;
       } catch (error) {
-        console.error("Error creating profile picture report issue:", error);
+        logger.error("Error creating profile picture report issue:", error);
         throw new GraphQLError(
           `Error creating issue: ${(error as Error)?.message || "unknown error"}`
         );
@@ -280,7 +281,7 @@ const getResolver = (input: Input) => {
       }
       return updateResult.issues[0];
     } catch (error) {
-      console.error("Error updating profile picture report issue:", error);
+      logger.error("Error updating profile picture report issue:", error);
       throw new GraphQLError("Error updating issue");
     }
   };

--- a/customResolvers/mutations/seedDataForCypressTests.ts
+++ b/customResolvers/mutations/seedDataForCypressTests.ts
@@ -30,6 +30,7 @@ import {
 import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type NewUserInput = {
   emailAddress: string;
@@ -164,7 +165,7 @@ const seedDataForCypressTestsResolver = (input: Input) => {
         },
       });
     } catch (error: unknown) {
-      console.error("Error updating server configuration:", error);
+      logger.error("Error updating server configuration:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Failed to update server configurations: ${message}`

--- a/customResolvers/mutations/sendBugReport.ts
+++ b/customResolvers/mutations/sendBugReport.ts
@@ -1,6 +1,7 @@
 import { sendEmail } from "../../services/mail/index.js";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   contactEmail: string;
@@ -90,8 +91,8 @@ ${text}
 
       // Convert markdown message to HTML
       const htmlMessage = convertMarkdownToHtml(text);
-      console.log("Original text:", text);
-      console.log("Converted HTML:", htmlMessage);
+      logger.info("Original text:", text);
+      logger.info("Converted HTML:", htmlMessage);
 
       // Create HTML version with formatted content
       const html = `
@@ -116,10 +117,10 @@ ${username ? `<p><strong>Username:</strong> ${username}</p>` : ''}
         throwOnMissingFrom: true,
       });
 
-      console.log("Sending bug report email to", process.env.SUPPORT_EMAIL);
+      logger.info("Sending bug report email to", process.env.SUPPORT_EMAIL);
       return emailSent;
     } catch (e: unknown) {
-      console.error("Error sending bug report email:", e);
+      logger.error("Error sending bug report email:", e);
       const message = e instanceof Error ? e.message : String(e);
       throw new Error(
         `An error occurred while sending the bug report: ${message}`

--- a/customResolvers/mutations/setServerPluginSecret.ts
+++ b/customResolvers/mutations/setServerPluginSecret.ts
@@ -4,6 +4,7 @@ import type {
 import type { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../../types/context.js'
 import { encryptSecret } from '../../services/plugin/encryption.js'
+import { logger } from "../../logger.js";
 
 type Input = {
   ServerSecret: ServerSecretModel
@@ -68,7 +69,7 @@ const getResolver = (input: Input) => {
 
       return true
     } catch (error: unknown) {
-      console.error('Error in setServerPluginSecret resolver:', error)
+      logger.error('Error in setServerPluginSecret resolver:', error)
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to set server plugin secret: ${message}`)
     }

--- a/customResolvers/mutations/shared/emailUtils.ts
+++ b/customResolvers/mutations/shared/emailUtils.ts
@@ -1,6 +1,7 @@
 import type { UserModel } from "../../../ogm_types.js";
 import { sendEmail } from "../../../services/mail/index.js";
 import { renderEmailMarkdownToHtml } from "../../../services/renderEmailMarkdown.js";
+import { logger } from "../../../logger.js";
 
 // Types for email content
 export type EmailContent = {
@@ -63,7 +64,7 @@ export const sendEmailToUser = async (
       html: emailContent.html,
     });
 
-    console.log("Sending email to", user.Email.address);
+    logger.info("Sending email to", user.Email.address);
     if (!emailSent) {
       return false;
     }
@@ -99,7 +100,7 @@ export const sendEmailToUser = async (
 
     return true;
   } catch (e) {
-    console.error("Error sending email:", e);
+    logger.error("Error sending email:", e);
     return false;
   }
 };

--- a/customResolvers/mutations/shared/pluginManifest.ts
+++ b/customResolvers/mutations/shared/pluginManifest.ts
@@ -2,6 +2,7 @@ import { Storage } from '@google-cloud/storage'
 import path from 'path'
 import tar from 'tar-stream'
 import zlib from 'zlib'
+import { logger } from "../../../logger.js";
 
 type ManifestData = {
   id: string
@@ -121,7 +122,7 @@ export async function parseManifestFromTarball(tarballBytes: Buffer): Promise<Ma
 }
 
 export async function getManifestArtifacts(tarballUrl: string): Promise<ManifestArtifacts> {
-  console.log(`Downloading and parsing manifest from: ${tarballUrl}`)
+  logger.info(`Downloading and parsing manifest from: ${tarballUrl}`)
 
   let tarballBytes: Buffer
   if (tarballUrl.startsWith('gs://')) {

--- a/customResolvers/mutations/subscribeToComment.ts
+++ b/customResolvers/mutations/subscribeToComment.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { CommentModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   commentId: string;
@@ -56,7 +57,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error subscribing to comment:", error);
+      logger.error("Error subscribing to comment:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to subscribe to comment: ${message}`);
     } finally {

--- a/customResolvers/mutations/subscribeToDiscussionChannel.ts
+++ b/customResolvers/mutations/subscribeToDiscussionChannel.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionChannelId: string;
@@ -24,20 +25,20 @@ const getResolver = (input: Input) => {
     const { discussionChannelId } = args;
     const { username } = context.user!;
 
-    console.log('=== DEBUG: subscribeToDiscussionChannel called with:', {
+    logger.info('=== DEBUG: subscribeToDiscussionChannel called with:', {
       discussionChannelId,
       username
     });
 
     if (!username) {
-      console.error('=== DEBUG ERROR: Authentication required for subscription');
+      logger.error('=== DEBUG ERROR: Authentication required for subscription');
       throw new Error("Authentication required");
     }
 
     const session = driver.session();
 
     try {
-      console.log('=== DEBUG: Creating subscription relationship');
+      logger.info('=== DEBUG: Creating subscription relationship');
       
       // Connect user to SubscribedToNotifications
       const subscriptionResult = await session.run(
@@ -50,7 +51,7 @@ const getResolver = (input: Input) => {
         { discussionChannelId, username }
       );
       
-      console.log('=== DEBUG: Subscription creation result:', {
+      logger.info('=== DEBUG: Subscription creation result:', {
         recordsCount: subscriptionResult.records.length,
         firstRecord: subscriptionResult.records[0] ? {
           discussionChannelId: subscriptionResult.records[0].get('discussionChannelId'),
@@ -73,14 +74,14 @@ const getResolver = (input: Input) => {
         }`
       });
 
-      console.log('=== DEBUG: Subscription successful, returning DiscussionChannel:', {
+      logger.info('=== DEBUG: Subscription successful, returning DiscussionChannel:', {
         id: result[0]?.id,
         subscribedUsersCount: result[0]?.SubscribedToNotifications?.length || 0
       });
       
       return result[0];
     } catch (error: unknown) {
-      console.error('=== DEBUG ERROR: Error subscribing to discussion channel:', error);
+      logger.error('=== DEBUG ERROR: Error subscribing to discussion channel:', error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to subscribe to discussion channel: ${message}`);
     } finally {

--- a/customResolvers/mutations/subscribeToEvent.ts
+++ b/customResolvers/mutations/subscribeToEvent.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { EventModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   eventId: string;
@@ -57,7 +58,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error subscribing to event:", error);
+      logger.error("Error subscribing to event:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to subscribe to event: ${message}`);
     } finally {

--- a/customResolvers/mutations/subscribeToEventUpdates.ts
+++ b/customResolvers/mutations/subscribeToEventUpdates.ts
@@ -1,6 +1,7 @@
 import type { Driver } from "neo4j-driver";
 import type { EventModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   eventId: string;
@@ -48,7 +49,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error subscribing to event updates:", error);
+      logger.error("Error subscribing to event updates:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to subscribe to event updates: ${message}`);
     } finally {

--- a/customResolvers/mutations/subscribeToIssue.ts
+++ b/customResolvers/mutations/subscribeToIssue.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { IssueModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   issueId: string;
@@ -58,7 +59,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error subscribing to issue:", error);
+      logger.error("Error subscribing to issue:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to subscribe to issue: ${message}`);
     } finally {

--- a/customResolvers/mutations/unarchiveComment.ts
+++ b/customResolvers/mutations/unarchiveComment.ts
@@ -14,6 +14,7 @@ import type { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../../types/context.js'
 import { getModerationActionCreateInput } from './reportComment.js'
 import { notifyIssueSubscribers } from '../../services/issueNotifications.js'
+import { logger } from "../../logger.js";
 
 type Args = {
   commentId: string
@@ -133,7 +134,7 @@ const getResolver = (input: Input) => {
         actionDescription: 'Un-archived the comment',
         issueId: existingIssueId
       })
-    console.log(
+    logger.info(
       'unarchiveModActionCreateInput',
       JSON.stringify(unarchiveModActionCreateInput)
     )
@@ -147,7 +148,7 @@ const getResolver = (input: Input) => {
         actionDescription: 'Closed the issue',
         issueId: existingIssueId
       })
-    console.log(
+    logger.info(
       'closeIssueModActionCreateInput',
       JSON.stringify(closeIssueModActionCreateInput)
     )
@@ -202,7 +203,7 @@ const getResolver = (input: Input) => {
           }
         }`
       })
-      console.log('issueData', JSON.stringify(issueData))
+      logger.info('issueData', JSON.stringify(issueData))
       const issueId = issueData.issues[0]?.id || null
       if (!issueId) {
         throw new GraphQLError('Error updating issue')

--- a/customResolvers/mutations/unarchiveImage.ts
+++ b/customResolvers/mutations/unarchiveImage.ts
@@ -13,6 +13,7 @@ import { GraphQLError } from "graphql";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   imageId: string;
@@ -264,7 +265,7 @@ const getResolver = (input: Input) => {
         commentText: explanation,
       });
     } catch (error) {
-      console.error("Error updating issue:", error);
+      logger.error("Error updating issue:", error);
       throw new GraphQLError("Error updating issue");
     }
 
@@ -289,7 +290,7 @@ const getResolver = (input: Input) => {
 
       return existingIssue;
     } catch (error) {
-      console.error("Error updating image:", error);
+      logger.error("Error updating image:", error);
       throw new GraphQLError("Error updating image");
     }
   };

--- a/customResolvers/mutations/undoSuperUpvote.ts
+++ b/customResolvers/mutations/undoSuperUpvote.ts
@@ -1,6 +1,7 @@
 import type { Driver } from "neo4j-driver";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 import type {
   CommentModel,
   DiscussionChannelModel,
@@ -147,7 +148,7 @@ const undoSuperUpvoteResolver = (input: Input) => {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error('Failed to rollback transaction', rollbackError);
+          logger.error('Failed to rollback transaction', rollbackError);
         }
       }
       throw e;
@@ -156,7 +157,7 @@ const undoSuperUpvoteResolver = (input: Input) => {
         try {
           await session.close();
         } catch (sessionCloseError) {
-          console.error('Failed to close session', sessionCloseError);
+          logger.error('Failed to close session', sessionCloseError);
         }
       }
     }

--- a/customResolvers/mutations/undoUpvoteComment.ts
+++ b/customResolvers/mutations/undoUpvoteComment.ts
@@ -5,6 +5,7 @@ import type { CommentModel, UserModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
 import { commentIsUpvotedByUserQuery } from "../cypher/cypherQueries.js";
 import { getWeightedVoteBonus } from "./utils.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Comment: CommentModel;
@@ -163,12 +164,12 @@ const undoUpvoteCommentResolver = (input: Input) => {
       };
       return returnValue;
     } catch (e) {
-      console.error("Error in undoUpvoteComment:", e);
+      logger.error("Error in undoUpvoteComment:", e);
       if (tx) {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error("Failed to rollback transaction", rollbackError);
+          logger.error("Failed to rollback transaction", rollbackError);
         }
       }
       throw e; // Re-throw the error after logging
@@ -177,7 +178,7 @@ const undoUpvoteCommentResolver = (input: Input) => {
         try {
           session.close();
         } catch (sessionCloseError) {
-          console.error("Failed to close session", sessionCloseError);
+          logger.error("Failed to close session", sessionCloseError);
         }
       }
     }

--- a/customResolvers/mutations/undoUpvoteDiscussionChannel.ts
+++ b/customResolvers/mutations/undoUpvoteDiscussionChannel.ts
@@ -7,6 +7,7 @@ import {
   discussionChannelIsUpvotedByUserQuery,
 } from "../cypher/cypherQueries.js";
 import { getWeightedVoteBonus } from "./utils.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   DiscussionChannel: DiscussionChannelModel;
@@ -160,16 +161,16 @@ const undoUpvoteDiscussionChannelResolver = (input: Input) => {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error("Failed to rollback transaction", rollbackError);
+          logger.error("Failed to rollback transaction", rollbackError);
         }
       }
-      console.error(e);
+      logger.error(e);
     } finally {
       if (session) {
         try {
           session.close();
         } catch (sessionCloseError) {
-          console.error("Failed to close session", sessionCloseError);
+          logger.error("Failed to close session", sessionCloseError);
         }
       }
     }

--- a/customResolvers/mutations/unlockChannel.ts
+++ b/customResolvers/mutations/unlockChannel.ts
@@ -9,6 +9,7 @@ import { GraphQLError } from "graphql";
 import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   channelUniqueName: string;
@@ -159,7 +160,7 @@ const getResolver = (input: Input) => {
           update: issueUpdateInput,
         });
       } catch (error) {
-        console.error("Error updating issue with unlock action:", error);
+        logger.error("Error updating issue with unlock action:", error);
         // Continue even if issue update fails - the channel unlock is more important
       }
     }
@@ -228,19 +229,19 @@ const getResolver = (input: Input) => {
             }
           );
         } catch (notifyError) {
-          console.error("Error notifying channel admins:", notifyError);
+          logger.error("Error notifying channel admins:", notifyError);
           // Don't fail the mutation if notifications fail
         } finally {
           await session.close();
         }
       }
 
-      console.log(
+      logger.info(
         `✅ Channel ${channelUniqueName} unlocked by ${loggedInModName}`
       );
       return updatedChannel;
     } catch (error) {
-      console.error("Error unlocking channel:", error);
+      logger.error("Error unlocking channel:", error);
       throw new GraphQLError("Error unlocking channel");
     }
   };

--- a/customResolvers/mutations/unlockIssue.ts
+++ b/customResolvers/mutations/unlockIssue.ts
@@ -9,6 +9,7 @@ import { GraphQLError } from "graphql";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
 import { notifyIssueSubscribers } from "../../services/issueNotifications.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   issueId: string;
@@ -193,10 +194,10 @@ const getResolver = (input: Input) => {
         commentText: reason || null,
       });
 
-      console.log(`✅ Issue ${existingIssue.issueNumber} unlocked by ${loggedInModName}`);
+      logger.info(`✅ Issue ${existingIssue.issueNumber} unlocked by ${loggedInModName}`);
       return updatedIssue;
     } catch (error) {
-      console.error("Error unlocking issue:", error);
+      logger.error("Error unlocking issue:", error);
       throw new GraphQLError("Error unlocking issue");
     }
   };

--- a/customResolvers/mutations/unsubscribeFromComment.ts
+++ b/customResolvers/mutations/unsubscribeFromComment.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { CommentModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   commentId: string;
@@ -57,7 +58,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error unsubscribing from comment:", error);
+      logger.error("Error unsubscribing from comment:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to unsubscribe from comment: ${message}`);
     } finally {

--- a/customResolvers/mutations/unsubscribeFromDiscussionChannel.ts
+++ b/customResolvers/mutations/unsubscribeFromDiscussionChannel.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionChannelId: string;
@@ -59,7 +60,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error unsubscribing from discussion channel:", error);
+      logger.error("Error unsubscribing from discussion channel:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to unsubscribe from discussion channel: ${message}`);
     } finally {

--- a/customResolvers/mutations/unsubscribeFromEvent.ts
+++ b/customResolvers/mutations/unsubscribeFromEvent.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { EventModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   eventId: string;
@@ -58,7 +59,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error unsubscribing from event:", error);
+      logger.error("Error unsubscribing from event:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to unsubscribe from event: ${message}`);
     } finally {

--- a/customResolvers/mutations/unsubscribeFromEventUpdates.ts
+++ b/customResolvers/mutations/unsubscribeFromEventUpdates.ts
@@ -1,6 +1,7 @@
 import type { Driver } from "neo4j-driver";
 import type { EventModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   eventId: string;
@@ -49,7 +50,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error unsubscribing from event updates:", error);
+      logger.error("Error unsubscribing from event updates:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Failed to unsubscribe from event updates: ${message}`

--- a/customResolvers/mutations/unsubscribeFromIssue.ts
+++ b/customResolvers/mutations/unsubscribeFromIssue.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { IssueModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   issueId: string;
@@ -59,7 +60,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error unsubscribing from issue:", error);
+      logger.error("Error unsubscribing from issue:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to unsubscribe from issue: ${message}`);
     } finally {

--- a/customResolvers/mutations/updateChannelPluginPipelines.ts
+++ b/customResolvers/mutations/updateChannelPluginPipelines.ts
@@ -7,6 +7,7 @@ import {
 } from '../../services/botUserService.js'
 import { mergeSettings } from '../../services/plugin/pipelineUtils.js'
 import { validatePipelines, type EventPipelineInput } from './updatePluginPipelines.js'
+import { logger } from "../../logger.js";
 
 type Input = {
   Channel: ChannelModel
@@ -221,7 +222,7 @@ const getResolver = (input: Input) => {
       )
 
       if (botsToDisconnect.length > 0) {
-        console.log('🧹 Marking orphaned bots as deprecated and disconnecting from channel (pipeline update)', {
+        logger.info('🧹 Marking orphaned bots as deprecated and disconnecting from channel (pipeline update)', {
           channelUniqueName,
           botsToDisconnect,
           desiredBots: Array.from(allDesiredBotUsernames)
@@ -249,7 +250,7 @@ const getResolver = (input: Input) => {
         })
       }
     } catch (error: unknown) {
-      console.warn(
+      logger.warn(
         `Failed to sync bot users for channel ${channelUniqueName}:`,
         (error instanceof Error ? error.message : undefined) || error
       )

--- a/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
@@ -7,6 +7,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { sanitizeAlbumCreateNode, sanitizeAlbumUpdateNode } from "./utils/ownershipSanitizers.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Discussion: DiscussionModel;
@@ -184,7 +185,7 @@ const getResolver = (input: Input) => {
 
       return result[0];
     } catch (error: unknown) {
-      console.error("Error updating discussion:", error);
+      logger.error("Error updating discussion:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to update discussion. ${message}`);
     }

--- a/customResolvers/mutations/updateDownloadLabels.ts
+++ b/customResolvers/mutations/updateDownloadLabels.ts
@@ -14,6 +14,7 @@ type LabelChangeHistoryModel = {
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { GraphQLError, type GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Args = {
   discussionId: string;
@@ -319,7 +320,7 @@ const getResolver = (input: Input) => {
         });
       }
     } catch (error) {
-      console.error("Error creating label change history:", error);
+      logger.error("Error creating label change history:", error);
       // Don't fail the label update if history creation fails
     }
 
@@ -348,7 +349,7 @@ const getResolver = (input: Input) => {
           input: [moderationActionInput],
         });
       } catch (error) {
-        console.error("Error creating moderation action:", error);
+        logger.error("Error creating moderation action:", error);
         // Don't fail the label update if moderation action creation fails
       }
     }

--- a/customResolvers/mutations/updateEventInSeries.ts
+++ b/customResolvers/mutations/updateEventInSeries.ts
@@ -10,6 +10,7 @@ import { createSeriesUpdateNotificationEmail } from "./shared/emailUtils.js";
 import { buildEventUpdateNotificationPayload } from "../../services/eventUpdateNotifications.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel, EventSeriesModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Event: EventModel;
@@ -385,7 +386,7 @@ const getResolver = (input: Input) => {
 
       return updatedEvent;
     } catch (error: unknown) {
-      console.error("Error updating event in series:", error);
+      logger.error("Error updating event in series:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to update event in series. ${message}`);
     } finally {

--- a/customResolvers/mutations/updateEventWithChannelConnections.ts
+++ b/customResolvers/mutations/updateEventWithChannelConnections.ts
@@ -7,6 +7,7 @@ import { createEventUpdateNotificationEmail } from "./shared/emailUtils.js";
 import { buildEventUpdateNotificationPayload } from "../../services/eventUpdateNotifications.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Event: EventModel;
@@ -222,7 +223,7 @@ const getResolver = (input: Input) => {
 
       return updatedEvent;
     } catch (error: unknown) {
-      console.error("Error updating event:", error);
+      logger.error("Error updating event:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to update event. ${message}`);
     } finally {

--- a/customResolvers/mutations/upvoteComment.ts
+++ b/customResolvers/mutations/upvoteComment.ts
@@ -4,6 +4,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { CommentModel, UserModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Comment: CommentModel;
@@ -162,16 +163,16 @@ const upvoteCommentResolver = (input: Input) => {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error("Failed to rollback transaction", rollbackError);
+          logger.error("Failed to rollback transaction", rollbackError);
         }
       }
-      console.error(e);
+      logger.error(e);
     } finally {
       if (session) {
         try {
           session.close();
         } catch (sessionCloseError) {
-          console.error("Failed to close session", sessionCloseError);
+          logger.error("Failed to close session", sessionCloseError);
         }
       }
     }

--- a/customResolvers/mutations/upvoteDiscussionChannel.ts
+++ b/customResolvers/mutations/upvoteDiscussionChannel.ts
@@ -4,6 +4,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { DiscussionChannelModel, UserModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   DiscussionChannel: DiscussionChannelModel;
@@ -154,16 +155,16 @@ const upvoteDiscussionChannelResolver = (input: Input) => {
         try {
           await tx.rollback();
         } catch (rollbackError) {
-          console.error("Failed to rollback transaction", rollbackError);
+          logger.error("Failed to rollback transaction", rollbackError);
         }
       }
-      console.error(e);
+      logger.error(e);
     } finally {
       if (session) {
         try {
           session.close();
         } catch (sessionCloseError) {
-          console.error("Failed to close session", sessionCloseError);
+          logger.error("Failed to close session", sessionCloseError);
         }
       }
     }

--- a/customResolvers/queries/getChannelContributions.ts
+++ b/customResolvers/queries/getChannelContributions.ts
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import type { Driver } from "neo4j-driver";
 import type { Record as Neo4jRecord } from "neo4j-driver";
 import type { ChannelModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 interface Input {
   Channel: ChannelModel;
@@ -45,7 +46,7 @@ const getChannelContributionsResolver = (input: Input) => {
         : (endDate || DateTime.now().toISODate());
 
       // Execute optimized Cypher query
-      console.log('Query parameters:', {
+      logger.info('Query parameters:', {
         channelUniqueName,
         startDate: effectiveStartDate,
         endDate: effectiveEndDate,
@@ -55,7 +56,7 @@ const getChannelContributionsResolver = (input: Input) => {
       // Debug: Test each step of the query
       const debugQuery1 = `MATCH (channel:Channel {uniqueName: $channelUniqueName}) RETURN channel.uniqueName`;
       const debug1 = await session.run(debugQuery1, { channelUniqueName });
-      console.log('Debug 1 - Channel found:', debug1.records.length > 0);
+      logger.info('Debug 1 - Channel found:', debug1.records.length > 0);
 
       const debugQuery2 = `
         MATCH (channel:Channel {uniqueName: $channelUniqueName})
@@ -63,7 +64,7 @@ const getChannelContributionsResolver = (input: Input) => {
         RETURN count(dc) as dcCount
       `;
       const debug2 = await session.run(debugQuery2, { channelUniqueName });
-      console.log('Debug 2 - DiscussionChannels found:', debug2.records[0]?.get('dcCount').toNumber());
+      logger.info('Debug 2 - DiscussionChannels found:', debug2.records[0]?.get('dcCount').toNumber());
 
       const debugQuery3 = `
         MATCH (channel:Channel {uniqueName: $channelUniqueName})
@@ -72,7 +73,7 @@ const getChannelContributionsResolver = (input: Input) => {
         RETURN count(d) as discussionCount
       `;
       const debug3 = await session.run(debugQuery3, { channelUniqueName });
-      console.log('Debug 3 - Discussions found via DiscussionChannel:', debug3.records[0]?.get('discussionCount').toNumber());
+      logger.info('Debug 3 - Discussions found via DiscussionChannel:', debug3.records[0]?.get('discussionCount').toNumber());
 
       const debugQuery4 = `
         MATCH (channel:Channel {uniqueName: $channelUniqueName})
@@ -82,7 +83,7 @@ const getChannelContributionsResolver = (input: Input) => {
         RETURN count(u) as userCount
       `;
       const debug4 = await session.run(debugQuery4, { channelUniqueName });
-      console.log('Debug 4 - Users found:', debug4.records[0]?.get('userCount').toNumber());
+      logger.info('Debug 4 - Users found:', debug4.records[0]?.get('userCount').toNumber());
 
       const debugQuery5 = `
         MATCH (channel:Channel {uniqueName: $channelUniqueName})
@@ -94,11 +95,11 @@ const getChannelContributionsResolver = (input: Input) => {
         LIMIT 5
       `;
       const debug5 = await session.run(debugQuery5, { channelUniqueName });
-      console.log('Debug 5 - Sample Discussion createdAt values:');
+      logger.info('Debug 5 - Sample Discussion createdAt values:');
       debug5.records.forEach((r: Neo4jRecord) => {
-        console.log('  - Raw:', r.get('createdAt'));
-        console.log('    Date:', r.get('dateOnly'));
-        console.log('    String:', r.get('createdAtString'));
+        logger.info('  - Raw:', r.get('createdAt'));
+        logger.info('    Date:', r.get('dateOnly'));
+        logger.info('    String:', r.get('createdAtString'));
       });
 
       const debugQuery6 = `
@@ -109,11 +110,11 @@ const getChannelContributionsResolver = (input: Input) => {
         startDate: effectiveStartDate,
         endDate: effectiveEndDate
       });
-      console.log('Debug 6 - Date parsing:');
-      console.log('  Start date string:', effectiveStartDate);
-      console.log('  Parsed start:', debug6.records[0]?.get('parsedStartDate'));
-      console.log('  End date string:', effectiveEndDate);
-      console.log('  Parsed end:', debug6.records[0]?.get('parsedEndDate'));
+      logger.info('Debug 6 - Date parsing:');
+      logger.info('  Start date string:', effectiveStartDate);
+      logger.info('  Parsed start:', debug6.records[0]?.get('parsedStartDate'));
+      logger.info('  End date string:', effectiveEndDate);
+      logger.info('  Parsed end:', debug6.records[0]?.get('parsedEndDate'));
 
       const debugQuery7 = `
         MATCH (channel:Channel {uniqueName: $channelUniqueName})
@@ -131,10 +132,10 @@ const getChannelContributionsResolver = (input: Input) => {
         startDate: effectiveStartDate,
         endDate: effectiveEndDate
       });
-      console.log('Debug 7 - Date comparisons:');
+      logger.info('Debug 7 - Date comparisons:');
       debug7.records.forEach((r: Neo4jRecord) => {
-        console.log('  Discussion:', r.get('discussionDate'), 'Start:', r.get('startDate'), 'End:', r.get('endDate'));
-        console.log('    After start?', r.get('afterStart'), 'Before end?', r.get('beforeEnd'));
+        logger.info('  Discussion:', r.get('discussionDate'), 'Start:', r.get('startDate'), 'End:', r.get('endDate'));
+        logger.info('    After start?', r.get('afterStart'), 'Before end?', r.get('beforeEnd'));
       });
 
       const result = await session.run(getChannelContributionsQuery, {
@@ -144,14 +145,14 @@ const getChannelContributionsResolver = (input: Input) => {
         limit: parseInt(String(limit || 10), 10),
       });
 
-      console.log('Query returned', result.records.length, 'records');
+      logger.info('Query returned', result.records.length, 'records');
 
       // Map results to UserContributionData format
       const contributions = result.records.map((record: Neo4jRecord) => {
         const dayData = record.get('dayData');
 
         // Log the dayData to debug null date issue
-        console.log('Raw dayData:', JSON.stringify(dayData, null, 2));
+        logger.info('Raw dayData:', JSON.stringify(dayData, null, 2));
 
         // Filter out any dayData entries with null dates
         const validDayData = Array.isArray(dayData)
@@ -172,7 +173,7 @@ const getChannelContributionsResolver = (input: Input) => {
       return contributions;
 
     } catch (error: unknown) {
-      console.error("Error fetching channel contributions:", error);
+      logger.error("Error fetching channel contributions:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to fetch contributions for channel ${channelUniqueName}: ${message}`);
     } finally {

--- a/customResolvers/queries/getCommentReplies.ts
+++ b/customResolvers/queries/getCommentReplies.ts
@@ -5,6 +5,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { CommentModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Comment: CommentModel;
@@ -79,7 +80,7 @@ const getResolver = (input: Input) => {
         aggregateChildCommentCount: aggregateCount || 0,
       };
     } catch (error: unknown) {
-      console.error("Error getting comment section:", error);
+      logger.error("Error getting comment section:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to fetch comment section. ${message}`);
     } finally {

--- a/customResolvers/queries/getCommentSection.ts
+++ b/customResolvers/queries/getCommentSection.ts
@@ -8,6 +8,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 const discussionChannelSelectionSet = `
 {
@@ -199,7 +200,7 @@ const getResolver = (input: Input) => {
         Comments: commentsResult
       }
     } catch (error: unknown) {
-      console.error('Error getting comment section:', error)
+      logger.error('Error getting comment section:', error)
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to fetch comment section. ${message}`)
     } finally {

--- a/customResolvers/queries/getDiscussionsInChannel.ts
+++ b/customResolvers/queries/getDiscussionsInChannel.ts
@@ -5,6 +5,7 @@ import { getDiscussionChannelsQuery } from "../cypher/cypherQueries.js";
 import { timeFrameOptions } from "./utils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 enum timeFrameOptionKeys {
   year = "year",
@@ -157,7 +158,7 @@ const getResolver = (input: Input) => {
           };
       }
     } catch (error: unknown) {
-      console.error("Error getting discussionChannels:", error);
+      logger.error("Error getting discussionChannels:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Failed to fetch discussionChannels in channel. ${message}`

--- a/customResolvers/queries/getEventComments.ts
+++ b/customResolvers/queries/getEventComments.ts
@@ -7,6 +7,7 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 const eventSelectionSet = `
   {
@@ -95,7 +96,7 @@ const getResolver = (input: Input) => {
         Comments: comments,
       };
     } catch (error: unknown) {
-      console.error("Error getting comment section:", error);
+      logger.error("Error getting comment section:", error);
       return {
         Event: null,
         Comments: []

--- a/customResolvers/queries/getInstalledPlugins.ts
+++ b/customResolvers/queries/getInstalledPlugins.ts
@@ -1,6 +1,7 @@
 import { Storage } from '@google-cloud/storage'
 import type { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../../types/context.js'
+import { logger } from "../../logger.js";
 import type {
   ServerConfigModel
 } from '../../ogm_types.js'
@@ -175,7 +176,7 @@ const getResolver = (input: Input) => {
           }
         } catch (error) {
           // Registry fetch failed - continue without version comparison
-          console.warn('Failed to fetch plugin registry for version comparison:', error instanceof Error ? error.message : String(error))
+          logger.warn('Failed to fetch plugin registry for version comparison:', error instanceof Error ? error.message : String(error))
         }
       }
 
@@ -238,7 +239,7 @@ const getResolver = (input: Input) => {
       return installedPlugins
 
     } catch (error) {
-      console.error('Error in getInstalledPlugins resolver:', error)
+      logger.error('Error in getInstalledPlugins resolver:', error)
       throw new Error(`Failed to get installed plugins: ${error instanceof Error ? error.message : String(error)}`)
     }
   }

--- a/customResolvers/queries/getModContributions.ts
+++ b/customResolvers/queries/getModContributions.ts
@@ -2,6 +2,7 @@ import { getModContributionsQuery } from "../cypher/cypherQueries.js";
 import { DateTime } from "luxon";
 import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import type { ModerationProfileModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 interface Input {
   ModerationProfile: ModerationProfileModel;
@@ -64,7 +65,7 @@ const getModContributionsResolver = (input: Input) => {
 
       return contributions;
     } catch (error: unknown) {
-      console.error("Error fetching mod contributions:", error);
+      logger.error("Error fetching mod contributions:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Failed to fetch contributions for mod ${displayName}: ${message}`

--- a/customResolvers/queries/getServerPluginSecrets.ts
+++ b/customResolvers/queries/getServerPluginSecrets.ts
@@ -1,5 +1,6 @@
 import type { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../../types/context.js'
+import { logger } from "../../logger.js";
 import type {
   ServerSecretModel
 } from '../../ogm_types.js'
@@ -41,7 +42,7 @@ const getResolver = (input: Input) => {
       }))
 
     } catch (error) {
-      console.error('Error in getServerPluginSecrets resolver:', error)
+      logger.error('Error in getServerPluginSecrets resolver:', error)
       throw new Error(`Failed to get server plugin secrets: ${error instanceof Error ? error.message : String(error)}`)
     }
   }

--- a/customResolvers/queries/getSiteWideDiscussionList.ts
+++ b/customResolvers/queries/getSiteWideDiscussionList.ts
@@ -4,6 +4,7 @@ import { getSiteWideDiscussionsQuery } from "../cypher/cypherQueries.js";
 import { timeFrameOptions } from "./utils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   Discussion: DiscussionModel;
@@ -161,7 +162,7 @@ const getResolver = (input: Input) => {
           };
       }
     } catch (error: unknown) {
-      console.error("Error getting discussions:", error);
+      logger.error("Error getting discussions:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to fetch discussions. ${message}`);
     } finally {

--- a/customResolvers/queries/getSiteWideWikiList.ts
+++ b/customResolvers/queries/getSiteWideWikiList.ts
@@ -1,5 +1,6 @@
 import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import { getSiteWideWikiPagesQuery } from "../cypher/cypherQueries.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   driver: Driver;
@@ -55,7 +56,7 @@ const getResolver = (input: Input) => {
         aggregateWikiPageCount: totalCount,
       };
     } catch (error: unknown) {
-      console.error("Error getting wiki pages:", error);
+      logger.error("Error getting wiki pages:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to fetch wiki pages. ${message}`);
     } finally {

--- a/customResolvers/queries/getSortedChannels.ts
+++ b/customResolvers/queries/getSortedChannels.ts
@@ -1,5 +1,6 @@
 import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   driver: Driver;
@@ -106,7 +107,7 @@ const getSortedChannelsResolver = (input: Input) => {
 
       return { channels, aggregateChannelCount };
     } catch (error) {
-      console.error("Error fetching sorted channels:", error);
+      logger.error("Error fetching sorted channels:", error);
       throw new Error("Failed to fetch sorted channels");
     } finally {
       await session.close();

--- a/customResolvers/queries/getUserContributions.ts
+++ b/customResolvers/queries/getUserContributions.ts
@@ -2,6 +2,7 @@ import { getUserContributionsQuery } from "../cypher/cypherQueries.js";
 import { DateTime } from "luxon";
 import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import type { UserModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 interface Input {
   User: UserModel;
@@ -68,7 +69,7 @@ const getUserContributionsResolver = (input: Input) => {
       return contributions;
 
     } catch (error: unknown) {
-      console.error("Error fetching user contributions:", error);
+      logger.error("Error fetching user contributions:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to fetch contributions for user ${username}: ${message}`);
     } finally {

--- a/customResolvers/queries/getUserFavoriteComment.ts
+++ b/customResolvers/queries/getUserFavoriteComment.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   driver: Driver;
@@ -44,7 +45,7 @@ const getResolver = (input: Input) => {
       const firstRecord = result.records[0];
       return firstRecord ? !!firstRecord.get("isFavorited") : false;
     } catch (error: unknown) {
-      console.error("Error checking favorite comment:", error);
+      logger.error("Error checking favorite comment:", error);
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to check favorite comment. ${message}`);
     } finally {

--- a/customResolvers/queries/publicCollectionsContaining.ts
+++ b/customResolvers/queries/publicCollectionsContaining.ts
@@ -2,6 +2,7 @@ import type { Driver } from "neo4j-driver";
 import type { Ogm } from "../../types/context.js";
 import { SortDirection } from "../../src/generated/graphql.js";
 import type { CollectionWhere } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 type Input = {
   driver: Driver;
@@ -108,7 +109,7 @@ const publicCollectionsContaining = ({ ogm }: Input) => {
 
       return collections;
     } catch (error) {
-      console.error("Error fetching public collections containing item:", {
+      logger.error("Error fetching public collections containing item:", {
         itemId,
         itemType,
         error,

--- a/errorHandling.ts
+++ b/errorHandling.ts
@@ -5,6 +5,7 @@
 
 import { GraphQLError, GraphQLFormattedError } from 'graphql';
 import type { SourceLocation } from 'graphql';
+import { logger } from "./logger.js";
 
 interface ErrorRequest {
   headers?: Record<string, string | string[] | undefined>;
@@ -50,7 +51,7 @@ export function formatGraphQLError(error: EnhancedError, context?: ErrorContext)
   const errorId = `err_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
   // Comprehensive error logging
-  console.error('🚨 GraphQL Error Details:', {
+  logger.error('🚨 GraphQL Error Details:', {
     errorId,
     timestamp,
     message,
@@ -71,11 +72,11 @@ export function formatGraphQLError(error: EnhancedError, context?: ErrorContext)
 
   // Log the full query for validation errors (most common debugging need)
   if (isValidationError(errorCode) && context?.query) {
-    console.error('📝 Full Query that caused validation error:');
-    console.error(context.query);
+    logger.error('📝 Full Query that caused validation error:');
+    logger.error(context.query);
     if (context.variables) {
-      console.error('📝 Variables:');
-      console.error(JSON.stringify(context.variables, null, 2));
+      logger.error('📝 Variables:');
+      logger.error(JSON.stringify(context.variables, null, 2));
     }
   }
 
@@ -204,7 +205,7 @@ function truncateQuery(query: string, maxLength: number = 1000): string {
  * Log critical errors for monitoring
  */
 export function logCriticalError(error: Error, context?: Record<string, unknown>): void {
-  console.error('🔥 CRITICAL ERROR:', {
+  logger.error('🔥 CRITICAL ERROR:', {
     timestamp: new Date().toISOString(),
     message: error.message,
     stack: error.stack,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,39 @@
+// Flat ESLint config (ESLint 9+).
+//
+// Intentionally minimal: this is not a full style ruleset. Its sole job is to
+// keep `console.*` out of server runtime code so logging stays structured and
+// leveled (see logger.ts). Use the `logger` instead.
+//
+// Scripts (build_scripts/) and tests keep `console` — it's fine there.
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "node_modules/**",
+      "ts_emitted/**",
+      "src/generated/**",
+      "ogm_types.ts",
+      "schema.introspection.json",
+      "eslint.config.js",
+    ],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    rules: {
+      "no-console": "error",
+    },
+  },
+  {
+    // console is acceptable in one-off scripts and tests.
+    files: ["build_scripts/**", "tests/**", "**/*.test.ts"],
+    rules: {
+      "no-console": "off",
+    },
+  }
+);

--- a/hooks/archivedContentNotificationHook.ts
+++ b/hooks/archivedContentNotificationHook.ts
@@ -1,6 +1,7 @@
 import { createInAppNotification } from './notificationHelpers.js';
 import type { Driver } from 'neo4j-driver';
 import type { Ogm } from '../types/context.js';
+import { logger } from "../logger.js";
 
 type ContentType = 'comment' | 'discussion' | 'event' | 'image';
 
@@ -93,7 +94,7 @@ export async function notifyArchivedContentAuthor(
 
     const UserModel = context.ogm?.model('User');
     if (!UserModel) {
-      console.error('UserModel not available for archived content notification');
+      logger.error('UserModel not available for archived content notification');
       return false;
     }
 
@@ -121,7 +122,7 @@ export async function notifyArchivedContentAuthor(
       notificationType: 'moderation',
     });
   } catch (error) {
-    console.error('Error sending archived content notification:', error);
+    logger.error('Error sending archived content notification:', error);
     return false;
   }
 }

--- a/hooks/commentVersionHistoryHook.ts
+++ b/hooks/commentVersionHistoryHook.ts
@@ -13,6 +13,7 @@ import type {
 } from '../ogm_types.js';
 import type { TextVersionCreateInput } from '../src/generated/graphql.js';
 import type { CommentSnapshot } from '../utils/buildCommentMentionContext.js';
+import { logger } from "../logger.js";
 
 type VersionHistoryHandlerInput = {
   context: GraphQLContext;
@@ -30,7 +31,7 @@ export const commentVersionHistoryHandler = async ({
   commentSnapshot,
 }: VersionHistoryHandlerInput) => {
   try {
-    console.log('Comment version history hook running...');
+    logger.info('Comment version history hook running...');
     
     // Extract parameters from the update operation
     const { where, update } = params;
@@ -38,7 +39,7 @@ export const commentVersionHistoryHandler = async ({
     
     // Make sure we have a comment ID and update data
     if (!commentId || !update) {
-      console.log('Missing comment ID or update data');
+      logger.info('Missing comment ID or update data');
       return;
     }
     
@@ -47,11 +48,11 @@ export const commentVersionHistoryHandler = async ({
     
     // If text is not being updated, skip version tracking
     if (!isTextUpdated) {
-      console.log('No text updates detected, skipping version history');
+      logger.info('No text updates detected, skipping version history');
       return;
     }
     
-    console.log('Processing version history for comment:', commentId);
+    logger.info('Processing version history for comment:', commentId);
     
     // Access OGM models
     const { ogm } = context;
@@ -104,7 +105,7 @@ export const commentVersionHistoryHandler = async ({
       });
 
       if (!comments.length) {
-        console.log('Comment not found');
+        logger.info('Comment not found');
         return;
       }
 
@@ -114,7 +115,7 @@ export const commentVersionHistoryHandler = async ({
     // Get the username from CommentAuthor which can be either User or ModerationProfile
     const commentAuthor = comment.CommentAuthor;
     if (!commentAuthor) {
-      console.log('Comment author information not found');
+      logger.info('Comment author information not found');
       return;
     }
 
@@ -187,10 +188,10 @@ export const commentVersionHistoryHandler = async ({
         commentId,
       });
     } else {
-      console.log('No text changes to track or current text is empty');
+      logger.info('No text changes to track or current text is empty');
     }
   } catch (error) {
-    console.error('Error in comment version history hook:', error);
+    logger.error('Error in comment version history hook:', error);
     // Don't re-throw the error, so we don't affect the mutation
   }
 };
@@ -206,14 +207,14 @@ async function trackTextVersionHistory(
   TextVersionModel: TextVersionModel,
   UserModel: UserModel
 ) {
-  console.log(
+  logger.info(
     `Tracking text version history for comment ${commentId} by user ${username ?? '[unknown]'}`
   );
 
   try {
     // Skip tracking if new text is null or empty
     if (!newText) {
-      console.log('New text is empty, skipping version history');
+      logger.info('New text is empty, skipping version history');
       return;
     }
 
@@ -241,7 +242,7 @@ async function trackTextVersionHistory(
     });
 
     if (!textVersionResult.textVersions.length) {
-      console.log('Failed to create TextVersion');
+      logger.info('Failed to create TextVersion');
       return;
     }
 
@@ -256,7 +257,7 @@ async function trackTextVersionHistory(
     });
 
     if (!comments.length) {
-      console.log('Comment not found when updating version order');
+      logger.info('Comment not found when updating version order');
       return;
     }
 
@@ -275,8 +276,8 @@ async function trackTextVersionHistory(
       } as unknown as CommentUpdateInput
     });
 
-    console.log(`Successfully added text version history for comment ${commentId}`);
+    logger.info(`Successfully added text version history for comment ${commentId}`);
   } catch (error) {
-    console.error('Error tracking text version history:', error);
+    logger.error('Error tracking text version history:', error);
   }
 }

--- a/hooks/discussionVersionHistoryHook.ts
+++ b/hooks/discussionVersionHistoryHook.ts
@@ -6,6 +6,7 @@ import {
 } from './issueActivityFeedHelpers.js';
 import { createInAppNotification } from './notificationHelpers.js';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 import type {
   DiscussionModel,
   DiscussionUpdateInput,
@@ -43,7 +44,7 @@ export const discussionVersionHistoryHandler = async ({
   discussionSnapshot,
 }: DiscussionVersionHistoryHandlerInput) => {
   try {
-    console.log('Discussion version history hook running...');
+    logger.info('Discussion version history hook running...');
     
     // Extract parameters from the update operation
     const { where, update } = params;
@@ -51,7 +52,7 @@ export const discussionVersionHistoryHandler = async ({
     
     // Make sure we have a discussion ID and update data
     if (!discussionId || !update) {
-      console.log('Missing discussion ID or update data');
+      logger.info('Missing discussion ID or update data');
       return;
     }
     
@@ -63,11 +64,11 @@ export const discussionVersionHistoryHandler = async ({
     
     // If neither title nor body is being updated, skip version tracking
     if (!isTitleUpdated && !isBodyUpdated) {
-      console.log('No title or body updates detected, skipping version history');
+      logger.info('No title or body updates detected, skipping version history');
       return;
     }
     
-    console.log('Processing version history for discussion:', discussionId);
+    logger.info('Processing version history for discussion:', discussionId);
     
     // Access OGM models
     const { ogm } = context;
@@ -109,7 +110,7 @@ export const discussionVersionHistoryHandler = async ({
       });
 
       if (!discussions.length) {
-        console.log('Discussion not found');
+        logger.info('Discussion not found');
         return;
       }
 
@@ -127,7 +128,7 @@ export const discussionVersionHistoryHandler = async ({
     const titleEditor = editorUsername || discussion.Author?.username;
 
     if (!titleEditor) {
-      console.log('Author username not found');
+      logger.info('Author username not found');
       return;
     }
 
@@ -205,7 +206,7 @@ export const discussionVersionHistoryHandler = async ({
       });
     }
   } catch (error) {
-    console.error('Error in discussion version history hook:', error);
+    logger.error('Error in discussion version history hook:', error);
     // Don't re-throw the error, so we don't affect the mutation
   }
 };
@@ -259,7 +260,7 @@ export const discussionEditNotificationHandler = async ({
       text: notificationText,
     });
   } catch (error) {
-    console.error('Error in discussion edit notification hook:', error);
+    logger.error('Error in discussion edit notification hook:', error);
   }
 };
 
@@ -274,8 +275,8 @@ async function trackTitleVersionHistory(
   TextVersionModel: TextVersionModel,
   UserModel: UserModel
 ): Promise<string | null> {
-  console.log(`Tracking title version history for discussion ${discussionId}`);
-  console.log(`Previous title: "${previousTitle}"`);
+  logger.info(`Tracking title version history for discussion ${discussionId}`);
+  logger.info(`Previous title: "${previousTitle}"`);
 
   try {
     // Get user by username
@@ -285,7 +286,7 @@ async function trackTitleVersionHistory(
     });
 
     if (!users.length) {
-      console.log('User not found');
+      logger.info('User not found');
       return null;
     }
 
@@ -301,7 +302,7 @@ async function trackTitleVersionHistory(
     });
 
     if (!textVersionResult.textVersions.length) {
-      console.log('Failed to create TextVersion');
+      logger.info('Failed to create TextVersion');
       return null;
     }
 
@@ -316,7 +317,7 @@ async function trackTitleVersionHistory(
     });
 
     if (!discussions.length) {
-      console.log('Discussion not found when updating version order');
+      logger.info('Discussion not found when updating version order');
       return null;
     }
     
@@ -334,10 +335,10 @@ async function trackTitleVersionHistory(
       } as unknown as DiscussionUpdateInput
     });
 
-    console.log(`Successfully added title version history for discussion ${discussionId}`);
+    logger.info(`Successfully added title version history for discussion ${discussionId}`);
     return textVersionId;
   } catch (error) {
-    console.error('Error tracking title version history:', error);
+    logger.error('Error tracking title version history:', error);
     return null;
   }
 }
@@ -353,7 +354,7 @@ async function trackBodyVersionHistory(
   TextVersionModel: TextVersionModel,
   UserModel: UserModel
 ): Promise<string | null> {
-  console.log(`Tracking body version history for discussion ${discussionId}`);
+  logger.info(`Tracking body version history for discussion ${discussionId}`);
 
   try {
     // Normalize null/undefined to empty string - we want to track edits
@@ -368,7 +369,7 @@ async function trackBodyVersionHistory(
     });
 
     if (!users.length) {
-      console.log('User not found');
+      logger.info('User not found');
       return null;
     }
 
@@ -384,7 +385,7 @@ async function trackBodyVersionHistory(
     });
 
     if (!textVersionResult.textVersions.length) {
-      console.log('Failed to create TextVersion');
+      logger.info('Failed to create TextVersion');
       return null;
     }
 
@@ -399,7 +400,7 @@ async function trackBodyVersionHistory(
     });
 
     if (!discussions.length) {
-      console.log('Discussion not found when updating version order');
+      logger.info('Discussion not found when updating version order');
       return null;
     }
 
@@ -417,10 +418,10 @@ async function trackBodyVersionHistory(
       } as unknown as DiscussionUpdateInput
     });
 
-    console.log(`Successfully added body version history for discussion ${discussionId}`);
+    logger.info(`Successfully added body version history for discussion ${discussionId}`);
     return textVersionId;
   } catch (error) {
-    console.error('Error tracking body version history:', error);
+    logger.error('Error tracking body version history:', error);
     return null;
   }
 }

--- a/hooks/feedbackNotificationHook.ts
+++ b/hooks/feedbackNotificationHook.ts
@@ -1,5 +1,6 @@
 import { createInAppNotification } from './notificationHelpers.js';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 
 type FeedbackContext = {
   feedbackCommentId: string;
@@ -30,7 +31,7 @@ export const notifyFeedback = async ({
   try {
     const UserModel = context?.ogm?.model('User');
     if (!UserModel) {
-      console.error('UserModel not available for feedback notification');
+      logger.error('UserModel not available for feedback notification');
       return;
     }
 
@@ -72,7 +73,7 @@ export const notifyFeedback = async ({
       notificationType: 'feedback',
     });
   } catch (error) {
-    console.error('Error sending feedback notification:', error);
+    logger.error('Error sending feedback notification:', error);
   }
 };
 

--- a/hooks/issueActivityFeedHelpers.ts
+++ b/hooks/issueActivityFeedHelpers.ts
@@ -27,6 +27,7 @@ type IssueActivityInput = {
 };
 
 import { notifyIssueSubscribers } from "../services/issueNotifications.js";
+import { logger } from "../logger.js";
 
 export const getAttributionFromContext = (context: GraphQLContext): ActivityAttribution => {
   return {
@@ -66,7 +67,7 @@ export const getIssueIdsForRelated = async (
       .map((issue: { id?: string }) => issue.id)
       .filter((id): id is string => Boolean(id));
   } catch (error) {
-    console.error('Error fetching related issues:', error);
+    logger.error('Error fetching related issues:', error);
     return [];
   }
 };
@@ -173,7 +174,7 @@ export const createIssueActivityFeedItems = async (
         });
       }
     } catch (error) {
-      console.error('Error creating issue activity feed item:', error);
+      logger.error('Error creating issue activity feed item:', error);
     }
   }
 };

--- a/hooks/modMentionNotificationHook.ts
+++ b/hooks/modMentionNotificationHook.ts
@@ -1,6 +1,7 @@
 import { createInAppNotification } from './notificationHelpers.js';
 import type { GraphQLContext } from '../types/context.js';
 import type { Record as Neo4jRecord } from 'neo4j-driver';
+import { logger } from "../logger.js";
 
 // Regex to match /m/modProfileName mentions
 const MOD_MENTION_REGEX = /\/m\/([a-zA-Z0-9_-]+)/g;
@@ -196,6 +197,6 @@ export const notifyModMentions = async ({
       });
     }
   } catch (error) {
-    console.error('Error sending mod mention notifications:', error);
+    logger.error('Error sending mod mention notifications:', error);
   }
 };

--- a/hooks/notificationHelpers.ts
+++ b/hooks/notificationHelpers.ts
@@ -1,4 +1,5 @@
 import type { UserModel } from '../ogm_types.js';
+import { logger } from "../logger.js";
 
 type CreateInAppNotificationInput = {
   UserModel: UserModel;
@@ -35,7 +36,7 @@ export const createInAppNotification = async ({
 
     return Boolean(userUpdateResult?.users?.length);
   } catch (error) {
-    console.error('Error creating in-app notification:', error);
+    logger.error('Error creating in-app notification:', error);
     return false;
   }
 };

--- a/hooks/userMentionNotificationHook.ts
+++ b/hooks/userMentionNotificationHook.ts
@@ -1,6 +1,7 @@
 import { createInAppNotification } from './notificationHelpers.js';
 import { getNewMentionUsernames } from '../utils/getNewMentionUsernames.js';
 import { sendEmail } from '../services/mail/index.js';
+import { logger } from "../logger.js";
 import {
   buildDiscussionMentionContext,
   MentionContextDiscussion,
@@ -282,6 +283,6 @@ export const notifyNewUserMentions = async ({
       }
     }
   } catch (error) {
-    console.error('Error sending user mention notifications:', error);
+    logger.error('Error sending user mention notifications:', error);
   }
 };

--- a/hooks/wikiPageVersionHistoryHook.ts
+++ b/hooks/wikiPageVersionHistoryHook.ts
@@ -1,5 +1,6 @@
 import type { TextVersionCreateInput } from "../src/generated/graphql.js";
 import type { GraphQLContext } from "../types/context.js";
+import { logger } from "../logger.js";
 import type {
   WikiPageModel,
   WikiPageUpdateInput,
@@ -21,7 +22,7 @@ type WikiPageVersionHistoryHandlerInput = {
  */
 export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPageVersionHistoryHandlerInput) => {
   try {
-    console.log('WikiPage version history hook running...');
+    logger.info('WikiPage version history hook running...');
     
     // Extract parameters from the update operation
     const { where, update } = params;
@@ -29,7 +30,7 @@ export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPag
     
     // Make sure we have a wikiPage ID and update data
     if (!wikiPageId || !update) {
-      console.log('Missing wikiPage ID or update data');
+      logger.info('Missing wikiPage ID or update data');
       return;
     }
     
@@ -39,11 +40,11 @@ export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPag
     
     // If neither title nor body is being updated, skip version tracking
     if (!isTitleUpdated && !isBodyUpdated) {
-      console.log('No title or body updates detected, skipping version history');
+      logger.info('No title or body updates detected, skipping version history');
       return;
     }
     
-    console.log('Processing version history for wikiPage:', wikiPageId);
+    logger.info('Processing version history for wikiPage:', wikiPageId);
     
     // Access OGM models
     const { ogm } = context;
@@ -71,7 +72,7 @@ export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPag
     });
 
     if (!wikiPages.length) {
-      console.log('WikiPage not found');
+      logger.info('WikiPage not found');
       return;
     }
 
@@ -79,7 +80,7 @@ export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPag
     const username = wikiPage.VersionAuthor?.username;
     
     if (!username) {
-      console.log('Author username not found');
+      logger.info('Author username not found');
       return;
     }
     
@@ -109,7 +110,7 @@ export const wikiPageVersionHistoryHandler = async ({ context, params }: WikiPag
       );
     }
   } catch (error) {
-    console.error('Error in wikiPage version history hook:', error);
+    logger.error('Error in wikiPage version history hook:', error);
     // Don't re-throw the error, so we don't affect the mutation
   }
 };
@@ -126,12 +127,12 @@ async function trackVersionHistory(
   TextVersionModel: TextVersionModel,
   UserModel: UserModel
 ) {
-  console.log(`Tracking version history for wikiPage ${wikiPageId}`);
+  logger.info(`Tracking version history for wikiPage ${wikiPageId}`);
 
   try {
     // Skip tracking if previous content is null or empty
     if (!previousContent) {
-      console.log('Previous content is empty, skipping version history');
+      logger.info('Previous content is empty, skipping version history');
       return;
     }
 
@@ -142,7 +143,7 @@ async function trackVersionHistory(
     });
 
     if (!users.length) {
-      console.log('User not found');
+      logger.info('User not found');
       return;
     }
 
@@ -164,7 +165,7 @@ async function trackVersionHistory(
     });
 
     if (!textVersionResult.textVersions.length) {
-      console.log('Failed to create TextVersion');
+      logger.info('Failed to create TextVersion');
       return;
     }
 
@@ -179,7 +180,7 @@ async function trackVersionHistory(
     });
 
     if (!wikiPages.length) {
-      console.log('WikiPage not found when updating version history');
+      logger.info('WikiPage not found when updating version history');
       return;
     }
 
@@ -197,8 +198,8 @@ async function trackVersionHistory(
       } as unknown as WikiPageUpdateInput
     });
 
-    console.log(`Successfully added version history for wikiPage ${wikiPageId}`);
+    logger.info(`Successfully added version history for wikiPage ${wikiPageId}`);
   } catch (error) {
-    console.error('Error tracking version history:', error);
+    logger.error('Error tracking version history:', error);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -40,20 +40,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config();
 
 import neo4j, { Driver } from "neo4j-driver";
+import { randomUUID } from "node:crypto";
+import { logger, runWithContext, enrichContext } from "./logger.js";
 
 async function connectToNeo4jWithRetry(driver: Driver, maxRetries = 10, retryDelay = 5000) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      console.log(`🔌 Attempting to connect to Neo4j (Attempt ${attempt}/${maxRetries})...`);
+      logger.info(`🔌 Attempting to connect to Neo4j (Attempt ${attempt}/${maxRetries})...`);
       const session = driver.session();
       await session.run("RETURN 1");
-      console.log("✅ Connected to Neo4j!");
+      logger.info("✅ Connected to Neo4j!");
       session.close();
       return; // Exit loop on successful connection
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const errorStack = error instanceof Error ? error.stack : undefined;
-      console.error(`❌ Neo4j connection attempt ${attempt} failed:`, {
+      logger.error(`❌ Neo4j connection attempt ${attempt} failed:`, {
         attempt,
         maxRetries,
         error: errorMessage,
@@ -70,7 +72,7 @@ async function connectToNeo4jWithRetry(driver: Driver, maxRetries = 10, retryDel
         });
         throw criticalError;
       }
-      console.log(`⏳ Retrying in ${retryDelay / 1000} seconds...`);
+      logger.info(`⏳ Retrying in ${retryDelay / 1000} seconds...`);
       await new Promise((resolve) => setTimeout(resolve, retryDelay));
     }
   }
@@ -85,16 +87,16 @@ if (process.env.GOOGLE_CREDENTIALS_BASE64) {
 
 const sendSlackNotification = async (text: string) => {
   if (!process.env.SLACK_WEBHOOK_URL) {
-    console.error("SLACK_WEBHOOK_URL environment variable is not set");
+    logger.error("SLACK_WEBHOOK_URL environment variable is not set");
     return;
   }
   try {
     await axios.post(process.env.SLACK_WEBHOOK_URL, {
       text: text,
     });
-    console.log("Slack notification sent successfully");
+    logger.info("Slack notification sent successfully");
   } catch (error) {
-    console.error("Error sending Slack notification:", error);
+    logger.error("Error sending Slack notification:", error);
   }
 };
 
@@ -167,14 +169,14 @@ REQUIRE (i.channelUniqueName, i.relatedWikiPageId, i.relatedWikiRevisionId) IS U
 
 async function initializeServer() {
   try {
-    console.log("🚀 Initializing server...");
+    logger.info("🚀 Initializing server...");
 
     await connectToNeo4jWithRetry(driver);
 
     const session = driver.session();
     const result = await session.run("CALL dbms.components()");
     const edition = result.records[0].get("edition");
-    console.log(`✅ Connected to Neo4j Edition: ${edition}`);
+    logger.info(`✅ Connected to Neo4j Edition: ${edition}`);
     session.close();
 
     if (edition === "enterprise") {
@@ -227,6 +229,12 @@ async function initializeServer() {
 
     await server.start();
 
+    // Bind a correlation id to every request so all log lines emitted while
+    // handling it can be traced back to the same operation.
+    app.use((req, _res, next) => {
+      runWithContext({ requestId: randomUUID() }, () => next());
+    });
+
     app.use(
       "/",
       cors<cors.CorsRequest>({
@@ -242,8 +250,10 @@ async function initializeServer() {
           // Add this information to the context so it can be used by permission rules
           (req as GraphQLRequest).isMutation = isMutation;
 
+          enrichContext({ operationName: req.body.operationName || undefined });
+
           if (!queryString.includes("IntrospectionQuery")) {
-            console.log('📊 GraphQL Operation:', {
+            logger.info('📊 GraphQL Operation:', {
               type: isMutation ? 'Mutation' : 'Query',
               operationName: req.body.operationName || 'Anonymous',
               query: req.body.query,
@@ -273,14 +283,14 @@ async function initializeServer() {
     );
 
     const url = `http://localhost:${port}/`;
-    console.log(`🚀 Server ready at ${url}`);
-    console.log(`📊 GraphQL endpoint available at ${url}`);
-    console.log(`🔧 Environment: ${process.env.NODE_ENV || 'development'}`);
+    logger.info(`🚀 Server ready at ${url}`);
+    logger.info(`📊 GraphQL endpoint available at ${url}`);
+    logger.info(`🔧 Environment: ${process.env.NODE_ENV || 'development'}`);
 
     // Start services with enhanced error handling
     startBackgroundServices(schema, ogm);
   } catch (e) {
-    console.error("💥 Failed to initialize server:", e);
+    logger.error("💥 Failed to initialize server:", e);
     logCriticalError(e as Error, {
       service: 'Server Initialization',
       step: 'initializeServer'
@@ -318,12 +328,12 @@ async function startBackgroundServices(schema: GraphQLSchema, ogm: Ogm) {
 
   for (const { name, service, critical } of services) {
     try {
-      console.log(`🔄 Starting ${name}...`);
+      logger.info(`🔄 Starting ${name}...`);
       const serviceInstance = service();
       await serviceInstance.start();
-      console.log(`✅ ${name} started successfully`);
+      logger.info(`✅ ${name} started successfully`);
     } catch (error) {
-      console.error(`❌ Failed to start ${name}:`, error);
+      logger.error(`❌ Failed to start ${name}:`, error);
       
       if (critical) {
         logCriticalError(error as Error, {
@@ -333,7 +343,7 @@ async function startBackgroundServices(schema: GraphQLSchema, ogm: Ogm) {
         throw error; // Stop server if critical service fails
       } else {
         // Log non-critical service failures but continue
-        console.warn(`⚠️  ${name} failed to start but server will continue`);
+        logger.warn(`⚠️  ${name} failed to start but server will continue`);
       }
     }
   }

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,156 @@
+/**
+ * Lightweight structured logger.
+ *
+ * Drop-in replacement for `console.*` across the server: the methods take the
+ * same `(message, ...rest)` arguments, so call sites read the same. On top of
+ * that it adds the things a production GraphQL server needs and `console` lacks:
+ *
+ *   - Levels (`debug` < `info` < `warn` < `error`) with a runtime threshold so
+ *     noisy logs can be silenced in production via the `LOG_LEVEL` env var.
+ *   - Structured JSON output (one object per line) when `LOG_FORMAT=json` or
+ *     `NODE_ENV=production`, so logs are machine-parseable. Human-friendly
+ *     coloured output otherwise.
+ *   - Request correlation: any fields stashed in the AsyncLocalStorage context
+ *     (e.g. a `requestId`) are merged into every log line emitted while handling
+ *     that request. See `runWithContext` / `enrichContext` below.
+ *
+ * No external dependencies — intentionally small so it can be swapped for pino
+ * or similar later without touching call sites.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { inspect } from "node:util";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export interface LogContext {
+  /** Correlates every log line emitted while handling a single request. */
+  requestId?: string;
+  /** GraphQL operation name, when known. */
+  operationName?: string;
+  [key: string]: unknown;
+}
+
+const contextStorage = new AsyncLocalStorage<LogContext>();
+
+/**
+ * Run `fn` with the given logging context bound for its entire async lifetime.
+ * Every log emitted inside (including from awaited continuations) carries the
+ * context fields. Used by the request middleware to attach a `requestId`.
+ */
+export function runWithContext<T>(context: LogContext, fn: () => T): T {
+  return contextStorage.run(context, fn);
+}
+
+/**
+ * Merge additional fields into the current request's logging context, if one is
+ * active. No-op outside a `runWithContext` scope.
+ */
+export function enrichContext(fields: LogContext): void {
+  const store = contextStorage.getStore();
+  if (store) Object.assign(store, fields);
+}
+
+function resolveThreshold(): number {
+  const fromEnv = process.env.LOG_LEVEL?.toLowerCase();
+  if (fromEnv && fromEnv in LEVEL_PRIORITY) {
+    return LEVEL_PRIORITY[fromEnv as LogLevel];
+  }
+  return process.env.NODE_ENV === "production"
+    ? LEVEL_PRIORITY.info
+    : LEVEL_PRIORITY.debug;
+}
+
+let threshold = resolveThreshold();
+
+/** Override the active log level (mainly for tests). */
+export function setLogLevel(level: LogLevel): void {
+  threshold = LEVEL_PRIORITY[level];
+}
+
+const useJson =
+  process.env.LOG_FORMAT === "json" || process.env.NODE_ENV === "production";
+
+const useColor = !useJson && process.stdout.isTTY === true;
+
+const COLORS: Record<LogLevel, string> = {
+  debug: "\x1b[90m", // gray
+  info: "\x1b[36m", // cyan
+  warn: "\x1b[33m", // yellow
+  error: "\x1b[31m", // red
+};
+const RESET = "\x1b[0m";
+
+function serializeArg(arg: unknown): unknown {
+  if (arg instanceof Error) {
+    return { name: arg.name, message: arg.message, stack: arg.stack };
+  }
+  return arg;
+}
+
+export interface Logger {
+  debug(message: unknown, ...rest: unknown[]): void;
+  info(message: unknown, ...rest: unknown[]): void;
+  warn(message: unknown, ...rest: unknown[]): void;
+  error(message: unknown, ...rest: unknown[]): void;
+  /** Returns a logger that always includes `bindings` in its output. */
+  child(bindings: LogContext): Logger;
+}
+
+function emit(level: LogLevel, bindings: LogContext, args: unknown[]): void {
+  if (LEVEL_PRIORITY[level] < threshold) return;
+
+  const context: LogContext = { ...contextStorage.getStore(), ...bindings };
+  const [first, ...rest] = args;
+  const message = typeof first === "string" ? first : undefined;
+  const extras = (message === undefined ? args : rest).map(serializeArg);
+
+  const stream =
+    level === "error" || level === "warn" ? process.stderr : process.stdout;
+
+  if (useJson) {
+    const record: Record<string, unknown> = {
+      level,
+      time: new Date().toISOString(),
+      ...context,
+    };
+    if (message !== undefined) record.msg = message;
+    if (extras.length === 1) record.details = extras[0];
+    else if (extras.length > 1) record.details = extras;
+    stream.write(JSON.stringify(record) + "\n");
+    return;
+  }
+
+  // Human-readable output for local development.
+  const time = new Date().toISOString();
+  const label = useColor ? `${COLORS[level]}${level.toUpperCase()}${RESET}` : level.toUpperCase();
+  const ctxStr = Object.keys(context).length
+    ? " " + inspect(context, { colors: useColor, depth: 4 })
+    : "";
+  const head = `${time} ${label}${ctxStr}${message !== undefined ? " " + message : ""}`;
+  const tail = extras
+    .map((e) => (typeof e === "string" ? e : inspect(e, { colors: useColor, depth: 4 })))
+    .join(" ");
+  stream.write(tail ? `${head} ${tail}\n` : `${head}\n`);
+}
+
+function createLogger(bindings: LogContext = {}): Logger {
+  return {
+    debug: (message, ...rest) => emit("debug", bindings, [message, ...rest]),
+    info: (message, ...rest) => emit("info", bindings, [message, ...rest]),
+    warn: (message, ...rest) => emit("warn", bindings, [message, ...rest]),
+    error: (message, ...rest) => emit("error", bindings, [message, ...rest]),
+    child: (childBindings) => createLogger({ ...bindings, ...childBindings }),
+  };
+}
+
+export const logger: Logger = createLogger();
+
+export default logger;

--- a/middleware/channelBotsMiddleware.ts
+++ b/middleware/channelBotsMiddleware.ts
@@ -7,6 +7,7 @@ import {
 } from '../services/botUserService.js';
 import { mergeSettings } from '../services/plugin/pipelineUtils.js';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 
 interface UpdateChannelsArgs {
   where?: { uniqueName?: string; [key: string]: unknown };
@@ -191,7 +192,7 @@ async function syncBotsForChannel(result: UpdateChannelsResult, args: UpdateChan
         channelSettingsWrapped
       );
 
-      console.log('🧩 Bot plugin settings (channel middleware)', {
+      logger.info('🧩 Bot plugin settings (channel middleware)', {
         channelUniqueName,
         pluginName,
         settingsDefaults: JSON.stringify(settingsDefaults || null),
@@ -202,7 +203,7 @@ async function syncBotsForChannel(result: UpdateChannelsResult, args: UpdateChan
 
       const botName = getBotNameFromSettings(mergedSettings);
       if (!botName) {
-        console.warn('⚠️ Bot plugin has no botName in merged settings', {
+        logger.warn('⚠️ Bot plugin has no botName in merged settings', {
           channelUniqueName,
           pluginName,
           mergedSettings: JSON.stringify(mergedSettings || null)
@@ -238,7 +239,7 @@ async function syncBotsForChannel(result: UpdateChannelsResult, args: UpdateChan
     );
 
     if (botsToDisconnect.length > 0) {
-      console.log('🧹 Marking orphaned bots as deprecated and disconnecting from channel', {
+      logger.info('🧹 Marking orphaned bots as deprecated and disconnecting from channel', {
         channelUniqueName,
         botsToDisconnect,
         desiredBots: Array.from(allDesiredBotUsernames)
@@ -266,7 +267,7 @@ async function syncBotsForChannel(result: UpdateChannelsResult, args: UpdateChan
       });
     }
   } catch (error) {
-    console.warn(
+    logger.warn(
       'Failed to sync bot users after channel plugin update:',
       error instanceof Error ? error.message : error
     );

--- a/middleware/channelCreatorModeratorMiddleware.ts
+++ b/middleware/channelCreatorModeratorMiddleware.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql';
 import type { GraphQLContext } from '../types/context.js';
 import type { ChannelCreateInput } from '../ogm_types.js';
+import { logger } from "../logger.js";
 import {
   setUserDataOnContext,
   type AuthContextForUserLookup,
@@ -39,7 +40,7 @@ const channelCreatorModeratorMiddleware = {
         });
 
         if (!userData?.username) {
-          console.warn('⚠️ No logged-in user found for channel creation, skipping moderator assignment');
+          logger.warn('⚠️ No logged-in user found for channel creation, skipping moderator assignment');
           return result;
         }
 
@@ -56,7 +57,7 @@ const channelCreatorModeratorMiddleware = {
         const displayName = userWithProfile[0]?.ModerationProfile?.displayName;
 
         if (!displayName) {
-          console.warn(`⚠️ User ${userData.username} has no ModerationProfile, skipping moderator assignment`);
+          logger.warn(`⚠️ User ${userData.username} has no ModerationProfile, skipping moderator assignment`);
           return result;
         }
 
@@ -93,10 +94,10 @@ const channelCreatorModeratorMiddleware = {
               },
             });
 
-            console.log(`✅ Added creator ${displayName} as moderator of channel ${channel.uniqueName}`);
+            logger.info(`✅ Added creator ${displayName} as moderator of channel ${channel.uniqueName}`);
           } catch (error) {
             // Log the error but don't fail the channel creation
-            console.error(
+            logger.error(
               `❌ Failed to add creator as moderator for channel ${channel.uniqueName}:`,
               error instanceof Error ? error.message : error
             );
@@ -104,7 +105,7 @@ const channelCreatorModeratorMiddleware = {
         }
       } catch (error) {
         // Log the error but don't fail the channel creation
-        console.warn(
+        logger.warn(
           '⚠️ Failed to add creator as moderator:',
           error instanceof Error ? error.message : error
         );

--- a/middleware/commentPluginPipelineMiddleware.ts
+++ b/middleware/commentPluginPipelineMiddleware.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../types/context.js'
 import { triggerPluginRunsForComment } from '../services/pluginRunner.js'
+import { logger } from "../logger.js";
 
 const commentPluginPipelineMiddleware = {
   Mutation: {
@@ -52,7 +53,7 @@ const commentPluginPipelineMiddleware = {
           })
         }
       } catch (error) {
-        console.warn('Comment plugin pipeline failed:', error instanceof Error ? error.message : error)
+        logger.warn('Comment plugin pipeline failed:', error instanceof Error ? error.message : error)
       }
 
       return result

--- a/middleware/commentUserMentionsMiddleware.ts
+++ b/middleware/commentUserMentionsMiddleware.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 import {
   notifyCommentMentions,
   type CommentSnapshot,
@@ -81,7 +82,7 @@ const commentUserMentionsMiddleware = {
           });
         }
       } catch (error) {
-        console.warn(
+        logger.warn(
           'Comment user mention notification failed:',
           error instanceof Error ? error.message : error
         );

--- a/middleware/discussionMentionsMiddleware.ts
+++ b/middleware/discussionMentionsMiddleware.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 import {
   notifyDiscussionMentions,
   type DiscussionSnapshot,
@@ -69,7 +70,7 @@ const discussionMentionsMiddleware = {
         const createdDiscussions = result?.discussions || [];
         await processCreatedDiscussions(context, createdDiscussions);
       } catch (error) {
-        console.warn(
+        logger.warn(
           'Discussion user mention notification failed:',
           error instanceof Error ? error.message : error
         );
@@ -97,7 +98,7 @@ const discussionMentionsMiddleware = {
           : result?.discussions || [];
         await processCreatedDiscussions(context, createdDiscussions);
       } catch (error) {
-        console.warn(
+        logger.warn(
           'Discussion user mention notification failed:',
           error instanceof Error ? error.message : error
         );

--- a/middleware/issueActivityFeedMiddleware.ts
+++ b/middleware/issueActivityFeedMiddleware.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
 import type {
   CommentModel,
   DiscussionModel,
@@ -160,7 +161,7 @@ const issueHasDeleteActivity = async (
     });
     return existing.length > 0;
   } catch (error) {
-    console.error('Error checking issue delete activity:', error);
+    logger.error('Error checking issue delete activity:', error);
     return false;
   }
 };
@@ -200,7 +201,7 @@ const recordDeleteClosure = async (input: {
         },
       });
     } catch (error) {
-      console.error('Error closing issue after deletion:', error);
+      logger.error('Error closing issue after deletion:', error);
     }
 
     const hasDeleteActivity = await issueHasDeleteActivity(IssueModel, issueId);

--- a/middleware/wikiPageVersionHistoryMiddleware.ts
+++ b/middleware/wikiPageVersionHistoryMiddleware.ts
@@ -9,6 +9,7 @@ import { wikiPageVersionHistoryHandler } from "../hooks/wikiPageVersionHistoryHo
 import { GraphQLResolveInfo } from 'graphql';
 import type { TextVersionCreateInput } from "../src/generated/graphql.js";
 import type { GraphQLContext } from "../types/context.js";
+import { logger } from "../logger.js";
 import type {
   TextVersionModel,
   WikiPageModel,
@@ -104,7 +105,7 @@ async function handleChildWikiPageCreation(
     // Get the updated WikiPages from the result
     const wikiPages = result?.updateWikiPages?.wikiPages;
     if (!wikiPages || !wikiPages.length) {
-      console.log('No wikiPages found in result for child page creation');
+      logger.info('No wikiPages found in result for child page creation');
       return;
     }
     
@@ -112,7 +113,7 @@ async function handleChildWikiPageCreation(
     const currentUsername = getCurrentUsernameFromContext(context);
     
     if (!currentUsername) {
-      console.log('Could not determine current user for child WikiPage creation');
+      logger.info('Could not determine current user for child WikiPage creation');
       return;
     }
     
@@ -125,7 +126,7 @@ async function handleChildWikiPageCreation(
       
       // Create TextVersions for each new child page
       for (const childPage of childPages) {
-        console.log(`Creating first TextVersion for child WikiPage ${childPage.id}`);
+        logger.info(`Creating first TextVersion for child WikiPage ${childPage.id}`);
         
         if (childPage.title) {
           await createFirstTextVersion(
@@ -151,9 +152,9 @@ async function handleChildWikiPageCreation(
       }
     }
     
-    console.log('Successfully created first TextVersions for child WikiPages');
+    logger.info('Successfully created first TextVersions for child WikiPages');
   } catch (error) {
-    console.error('Error creating first TextVersions for child pages:', error);
+    logger.error('Error creating first TextVersions for child pages:', error);
     // Don't throw the error - we don't want to break the WikiPage creation
   }
 }
@@ -187,7 +188,7 @@ async function createFirstTextVersion(
     });
 
     if (!textVersionResult.textVersions.length) {
-      console.log('Failed to create TextVersion');
+      logger.info('Failed to create TextVersion');
       return;
     }
 
@@ -210,9 +211,9 @@ async function createFirstTextVersion(
       } as unknown as WikiPageUpdateInput
     });
 
-    console.log(`Successfully created first TextVersion for WikiPage ${wikiPageId}`);
+    logger.info(`Successfully created first TextVersion for WikiPage ${wikiPageId}`);
   } catch (error) {
-    console.error(`Error creating first TextVersion for WikiPage ${wikiPageId}:`, error);
+    logger.error(`Error creating first TextVersion for WikiPage ${wikiPageId}:`, error);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,10 +52,12 @@
         "@types/node": "^25.6.0",
         "c8": "^11.0.0",
         "concurrently": "^9.2.1",
+        "eslint": "^9.39.4",
         "husky": "^9.1.7",
         "testcontainers": "^12.0.3",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.62.0"
       },
       "engines": {
         "node": "22.x"
@@ -727,6 +729,212 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -2275,6 +2483,72 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -3227,6 +3501,13 @@
         "@types/ssh2": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
@@ -3270,6 +3551,13 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3501,6 +3789,262 @@
       "integrity": "sha512-qRyuv+P/1t1JK1rA+elmK1MmCL1BapEzKKfbEhDBV/LMMse4lmhZ/XbgETI39JveDJRpLjmToOI6uFtMW/WR2g==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@whatwg-node/disposablestack": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
@@ -3594,6 +4138,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -3628,6 +4182,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -4767,6 +5338,13 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concurrently": {
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
@@ -5083,6 +5661,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -5508,6 +6093,217 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5594,6 +6390,13 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -5616,6 +6419,20 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
@@ -5712,6 +6529,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5761,6 +6591,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -6040,6 +6891,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
@@ -6808,6 +7672,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -7250,10 +8124,31 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7365,6 +8260,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -7416,6 +8321,20 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/limiter": {
@@ -7570,6 +8489,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -8020,6 +8946,13 @@
       "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -8214,6 +9147,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -8514,6 +9465,16 @@
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
       "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
       "license": "MIT-0"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/prettier": {
       "version": "2.8.8",
@@ -9467,6 +10428,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
@@ -9705,6 +10679,54 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -9787,6 +10809,19 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-log": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
@@ -9850,6 +10885,19 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -9930,6 +10978,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/typescript-memoize": {
@@ -10051,6 +11123,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -10206,6 +11288,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:integration": "TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
     "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
-    "prepare": "husky install",
+    "prepare": "husky",
     "codegen": "node --loader ts-node/esm build_scripts/generateTypes.ts",
     "lint": "eslint .",
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "prepare": "husky install",
     "codegen": "node --loader ts-node/esm build_scripts/generateTypes.ts",
+    "lint": "eslint .",
     "tsc": "tsc",
     "logSchema": "node build_scripts/logSchema.js",
     "build": "npm run codegen && tsc && node build_scripts/copyCypherFiles.js",
@@ -67,10 +68,12 @@
     "@types/node": "^25.6.0",
     "c8": "^11.0.0",
     "concurrently": "^9.2.1",
+    "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "testcontainers": "^12.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.62.0"
   },
   "overrides": {
     "whatwg-url": "^11.0.0",

--- a/rules/permission/canArchiveAndUnarchiveDiscussion.ts
+++ b/rules/permission/canArchiveAndUnarchiveDiscussion.ts
@@ -4,6 +4,7 @@ import { resolveChannelForModPermission } from "./resolveChannelForModPermission
 import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 interface CanArchiveAndUnarchiveDiscussionArgs {
   channelUniqueName?: string;
@@ -17,9 +18,9 @@ export const canArchiveAndUnarchiveDiscussion = rule({ cache: "contextual" })(
     // Support both direct issueId arg and where.id from updateIssues mutation
     const issueId = args.issueId || args.where?.id;
 
-    console.log('can archive and unarchive discussion');
-    console.log("channelUniqueName", channelUniqueName);
-    console.log("issueId", issueId);
+    logger.info('can archive and unarchive discussion');
+    logger.info("channelUniqueName", channelUniqueName);
+    logger.info("issueId", issueId);
 
     // If channelUniqueName is not provided, look it up from the issue.
     let issue;

--- a/rules/permission/canArchiveAndUnarchiveEvent.ts
+++ b/rules/permission/canArchiveAndUnarchiveEvent.ts
@@ -4,6 +4,7 @@ import { resolveChannelForModPermission } from "./resolveChannelForModPermission
 import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 interface CanArchiveAndUnarchiveEventArgs {
   channelUniqueName?: string;
@@ -15,9 +16,9 @@ export const canArchiveAndUnarchiveEvent = rule({ cache: "contextual" })(
     let channelUniqueName = args.channelUniqueName;
     const issueId = args.issueId;
     
-    console.log('can archive and unarchive event');
-    console.log("channelUniqueName", channelUniqueName);
-    console.log("issueId", issueId);
+    logger.info('can archive and unarchive event');
+    logger.info("channelUniqueName", channelUniqueName);
+    logger.info("issueId", issueId);
     
     // If channelUniqueName is not provided, look it up from the issue.
     let issue;

--- a/rules/permission/canReport.ts
+++ b/rules/permission/canReport.ts
@@ -4,6 +4,7 @@ import { resolveChannelForModPermission } from "./resolveChannelForModPermission
 import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 export interface CanReportArgs {
   channelUniqueName?: string;
@@ -15,9 +16,9 @@ export const canReport = rule({ cache: "contextual" })(
     let channelUniqueName = args.channelUniqueName;
     const issueId = args.issueId;
     
-    console.log('can report');
-    console.log("channelUniqueName", channelUniqueName);
-    console.log("issueId", issueId);
+    logger.info('can report');
+    logger.info("channelUniqueName", channelUniqueName);
+    logger.info("issueId", issueId);
     
     // If channelUniqueName is not provided, look it up from the issue.
     let issue;

--- a/rules/permission/canSuspendAndUnsuspendUser.ts
+++ b/rules/permission/canSuspendAndUnsuspendUser.ts
@@ -6,6 +6,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import { ERROR_MESSAGES } from "../errorMessages.js";
 import { getServerScopedMembership } from "./getServerScopedMembership.js";
 import { hasServerModPermission } from "./hasServerModPermission.js";
+import { logger } from "../../logger.js";
 
 // Helper function to check if a user is a channel owner
 async function isUserChannelOwner(username: string, channelName: string, context: GraphQLContext): Promise<boolean> {
@@ -116,10 +117,10 @@ export const canSuspendAndUnsuspendUser = rule({ cache: "contextual" })(
     const issueId = args.issueId;
     const targetUsername = args.username; // The username of the user to be suspended
     
-    console.log('can suspend and unsuspend user');
-    console.log("channelUniqueName", channelUniqueName);
-    console.log("issueId", issueId);
-    console.log("targetUsername", targetUsername);
+    logger.info('can suspend and unsuspend user');
+    logger.info("channelUniqueName", channelUniqueName);
+    logger.info("issueId", issueId);
+    logger.info("targetUsername", targetUsername);
     
     // If channelUniqueName is not provided, look it up from the issue
     if (!channelUniqueName && issueId) {

--- a/rules/permission/channelHasZeroAdmins.ts
+++ b/rules/permission/channelHasZeroAdmins.ts
@@ -1,5 +1,6 @@
 import { ChannelModel } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 
 type CheckZeroAdminsInput = {
   channelName: string;
@@ -32,7 +33,7 @@ export const channelHasZeroAdmins = async (input: CheckZeroAdminsInput): Promise
     
     return admins.length === 0;
   } catch (error) {
-    console.error("Error checking if channel has zero admins:", error);
+    logger.error("Error checking if channel has zero admins:", error);
     return false;
   }
 };

--- a/rules/permission/disconnectExpiredSuspensions.ts
+++ b/rules/permission/disconnectExpiredSuspensions.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../logger.js";
 // Disconnects expired suspensions from a channel.
 // This keeps the Suspension nodes for historical display but removes
 // them from the channel's active suspended users/mods lists.
@@ -56,7 +57,7 @@ export async function disconnectExpiredSuspensions(
         update: disconnectOperations,
       });
     } catch (error) {
-      console.error("Error disconnecting expired suspensions", error);
+      logger.error("Error disconnecting expired suspensions", error);
     }
   }
 

--- a/rules/permission/hasChannelModPermission.ts
+++ b/rules/permission/hasChannelModPermission.ts
@@ -5,6 +5,7 @@ import { getActiveSuspension } from "./getActiveSuspension.js";
 import { disconnectExpiredSuspensions } from "./disconnectExpiredSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
 import type { ModerationProfile } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
 
 // Define the moderator permissions as an enum for type safety
 export enum ModChannelPermission {
@@ -190,7 +191,7 @@ export const hasChannelModPermission: (
       expiredUserSuspensions: suspensionInfo.expiredUserSuspensions,
       expiredModSuspensions: suspensionInfo.expiredModSuspensions,
     }).catch((error) => {
-      console.error("Failed to disconnect expired suspensions", error);
+      logger.error("Failed to disconnect expired suspensions", error);
     });
   }
 
@@ -252,7 +253,7 @@ export const hasChannelModPermission: (
         actorType: "mod",
       });
     } catch (error) {
-      console.error("Failed to create suspension notification for mod", error);
+      logger.error("Failed to create suspension notification for mod", error);
     }
   }
   return new Error(ERROR_MESSAGES.channel.noModPermission);

--- a/rules/permission/hasChannelPermission.ts
+++ b/rules/permission/hasChannelPermission.ts
@@ -5,6 +5,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import { getActiveSuspension } from "./getActiveSuspension.js";
 import { disconnectExpiredSuspensions } from "./disconnectExpiredSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
+import { logger } from "../../logger.js";
 
 type HasChannelPermissionInput = {
   permission: keyof ChannelRole;
@@ -93,7 +94,7 @@ export const hasChannelPermission: (
       expiredUserSuspensions: suspensionInfo.expiredUserSuspensions,
       expiredModSuspensions: suspensionInfo.expiredModSuspensions,
     }).catch((error) => {
-      console.error("Failed to disconnect expired suspensions", error);
+      logger.error("Failed to disconnect expired suspensions", error);
     });
   }
 
@@ -171,7 +172,7 @@ export const hasChannelPermission: (
         actorType: "user",
       });
     } catch (error) {
-      console.error("Failed to create suspension notification", error);
+      logger.error("Failed to create suspension notification", error);
     }
   }
 

--- a/rules/permission/hasServerModPermission.ts
+++ b/rules/permission/hasServerModPermission.ts
@@ -7,6 +7,7 @@ import { getServerScopedMembership } from "./getServerScopedMembership.js";
 import { getActiveServerSuspension } from "./getActiveServerSuspension.js";
 import { disconnectExpiredServerSuspensions } from "./disconnectExpiredServerSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
+import { logger } from "../../logger.js";
 
 export const hasServerModPermission: (
   permission: keyof ModServerRole,
@@ -46,7 +47,7 @@ export const hasServerModPermission: (
       expiredUserSuspensions: suspensionInfo.expiredUserSuspensions,
       expiredModSuspensions: suspensionInfo.expiredModSuspensions,
     }).catch((error) => {
-      console.error("Failed to disconnect expired server suspensions", error);
+      logger.error("Failed to disconnect expired server suspensions", error);
     });
   }
 
@@ -93,7 +94,7 @@ export const hasServerModPermission: (
         actorType: "mod",
       });
     } catch (error) {
-      console.error("Failed to create server mod suspension notification", error);
+      logger.error("Failed to create server mod suspension notification", error);
     }
   }
 

--- a/rules/permission/hasServerPermission.ts
+++ b/rules/permission/hasServerPermission.ts
@@ -6,6 +6,7 @@ import { getServerConfigForPermissions } from "./getServerConfigForPermissions.j
 import { getActiveServerSuspension } from "./getActiveServerSuspension.js";
 import { disconnectExpiredServerSuspensions } from "./disconnectExpiredServerSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
+import { logger } from "../../logger.js";
 
 type EvaluateServerPermissionInput = {
   permission: keyof ServerRole;
@@ -97,7 +98,7 @@ export const hasServerPermission: (
         expiredUserSuspensions: suspensionInfo.expiredUserSuspensions,
         expiredModSuspensions: suspensionInfo.expiredModSuspensions,
       }).catch((error) => {
-        console.error("Failed to disconnect expired server suspensions", error);
+        logger.error("Failed to disconnect expired server suspensions", error);
       });
     }
   }
@@ -137,7 +138,7 @@ export const hasServerPermission: (
         actorType: "user",
       });
     } catch (error) {
-      console.error("Failed to create server suspension notification", error);
+      logger.error("Failed to create server suspension notification", error);
     }
   }
 

--- a/rules/permission/isOwner.ts
+++ b/rules/permission/isOwner.ts
@@ -24,6 +24,7 @@ import {
   IssueWhere,
 } from "../../src/generated/graphql.js";
 import { setUserDataOnContext } from "./userDataHelperFunctions.js";
+import { logger } from "../../logger.js";
 
 type IsChannelOwnerInput = {
   where: ChannelWhere;
@@ -34,7 +35,7 @@ type IsChannelOwnerInput = {
 
 export const isChannelOwner = rule({ cache: "contextual" })(
   async (parent: unknown, args: IsChannelOwnerInput, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
-    console.log('🔐 isChannelOwner rule called with args:', JSON.stringify(args));
+    logger.info('🔐 isChannelOwner rule called with args:', JSON.stringify(args));
 
     // set user data
     ctx.user = await setUserDataOnContext({
@@ -42,11 +43,11 @@ export const isChannelOwner = rule({ cache: "contextual" })(
       getPermissionInfo: false,
     });
     let username = ctx.user.username;
-    console.log("username: ", ctx.user);
+    logger.info("username: ", ctx.user);
 
     let ogm = ctx.ogm;
     const { where, channelUniqueName, issueId, commentId } = args;
-    console.log('args: ', JSON.stringify(args));
+    logger.info('args: ', JSON.stringify(args));
     let uniqueName = '';
 
     if (where?.uniqueName) {
@@ -98,7 +99,7 @@ export const isChannelOwner = rule({ cache: "contextual" })(
           channelUniqueName
         }`,
       });
-      console.log('issue', JSON.stringify(issue));
+      logger.info('issue', JSON.stringify(issue));
 
       if (!issue || !issue[0]) {
         // Return false instead of throwing to allow OR chain to continue
@@ -276,7 +277,7 @@ type IsCommentAuthorInput = {
 
 export const isCommentAuthor = rule({ cache: "contextual" })(
   async (parent: unknown, args: IsCommentAuthorInput, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
-    console.log("isCommentAuthor rule");
+    logger.info("isCommentAuthor rule");
     const { where } = args;
     const commentId  = where.id
 
@@ -288,8 +289,8 @@ export const isCommentAuthor = rule({ cache: "contextual" })(
 
     let username = ctx.user.username;
     let modName =  ctx.user.data?.ModerationProfile?.displayName || null;
-    console.log("username: ", username);
-    console.log("modName: ", modName);
+    logger.info("username: ", username);
+    logger.info("modName: ", modName);
 
     let ogm = ctx.ogm;
 
@@ -486,7 +487,7 @@ export const isDiscussionChannelOwner = rule({ cache: "contextual" })(
     }
 
     if (!discussionId || !channelUniqueName) {
-      console.error("Missing discussionId or channelUniqueName in args:", args);
+      logger.error("Missing discussionId or channelUniqueName in args:", args);
       return false;
     }
 
@@ -531,7 +532,7 @@ export const isDiscussionChannelOwner = rule({ cache: "contextual" })(
 
       return false;
     } catch (error) {
-      console.error("Error in isDiscussionChannelOwner:", error);
+      logger.error("Error in isDiscussionChannelOwner:", error);
       return false;
     }
   }
@@ -572,7 +573,7 @@ export const isImageUploader = rule({ cache: "contextual" })(
       }`,
     });
 
-    console.log('🔍 isImageUploader - Found images:', JSON.stringify(images, null, 2));
+    logger.info('🔍 isImageUploader - Found images:', JSON.stringify(images, null, 2));
 
     if (!images || images.length === 0) {
       throw new Error(ERROR_MESSAGES.image.notFound);
@@ -581,22 +582,22 @@ export const isImageUploader = rule({ cache: "contextual" })(
     const image = images[0];
     const uploaderUsername = image?.Uploader?.username;
 
-    console.log('🔍 isImageUploader - Image:', { imageId: image.id, uploaderUsername, loggedInUsername: username });
+    logger.info('🔍 isImageUploader - Image:', { imageId: image.id, uploaderUsername, loggedInUsername: username });
 
     // If there's no uploader set (legacy/test data), allow anyone authenticated to edit
     // This maintains backward compatibility with existing images
     if (!uploaderUsername) {
-      console.log('⚠️ isImageUploader - No uploader found, allowing edit (legacy data)');
+      logger.info('⚠️ isImageUploader - No uploader found, allowing edit (legacy data)');
       return true;
     }
 
     // Check if the user is the uploader
     if (uploaderUsername !== username) {
-      console.log('❌ isImageUploader - User is not the uploader');
+      logger.info('❌ isImageUploader - User is not the uploader');
       return false; // Permission check - return false to allow OR to work
     }
 
-    console.log('✅ isImageUploader - User is the uploader');
+    logger.info('✅ isImageUploader - User is the uploader');
     return true;
   }
 );

--- a/rules/permission/userDataHelperFunctions.ts
+++ b/rules/permission/userDataHelperFunctions.ts
@@ -12,6 +12,7 @@ import type {
 import jwksClient from "jwks-rsa";
 import axios from "axios";
 import NodeCache from "node-cache";
+import { logger } from "../../logger.js";
 
 type CachedUserInfo = {
   email: string | null;
@@ -64,9 +65,9 @@ const getKey: GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCal
     const jwksClientInstance = getJwksClient(); // Lazily initialize the JWKS client
     jwksClientInstance.getSigningKey(header.kid, (err: Error | null, key?: jwksClient.SigningKey) => {
       if (err) {
-        console.error("Error retrieving signing key:", err);
+        logger.error("Error retrieving signing key:", err);
         if ((err as NodeJS.ErrnoException).code === "ENOTFOUND") {
-          console.error(
+          logger.error(
             `DNS resolution failed for domain: ${process.env.AUTH0_DOMAIN}`
           );
         }
@@ -76,7 +77,7 @@ const getKey: GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCal
       callback(null, signingKey);
     });
   } catch (error) {
-    console.error("Error initializing JWKS client or retrieving key:", error);
+    logger.error("Error initializing JWKS client or retrieving key:", error);
     return callback(error instanceof Error ? error : new Error(String(error)), undefined);
   }
 };
@@ -98,7 +99,7 @@ export const getModProfileNameFromUsername = async (
     });
     return userData[0]?.ModerationProfile?.displayName;
   } catch (error) {
-    console.error("Error fetching mod profile name:", error);
+    logger.error("Error fetching mod profile name:", error);
     return null;
   }
 }
@@ -119,7 +120,7 @@ export const getUserFromEmail = async (
     });
     return emailDataWithUser[0]?.User?.username;
   } catch (error) {
-    console.error("Error fetching user from database:", error);
+    logger.error("Error fetching user from database:", error);
     return null;
   }
 };
@@ -192,11 +193,11 @@ export const setUserDataOnContext = async (
           resolve(decoded);
           return;
         } 
-        console.error("JWT Verification Error:", err);
+        logger.error("JWT Verification Error:", err);
         
         // Check if this is a mutation to determine how to handle the error
         const isMutation = context.req?.isMutation === true;
-        console.log("🔍 JWT Error Debug:", {
+        logger.info("🔍 JWT Error Debug:", {
           errorName: err.name,
           isMutation,
           requestBody: context.req?.body?.query?.substring(0, 100)
@@ -206,24 +207,24 @@ export const setUserDataOnContext = async (
           const errorMessage = ERROR_MESSAGES.channel.tokenExpired || "Your session has expired. Please sign in again.";
           if (isMutation) {
             // For mutations, throw the error immediately
-            console.log("🚨 Rejecting JWT promise for mutation with expired token");
+            logger.info("🚨 Rejecting JWT promise for mutation with expired token");
             reject(new Error(errorMessage));
             return;
           } else {
             // For queries, store the error on context and let the rules handle it
-            console.log("📝 Setting JWT error on context for query");
+            logger.info("📝 Setting JWT error on context for query");
             context.jwtError = new Error(errorMessage);
           }
         } else {
           const errorMessage = ERROR_MESSAGES.channel.invalidToken || "Your authentication token is invalid. Please sign in again.";
           if (isMutation) {
             // For mutations, throw the error immediately
-            console.log("🚨 Rejecting JWT promise for mutation with invalid token");
+            logger.info("🚨 Rejecting JWT promise for mutation with invalid token");
             reject(new Error(errorMessage));
             return;
           } else {
             // For queries, store the error on context and let the rules handle it
-            console.log("📝 Setting JWT error on context for query");
+            logger.info("📝 Setting JWT error on context for query");
             context.jwtError = new Error(errorMessage);
           }
         }
@@ -273,7 +274,7 @@ export const setUserDataOnContext = async (
             );
             email = userInfoResponse?.data?.email;
           } catch (error) {
-            console.error("Error fetching email from Auth0 userinfo:", error);
+            logger.error("Error fetching email from Auth0 userinfo:", error);
           }
 
           // Cache the userinfo response
@@ -281,7 +282,7 @@ export const setUserDataOnContext = async (
           userInfoCache.set(token, userInfoToCache);
         }
       }  else {
-        console.error("Token audience is unrecognized.");
+        logger.error("Token audience is unrecognized.");
       }
 
       // Get the username from the email by calling getUserFromEmail
@@ -371,20 +372,20 @@ export const isAuthenticated = rule({ cache: "contextual" })(
       context.req.isMutation = isMutation;
     }
 
-    console.log("🔐 isAuthenticated rule called for:", context.req?.body?.operationName);
+    logger.info("🔐 isAuthenticated rule called for:", context.req?.body?.operationName);
     try {
       // Set user data on context - this may throw for mutations with JWT errors
       context.user = await setUserDataOnContext({
         context,
         getPermissionInfo: false,
       });
-      console.log("✅ setUserDataOnContext completed successfully");
+      logger.info("✅ setUserDataOnContext completed successfully");
     } catch (error) {
       // JWT errors for mutations are thrown from setUserDataOnContext
-      console.log("🚨 isAuthenticated rule caught error from setUserDataOnContext:", (error as Error).message);
+      logger.info("🚨 isAuthenticated rule caught error from setUserDataOnContext:", (error as Error).message);
       throw error;
     }
-    console.log("🔍 isAuthenticated debug:", {
+    logger.info("🔍 isAuthenticated debug:", {
       isMutation,
       hasUsername: !!context.user?.username,
       hasJwtError: !!context.jwtError
@@ -392,23 +393,23 @@ export const isAuthenticated = rule({ cache: "contextual" })(
     
     // For queries, check if there was a JWT error
     if (context.jwtError && !isMutation) {
-      console.log("📝 Returning false for query with JWT error");
+      logger.info("📝 Returning false for query with JWT error");
       return false;
     }
     
     if (!context.user?.username) {
       // Only throw authentication errors for mutations
       if (isMutation) {
-        console.log("🚨 Throwing not authenticated error for mutation");
+        logger.info("🚨 Throwing not authenticated error for mutation");
         throw new Error(ERROR_MESSAGES.channel.notAuthenticated);
       } else {
         // For queries, just return false without throwing an error
-        console.log("📝 Returning false for query without username");
+        logger.info("📝 Returning false for query without username");
         return false;
       }
     }
     
-    console.log("✅ isAuthenticated rule passed");
+    logger.info("✅ isAuthenticated rule passed");
     return true;
   }
 );

--- a/rules/validation/channelIsValid.ts
+++ b/rules/validation/channelIsValid.ts
@@ -1,6 +1,7 @@
 import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
 import {
   ChannelCreateInput,
   ChannelUpdateInput,
@@ -67,7 +68,7 @@ export const validateChannelInput = (input: ChannelInput): true | string => {
       return "The rules must be a valid JSON array.";
     }
   }
-  console.log("channel input is valid");
+  logger.info("channel input is valid");
 
   return true;
 };
@@ -88,7 +89,7 @@ export const createChannelInputIsValid = rule({ cache: "contextual" })(
 type UpdateChannelInput = { update: ChannelUpdateInput };
 export const updateChannelInputIsValid = rule({ cache: "contextual" })(
   async (parent: unknown, args: UpdateChannelInput, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
-    console.log("checking if update channel input is valid", args);
+    logger.info("checking if update channel input is valid", args);
     if (!args.update) {
       return "Missing update input in args.";
     }

--- a/rules/validation/commentIsValid.ts
+++ b/rules/validation/commentIsValid.ts
@@ -3,6 +3,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
 import { CommentCreateInput, CommentUpdateInput } from "../../src/generated/graphql.js";
 import { MAX_CHARS_IN_COMMENT_TEXT } from "./constants.js";
+import { logger } from "../../logger.js";
 
 type CommentTextValidationInput = {
   text: string;
@@ -23,7 +24,7 @@ const validateCommentInput = (input: CommentTextValidationInput): true | string 
   if (text.length > MAX_CHARS_IN_COMMENT_TEXT) {
     return `The comment text cannot exceed ${MAX_CHARS_IN_COMMENT_TEXT} characters.`;
   }
-  console.log('comment is valid')
+  logger.info('comment is valid')
 
   return true;
 };
@@ -99,8 +100,8 @@ export const createCommentInputIsValid = rule({ cache: "contextual" })(
       return "Missing or empty input in args.";
     }
     const createCommentInput: CommentCreateInput = args.input[0]
-    console.log('validating comment input')
-    console.log('arguments passed to validate comment input ', {
+    logger.info('validating comment input')
+    logger.info('arguments passed to validate comment input ', {
       text: createCommentInput.text || "",
       modProfileName: createCommentInput?.CommentAuthor?.ModerationProfile?.connect?.where?.node?.displayName || "",
       username: createCommentInput?.CommentAuthor?.User?.connect?.where?.node?.username || "",

--- a/rules/validation/downloadableFileIsValid.ts
+++ b/rules/validation/downloadableFileIsValid.ts
@@ -1,6 +1,7 @@
 import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLRequest, Ogm } from "../../types/context.js";
+import { logger } from "../../logger.js";
 import {
   DownloadableFileCreateInput,
   DownloadableFileUpdateInput,
@@ -137,7 +138,7 @@ export const validateFileTypePermissions = async (
 
     return true;
   } catch (error) {
-    console.error("Error validating file type permissions:", error);
+    logger.error("Error validating file type permissions:", error);
     return "Failed to validate file type permissions";
   }
 };
@@ -226,7 +227,7 @@ export const updateDownloadableFileInputIsValid = rule({ cache: "contextual" })(
 
       return true;
     } catch (error) {
-      console.error("Error validating downloadable file update:", error);
+      logger.error("Error validating downloadable file update:", error);
       return "Failed to validate file update";
     }
   }

--- a/services/botReportService.ts
+++ b/services/botReportService.ts
@@ -18,6 +18,7 @@ import {
 } from '../customResolvers/mutations/reportComment.js'
 import { getFinalCommentText } from '../customResolvers/mutations/reportDiscussion.js'
 import getNextIssueNumber from '../customResolvers/mutations/utils/getNextIssueNumber.js'
+import { logger } from "../logger.js";
 
 type ReportContentAsBotInput = {
   contentType: 'comment' | 'discussion' | 'event'
@@ -237,7 +238,7 @@ export const createBotReport = async (input: {
       }
       existingIssueId = issueId
     } catch (error) {
-      console.error('Error creating issue:', error)
+      logger.error('Error creating issue:', error)
       throw new Error(`Error creating issue: ${(error as Error)?.message || 'unknown error'}`)
     }
   }
@@ -303,7 +304,7 @@ export const createBotReport = async (input: {
       issueNumber: issue.issueNumber ?? 0
     }
   } catch (error) {
-    console.error('Error updating issue:', error)
+    logger.error('Error updating issue:', error)
     throw new Error(`Error updating issue: ${(error as Error)?.message || 'unknown error'}`)
   }
 }

--- a/services/commentNotificationHandler.ts
+++ b/services/commentNotificationHandler.ts
@@ -22,6 +22,7 @@ import { notifyFeedback } from "../hooks/feedbackNotificationHook.js";
 import { notifyModMentions } from "../hooks/modMentionNotificationHook.js";
 import { notifyCommentMentions } from "../hooks/userMentionNotificationHook.js";
 import { appendNotificationFooter } from "../utils/notificationFooter.js";
+import { logger } from "../logger.js";
 
 export interface NotificationDeps {
   ogm: any;
@@ -175,7 +176,7 @@ export const sendNotificationEmails = async (
 
     await sendBatchEmails(emailsToSend);
   } catch (error) {
-    console.error("Failed to send notification emails:", error);
+    logger.error("Failed to send notification emails:", error);
     // Don't throw - continue with in-app notifications even if emails fail.
   }
 };
@@ -211,7 +212,7 @@ export const createBatchNotifications = async (
     });
 
     if (!entityResults || !entityResults.length) {
-      console.error("Entity not found for notifications:", { entityType, entityId });
+      logger.error("Entity not found for notifications:", { entityType, entityId });
       return 0;
     }
 
@@ -258,7 +259,7 @@ export const createBatchNotifications = async (
 
     return result.records[0]?.get("notificationsCreated")?.toNumber() || 0;
   } catch (error) {
-    console.error("Error in createBatchNotifications:", error);
+    logger.error("Error in createBatchNotifications:", error);
     throw error;
   } finally {
     session.close();
@@ -347,7 +348,7 @@ export const processDiscussionCommentNotification = async (
   );
 
   if (!deps.driver) {
-    console.error("Driver not available for batch notifications");
+    logger.error("Driver not available for batch notifications");
     return;
   }
 
@@ -399,7 +400,7 @@ export const processEventCommentNotification = async (
   );
 
   if (!deps.driver) {
-    console.error("Driver not available for batch notifications");
+    logger.error("Driver not available for batch notifications");
     return;
   }
 
@@ -449,7 +450,7 @@ export const processCommentReplyNotification = async (
     contentUrl = `${process.env.FRONTEND_URL}/forums/${channelName}/events/${event?.id}`;
     commentPermalinkUrl = `${contentUrl}/comments/${parentCommentId}`;
   } else {
-    console.log("No content reference found for comment reply");
+    logger.info("No content reference found for comment reply");
     return;
   }
 
@@ -477,7 +478,7 @@ export const processCommentReplyNotification = async (
   }
 
   if (!deps.driver) {
-    console.error("Driver not available for batch notifications");
+    logger.error("Driver not available for batch notifications");
     return;
   }
 
@@ -551,7 +552,7 @@ export const processFeedbackNotification = async (
       targetAuthorUsername,
     });
   } catch (error) {
-    console.error("Error processing feedback notification:", error);
+    logger.error("Error processing feedback notification:", error);
   }
 };
 
@@ -588,7 +589,7 @@ export const processModMentionNotifications = async (
       nextText: fullComment.text,
     });
   } catch (error) {
-    console.error("Error processing mod mention notifications:", error);
+    logger.error("Error processing mod mention notifications:", error);
   }
 };
 
@@ -614,7 +615,7 @@ export const processUserMentionNotifications = async (
       nextText: fullComment.text,
     });
   } catch (error) {
-    console.error("Error processing user mention notifications:", error);
+    logger.error("Error processing user mention notifications:", error);
   }
 };
 
@@ -635,7 +636,7 @@ export const handleCommentCreatedNotification = async (
   });
 
   if (!fullComments || !fullComments.length) {
-    console.error("Could not find comment details for ID:", commentId);
+    logger.error("Could not find comment details for ID:", commentId);
     return;
   }
 

--- a/services/commentNotificationService.ts
+++ b/services/commentNotificationService.ts
@@ -1,5 +1,6 @@
 import { execute, parse, subscribe } from 'graphql';
 import { handleCommentCreatedNotification } from './commentNotificationHandler.js';
+import { logger } from "../logger.js";
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
 
@@ -18,7 +19,7 @@ export class CommentNotificationService {
     this.schema = schema;
     this.ogm = ogm;
     this.driver = driver;
-    console.log('Comment notification service initialized');
+    logger.info('Comment notification service initialized');
   }
 
   /**
@@ -26,12 +27,12 @@ export class CommentNotificationService {
    */
   async start() {
     if (this.isRunning) {
-      console.log('Comment notification service is already running');
+      logger.info('Comment notification service is already running');
       return;
     }
 
     try {
-      console.log('Starting comment notification service...');
+      logger.info('Starting comment notification service...');
       this.isRunning = true;
 
       // Define the subscription query to listen for comment creation events
@@ -69,14 +70,14 @@ export class CommentNotificationService {
 
         // Start processing comment events
         this.processCommentEvents();
-        console.log('=== DEBUG: Comment notification service started successfully');
+        logger.info('=== DEBUG: Comment notification service started successfully');
       } else {
         // If not an AsyncIterator, it's an error result
-        console.error('=== DEBUG ERROR: Subscription failed:', result);
+        logger.error('=== DEBUG ERROR: Subscription failed:', result);
         this.isRunning = false;
       }
     } catch (error) {
-      console.error('Error starting comment notification service:', error);
+      logger.error('Error starting comment notification service:', error);
       this.isRunning = false;
     }
   }
@@ -91,14 +92,14 @@ export class CommentNotificationService {
       // Process each comment event as it arrives
       for await (const result of this.subscriptionIterator) {
         if (!result.data?.commentCreated?.createdComment) {
-          console.log('Received invalid comment event:', result);
+          logger.info('Received invalid comment event:', result);
           continue;
         }
 
         const commentBasicInfo = result.data.commentCreated.createdComment;
         const commentId = commentBasicInfo.id;
 
-        console.log('Processing notification for newly created comment:', commentId);
+        logger.info('Processing notification for newly created comment:', commentId);
 
         try {
           await handleCommentCreatedNotification(
@@ -106,16 +107,16 @@ export class CommentNotificationService {
             commentId
           );
         } catch (error) {
-          console.error('Error processing comment notification:', error);
+          logger.error('Error processing comment notification:', error);
           // Continue processing other events even if one fails
         }
       }
     } catch (error) {
-      console.error('Error in comment event processing:', error);
+      logger.error('Error in comment event processing:', error);
       
       // If the subscription fails, wait and restart
       if (this.isRunning) {
-        console.log('Restarting comment notification service in 5 seconds...');
+        logger.info('Restarting comment notification service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
     }
@@ -125,7 +126,7 @@ export class CommentNotificationService {
    * Stop the comment notification service
    */
   stop() {
-    console.log('Stopping comment notification service');
+    logger.info('Stopping comment notification service');
     this.isRunning = false;
 
     // Clear the subscription iterator

--- a/services/commentVersionHistoryService.ts
+++ b/services/commentVersionHistoryService.ts
@@ -1,5 +1,6 @@
 import { execute, parse, subscribe } from 'graphql';
 import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
+import { logger } from "../logger.js";
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
 
@@ -75,7 +76,7 @@ export const handleCommentUpdateEvent = async (
 
   const username = await getCommentAuthorUsername(ogm, updatedComment.id);
   if (!username) {
-    console.log('Could not determine username from comment author');
+    logger.info('Could not determine username from comment author');
     return;
   }
 
@@ -95,7 +96,7 @@ export class CommentVersionHistoryService {
   constructor(schema: any, ogm: any) {
     this.schema = schema;
     this.ogm = ogm;
-    console.log('Comment version history service initialized');
+    logger.info('Comment version history service initialized');
   }
 
   /**
@@ -103,12 +104,12 @@ export class CommentVersionHistoryService {
    */
   async start() {
     if (this.isRunning) {
-      console.log('Comment version history service is already running');
+      logger.info('Comment version history service is already running');
       return;
     }
 
     try {
-      console.log('Starting comment version history service...');
+      logger.info('Starting comment version history service...');
       this.isRunning = true;
 
       // Define the subscription query to listen for comment update events
@@ -148,14 +149,14 @@ export class CommentVersionHistoryService {
 
         // Start processing comment update events
         this.processCommentUpdateEvents();
-        console.log('Comment version history service started');
+        logger.info('Comment version history service started');
       } else {
         // If not an AsyncIterator, it's an error result
-        console.error('Subscription failed:', result);
+        logger.error('Subscription failed:', result);
         this.isRunning = false;
       }
     } catch (error) {
-      console.error('Error starting comment version history service:', error);
+      logger.error('Error starting comment version history service:', error);
       this.isRunning = false;
     }
   }
@@ -170,28 +171,28 @@ export class CommentVersionHistoryService {
       // Process each comment update event as it arrives
       for await (const result of this.subscriptionIterator) {
         if (!result.data?.commentUpdated) {
-          console.log('Received invalid comment update event:', result);
+          logger.info('Received invalid comment update event:', result);
           continue;
         }
 
         const updatedComment = result.data.commentUpdated.updatedComment;
         const previousValues = result.data.commentUpdated.previousValues;
 
-        console.log('Processing version history for updated comment:', updatedComment.id);
+        logger.info('Processing version history for updated comment:', updatedComment.id);
 
         try {
           await handleCommentUpdateEvent(this.ogm, updatedComment, previousValues);
         } catch (error) {
-          console.error('Error processing comment version history:', error);
+          logger.error('Error processing comment version history:', error);
           // Continue processing other events even if one fails
         }
       }
     } catch (error) {
-      console.error('Error in comment update event processing:', error);
+      logger.error('Error in comment update event processing:', error);
       
       // If the subscription fails, wait and restart
       if (this.isRunning) {
-        console.log('Restarting comment version history service in 5 seconds...');
+        logger.info('Restarting comment version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
     }
@@ -201,7 +202,7 @@ export class CommentVersionHistoryService {
    * Stop the comment version history service
    */
   stop() {
-    console.log('Stopping comment version history service');
+    logger.info('Stopping comment version history service');
     this.isRunning = false;
 
     // Clear the subscription iterator

--- a/services/discussionVersionHistoryService.ts
+++ b/services/discussionVersionHistoryService.ts
@@ -1,5 +1,6 @@
 import { execute, parse, subscribe } from 'graphql';
 import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
+import { logger } from "../logger.js";
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
 
@@ -33,7 +34,7 @@ export const getDiscussionAuthorUsername = async (
     }
     return discussions[0].Author.username;
   } catch (error) {
-    console.error('Error getting current user username:', error);
+    logger.error('Error getting current user username:', error);
     return null;
   }
 };
@@ -87,7 +88,7 @@ export const handleDiscussionUpdateEvent = async (
   const discussionId = updatedDiscussion.id;
   const currentUsername = await getDiscussionAuthorUsername(ogm, discussionId);
   if (!currentUsername) {
-    console.log('Could not determine current user, skipping version history');
+    logger.info('Could not determine current user, skipping version history');
     return;
   }
 
@@ -121,7 +122,7 @@ export class DiscussionVersionHistoryService {
   constructor(schema: any, ogm: any) {
     this.schema = schema;
     this.ogm = ogm;
-    console.log('Discussion version history service initialized');
+    logger.info('Discussion version history service initialized');
   }
 
   /**
@@ -129,12 +130,12 @@ export class DiscussionVersionHistoryService {
    */
   async start() {
     if (this.isRunning) {
-      console.log('Discussion version history service is already running');
+      logger.info('Discussion version history service is already running');
       return;
     }
 
     try {
-      console.log('Starting discussion version history service...');
+      logger.info('Starting discussion version history service...');
       this.isRunning = true;
 
       // Define the subscription query to listen for discussion update events
@@ -171,14 +172,14 @@ export class DiscussionVersionHistoryService {
 
         // Start processing discussion update events
         this.processDiscussionUpdateEvents();
-        console.log('Discussion version history service started');
+        logger.info('Discussion version history service started');
       } else {
         // If not an AsyncIterator, it's an error result
-        console.error('Subscription failed:', result);
+        logger.error('Subscription failed:', result);
         this.isRunning = false;
       }
     } catch (error) {
-      console.error('Error starting discussion version history service:', error);
+      logger.error('Error starting discussion version history service:', error);
       this.isRunning = false;
     }
   }
@@ -193,28 +194,28 @@ export class DiscussionVersionHistoryService {
       // Process each discussion update event as it arrives
       for await (const result of this.subscriptionIterator) {
         if (!result.data?.discussionUpdated) {
-          console.log('Received invalid discussion update event:', result);
+          logger.info('Received invalid discussion update event:', result);
           continue;
         }
 
         const updatedDiscussion = result.data.discussionUpdated.updatedDiscussion;
         const previousValues = result.data.discussionUpdated.previousValues;
 
-        console.log('Processing version history for updated discussion:', updatedDiscussion.id);
+        logger.info('Processing version history for updated discussion:', updatedDiscussion.id);
 
         try {
           await handleDiscussionUpdateEvent(this.ogm, updatedDiscussion, previousValues);
         } catch (error) {
-          console.error('Error processing discussion version history:', error);
+          logger.error('Error processing discussion version history:', error);
           // Continue processing other events even if one fails
         }
       }
     } catch (error) {
-      console.error('Error in discussion update event processing:', error);
+      logger.error('Error in discussion update event processing:', error);
       
       // If the subscription fails, wait and restart
       if (this.isRunning) {
-        console.log('Restarting discussion version history service in 5 seconds...');
+        logger.info('Restarting discussion version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
     }
@@ -224,7 +225,7 @@ export class DiscussionVersionHistoryService {
    * Stop the discussion version history service
    */
   stop() {
-    console.log('Stopping discussion version history service');
+    logger.info('Stopping discussion version history service');
     this.isRunning = false;
 
     // Clear the subscription iterator

--- a/services/mail/index.ts
+++ b/services/mail/index.ts
@@ -7,6 +7,7 @@ import {
   type ResendMailClient,
 } from "./resendProvider.js";
 import type { MailMessage, MailProvider } from "./types.js";
+import { logger } from "../../logger.js";
 
 type MailProviderName = "sendgrid" | "resend";
 
@@ -35,7 +36,7 @@ export const getMailProviderName = (): MailProviderName => {
     return providerName as MailProviderName;
   }
 
-  console.warn(
+  logger.warn(
     `Unsupported EMAIL_PROVIDER "${process.env.EMAIL_PROVIDER}". Falling back to ${DEFAULT_PROVIDER}.`
   );
 
@@ -86,7 +87,7 @@ const resolveFromEmail = (options?: SendOptions): string | null => {
     throw new Error("EMAIL_FROM is not set");
   }
 
-  console.warn("EMAIL_FROM is not set. Email will not be sent.");
+  logger.warn("EMAIL_FROM is not set. Email will not be sent.");
   return null;
 };
 
@@ -99,7 +100,7 @@ const handleSendFailure = (
     throw error;
   }
 
-  console.error(defaultMessage, error);
+  logger.error(defaultMessage, error);
   return false;
 };
 
@@ -110,7 +111,7 @@ export const sendEmail = async (
   const provider = getMailProvider(options?.dependencies);
 
   if (!provider) {
-    console.warn("Mail provider is not configured. Email will not be sent.");
+    logger.warn("Mail provider is not configured. Email will not be sent.");
     return false;
   }
 
@@ -139,7 +140,7 @@ export const sendBatchEmails = async (
   const provider = getMailProvider(options?.dependencies);
 
   if (!provider) {
-    console.warn("Mail provider is not configured. Email will not be sent.");
+    logger.warn("Mail provider is not configured. Email will not be sent.");
     return false;
   }
 

--- a/services/plugin/channelTrigger.ts
+++ b/services/plugin/channelTrigger.ts
@@ -7,6 +7,7 @@ import { generatePipelineId, shouldRunStep, mergeSettings, buildPluginVersionMap
 import { buildBotInvocationContext } from './buildBotInvocationContext.js'
 import { createPromptDebugLogger } from './promptDebug.js'
 import type { PluginRunCreateInput, PluginRunUpdateInput, Channel, Discussion, DownloadableFile, ServerConfig } from '../../ogm_types.js'
+import { logger } from "../../logger.js";
 
 export const isChannelEvent = (event: string) => CHANNEL_EVENTS.has(event)
 
@@ -394,7 +395,7 @@ export const triggerChannelPluginPipeline = async ({
         log: (...args: unknown[]) => {
           const message = args.map(arg => (typeof arg === 'string' ? arg : JSON.stringify(arg))).join(' ')
           logs.push(message)
-          console.log(`[Plugin:${pluginId}:${channelUniqueName}]`, message)
+          logger.info(`[Plugin:${pluginId}:${channelUniqueName}]`, message)
         },
         storeFlag: async (flag: unknown) => {
           flags.push(flag)

--- a/services/plugin/commentTrigger.ts
+++ b/services/plugin/commentTrigger.ts
@@ -11,6 +11,7 @@ import { createPromptDebugLogger } from './promptDebug.js'
 import { getActiveSuspension } from '../../rules/permission/getActiveSuspension.js'
 import type { Ogm } from '../../types/context.js'
 import type { PluginRunCreateInput, PluginRunUpdateInput, Channel, Comment, ServerConfig } from '../../ogm_types.js'
+import { logger } from "../../logger.js";
 
 export const isCommentEvent = (event: string) => COMMENT_EVENTS.has(event)
 
@@ -225,7 +226,7 @@ export const triggerPluginRunsForComment = async ({
     }
   }
 
-  console.log('[Plugin] Pipeline check:', {
+  logger.info('[Plugin] Pipeline check:', {
     event,
     channelUniqueName,
     channelPipelinesCount: channelPipelines.length,
@@ -243,14 +244,14 @@ export const triggerPluginRunsForComment = async ({
     eventPipeline.steps.forEach((step, index) => {
       // Get plugin for step, respecting version specification
       const pluginMatch = getPluginForStep(pluginVersionsMap, step.pluginId, step.version)
-      console.log(`[Plugin] Step ${index}: pluginId="${step.pluginId}", requestedVersion="${step.version || 'latest'}", found=${!!pluginMatch}${pluginMatch ? `, resolvedVersion="${pluginMatch.version}"` : ''}`)
+      logger.info(`[Plugin] Step ${index}: pluginId="${step.pluginId}", requestedVersion="${step.version || 'latest'}", found=${!!pluginMatch}${pluginMatch ? `, resolvedVersion="${pluginMatch.version}"` : ''}`)
 
       if (pluginMatch) {
         const { edgeData, version } = pluginMatch
         const manifest = parseManifest(edgeData.node.manifest)
         const manifestEvents: string[] = Array.isArray(manifest.events) ? manifest.events : []
         const eventMatch = manifestEvents.includes(event)
-        console.log(`[Plugin] Step ${index}: version=${version}, manifestEvents=${JSON.stringify(manifestEvents)}, eventMatch=${eventMatch}`)
+        logger.info(`[Plugin] Step ${index}: version=${version}, manifestEvents=${JSON.stringify(manifestEvents)}, eventMatch=${eventMatch}`)
         if (eventMatch) {
           pluginsToRun.push({
             pluginId: step.pluginId,
@@ -452,7 +453,7 @@ export const triggerPluginRunsForComment = async ({
         log: (...args: unknown[]) => {
           const message = args.map(arg => (typeof arg === 'string' ? arg : JSON.stringify(arg))).join(' ')
           logs.push(message)
-          console.log(`[Plugin:${pluginId}]`, message)
+          logger.info(`[Plugin:${pluginId}]`, message)
         },
         storeFlag: async (flag: unknown) => {
           flags.push(flag)

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -7,6 +7,7 @@ import { generatePipelineId, shouldRunStep, mergeSettings, getAttachmentUrls, pa
 import { buildBotInvocationContext } from './buildBotInvocationContext.js'
 import { createPromptDebugLogger } from './promptDebug.js'
 import type { PluginRunCreateInput, PluginRunUpdateInput, DownloadableFile as DownloadableFileType, ServerConfig as ServerConfigType, Discussion as DiscussionType } from '../../ogm_types.js'
+import { logger } from "../../logger.js";
 
 export const isSupportedEvent = (event: string) => DOWNLOAD_EVENTS.has(event)
 
@@ -310,7 +311,7 @@ export const triggerPluginRunsForDownloadableFile = async ({
         log: (...args: unknown[]) => {
           const message = args.map(arg => (typeof arg === 'string' ? arg : JSON.stringify(arg))).join(' ')
           logs.push(message)
-          console.log(`[Plugin:${pluginId}]`, message)
+          logger.info(`[Plugin:${pluginId}]`, message)
         },
         storeFlag: async (flag: unknown) => {
           flags.push(flag)

--- a/services/plugin/pluginLoader.ts
+++ b/services/plugin/pluginLoader.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'url'
 import { promises as fs } from 'fs'
 import tar from 'tar-stream'
 import zlib from 'zlib'
+import { logger } from "../../logger.js";
 
 // Shape of the value a plugin's handleEvent resolves to.
 export type PluginRunResult = {
@@ -108,9 +109,9 @@ export const loadPluginImplementation = async (tarballUrl: string, entryPath: st
     const importedModule = (await import(moduleUrl)) as Record<string, unknown>
 
     // Debug: Log what the module exports
-    console.log(`[PluginLoader] Module keys for ${entryPath}:`, Object.keys(importedModule))
-    console.log(`[PluginLoader] Has default export:`, !!importedModule.default)
-    console.log(`[PluginLoader] Default export type:`, typeof importedModule.default)
+    logger.info(`[PluginLoader] Module keys for ${entryPath}:`, Object.keys(importedModule))
+    logger.info(`[PluginLoader] Has default export:`, !!importedModule.default)
+    logger.info(`[PluginLoader] Default export type:`, typeof importedModule.default)
 
     // Try to find the plugin class in various export formats
     let PluginClass: unknown = importedModule.default
@@ -118,13 +119,13 @@ export const loadPluginImplementation = async (tarballUrl: string, entryPath: st
     // If default is an object (not a function), look inside it for the class
     if (PluginClass && typeof PluginClass === 'object' && typeof PluginClass !== 'function') {
       const defaultObject = PluginClass as Record<string, unknown>
-      console.log(`[PluginLoader] Default is an object with keys:`, Object.keys(defaultObject))
+      logger.info(`[PluginLoader] Default is an object with keys:`, Object.keys(defaultObject))
 
       // Look for common property names that might hold the class
       const possibleNames = ['Plugin', 'default', 'ChatGPTBotProfiles', 'BetaReaderBot']
       for (const name of possibleNames) {
         if (typeof defaultObject[name] === 'function') {
-          console.log(`[PluginLoader] Found plugin class inside default.${name}`)
+          logger.info(`[PluginLoader] Found plugin class inside default.${name}`)
           PluginClass = defaultObject[name]
           break
         }
@@ -134,7 +135,7 @@ export const loadPluginImplementation = async (tarballUrl: string, entryPath: st
       if (typeof PluginClass !== 'function') {
         for (const key of Object.keys(defaultObject)) {
           if (typeof defaultObject[key] === 'function') {
-            console.log(`[PluginLoader] Found plugin class inside default.${key}`)
+            logger.info(`[PluginLoader] Found plugin class inside default.${key}`)
             PluginClass = defaultObject[key]
             break
           }
@@ -148,7 +149,7 @@ export const loadPluginImplementation = async (tarballUrl: string, entryPath: st
       for (const name of possibleNames) {
         if (typeof importedModule[name] === 'function') {
           PluginClass = importedModule[name]
-          console.log(`[PluginLoader] Found plugin class at named export: ${name}`)
+          logger.info(`[PluginLoader] Found plugin class at named export: ${name}`)
           break
         }
       }
@@ -158,7 +159,7 @@ export const loadPluginImplementation = async (tarballUrl: string, entryPath: st
         for (const key of Object.keys(importedModule)) {
           if (typeof importedModule[key] === 'function') {
             PluginClass = importedModule[key]
-            console.log(`[PluginLoader] Found plugin class at named export: ${key}`)
+            logger.info(`[PluginLoader] Found plugin class at named export: ${key}`)
             break
           }
         }

--- a/services/plugin/promptDebug.ts
+++ b/services/plugin/promptDebug.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../logger.js";
 type PromptDebugInput = {
   prompt: string
   context?: unknown
@@ -28,7 +29,7 @@ export const createPromptDebugLogger = ({
     const message = `[PromptDebug:${pluginId}${scopeSuffix}] ${serialized}`
 
     logs.push(message)
-    console.log(message)
+    logger.info(message)
 
     return serialized
   }

--- a/services/wikiPageVersionHistoryService.ts
+++ b/services/wikiPageVersionHistoryService.ts
@@ -1,5 +1,6 @@
 import { execute, parse, subscribe } from 'graphql';
 import { trackTextVersion, type OGMLike } from './textVersionHistory.js';
+import { logger } from "../logger.js";
 
 type AsyncIterableIterator<T> = AsyncIterable<T> & AsyncIterator<T>;
 
@@ -34,7 +35,7 @@ export const getWikiPageVersionAuthorUsername = async (
     }
     return wikiPages[0].VersionAuthor.username;
   } catch (error) {
-    console.error('Error getting current user username:', error);
+    logger.error('Error getting current user username:', error);
     return null;
   }
 };
@@ -72,7 +73,7 @@ export const handleWikiPageUpdateEvent = async (
   const wikiPageId = updatedWikiPage.id;
   const currentUsername = await getWikiPageVersionAuthorUsername(ogm, wikiPageId);
   if (!currentUsername) {
-    console.log('Could not determine current user, skipping version history');
+    logger.info('Could not determine current user, skipping version history');
     return;
   }
 
@@ -118,7 +119,7 @@ export class WikiPageVersionHistoryService {
   constructor(schema: any, ogm: any) {
     this.schema = schema;
     this.ogm = ogm;
-    console.log('WikiPage version history service initialized');
+    logger.info('WikiPage version history service initialized');
   }
 
   /**
@@ -126,12 +127,12 @@ export class WikiPageVersionHistoryService {
    */
   async start() {
     if (this.isRunning) {
-      console.log('WikiPage version history service is already running');
+      logger.info('WikiPage version history service is already running');
       return;
     }
 
     try {
-      console.log('Starting wikiPage version history service...');
+      logger.info('Starting wikiPage version history service...');
       this.isRunning = true;
 
       // Define the subscription query to listen for wikiPage update events
@@ -168,14 +169,14 @@ export class WikiPageVersionHistoryService {
 
         // Start processing wikiPage update events
         this.processWikiPageUpdateEvents();
-        console.log('WikiPage version history service started');
+        logger.info('WikiPage version history service started');
       } else {
         // If not an AsyncIterator, it's an error result
-        console.error('Subscription failed:', result);
+        logger.error('Subscription failed:', result);
         this.isRunning = false;
       }
     } catch (error) {
-      console.error('Error starting wikiPage version history service:', error);
+      logger.error('Error starting wikiPage version history service:', error);
       this.isRunning = false;
     }
   }
@@ -190,28 +191,28 @@ export class WikiPageVersionHistoryService {
       // Process each wikiPage update event as it arrives
       for await (const result of this.subscriptionIterator) {
         if (!result.data?.wikiPageUpdated) {
-          console.log('Received invalid wikiPage update event:', result);
+          logger.info('Received invalid wikiPage update event:', result);
           continue;
         }
 
         const updatedWikiPage = result.data.wikiPageUpdated.updatedWikiPage;
         const previousState = result.data.wikiPageUpdated.previousState;
 
-        console.log('Processing version history for updated wikiPage:', updatedWikiPage.id);
+        logger.info('Processing version history for updated wikiPage:', updatedWikiPage.id);
 
         try {
           await handleWikiPageUpdateEvent(this.ogm, updatedWikiPage, previousState);
         } catch (error) {
-          console.error('Error processing wikiPage version history:', error);
+          logger.error('Error processing wikiPage version history:', error);
           // Continue processing other events even if one fails
         }
       }
     } catch (error) {
-      console.error('Error in wikiPage update event processing:', error);
+      logger.error('Error in wikiPage update event processing:', error);
       
       // If the subscription fails, wait and restart
       if (this.isRunning) {
-        console.log('Restarting wikiPage version history service in 5 seconds...');
+        logger.info('Restarting wikiPage version history service in 5 seconds...');
         setTimeout(() => this.start(), 5000);
       }
     }
@@ -221,7 +222,7 @@ export class WikiPageVersionHistoryService {
    * Stop the wikiPage version history service
    */
   stop() {
-    console.log('Stopping wikiPage version history service');
+    logger.info('Stopping wikiPage version history service');
     this.isRunning = false;
 
     // Clear the subscription iterator


### PR DESCRIPTION
## Problem

Tech debt: **no structured logging.** ~450 `console.*` calls in non-test code — fine for scripts, risky for a production GraphQL server: no levels, no correlation, noisy and impossible to filter or trace.

## What this does

### 1. Lightweight structured logger (`logger.ts`)
A zero-dependency logger that is a **drop-in for `console`** (same `(message, ...rest)` signature, so call sites read the same), but adds what a production server needs:

- **Levels** (`debug` < `info` < `warn` < `error`) with a runtime threshold via `LOG_LEVEL`, so noisy logs can be silenced in prod. Defaults to `info` in production, `debug` otherwise.
- **Structured JSON output** (one object per line) when `LOG_FORMAT=json` or `NODE_ENV=production`; human-readable coloured output locally.
- **stderr routing** for `warn`/`error`; `Error` objects serialized to `{name, message, stack}`.
- **`logger.child({ ... })`** for bound context.

Intentionally small/dependency-free so it can be swapped for pino later without touching call sites.

### 2. Request correlation
An Express middleware binds a `requestId` per request via `AsyncLocalStorage`, and the GraphQL context enriches it with `operationName`. Every log line emitted while handling a request carries these fields, so a request's logs can be traced together — directly addressing the "no correlation" gap.

### 3. The sweep
Replaced **453 `console.*` calls across 134 runtime files** with the logger (`.log`/`.info` → `logger.info`, `.warn` → `logger.warn`, `.error` → `logger.error`), inserting the correct relative import in each. Done with a one-shot codemod (safe because the logger is a drop-in), which was then removed.

**Left as `console`:** `build_scripts/` and test files — console is fine there per the tech-debt note; `tests/testUtils.ts` deliberately stubs `console.error`.

### 4. Lint enforcement (so it doesn't regress)
- Minimal ESLint flat config (`eslint.config.js`) with a single rule, `no-console: error`, scoped to runtime `.ts` — scripts and tests exempt. Not a full style ruleset, to avoid flagging unrelated code.
- New `npm run lint` script; lint added to the pre-commit hook and CI (before type-check).

### 5. Drift cleanup
Fixed husky v9 deprecation warnings surfaced while wiring lint into the hook: removed the deprecated `#!/bin/sh` + `husky.sh` sourcing lines from `.husky/pre-commit` and switched `prepare` from `husky install` to `husky` (both fail in husky v10).

## Verification
- `npm run lint` — clean (confirms the sweep was complete; a temp `console.log` in runtime code does error).
- `npm run codegen` + `npm run tsc` — clean.
- `npm test` — **565/565 pass.**
- Smoke-tested all four levels, JSON vs dev format, stderr routing, level filtering, and `requestId` correlation propagation.
- Both commits passed the full pre-commit hook (lint + tsc + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)