### PR TITLE
test(plugin): cover all three plugin triggers (decision + execution) + coverage baseline

### DIFF
--- a/build_scripts/coverage-merged.sh
+++ b/build_scripts/coverage-merged.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Merged unit + integration line coverage — the number Codecov reports by merging
+# its `unit` and `integration` flag uploads, and what the README badge reflects.
+#
+# Runs both suites under c8 into one accumulated temp directory and emits
+# coverage/lcov.info plus a text summary. Requires Docker (the integration suite
+# uses Testcontainers Neo4j) and the generated type files (`npm run codegen`).
+#
+# CI runs the two suites as parallel jobs; this is the local, single-command,
+# sequential equivalent. The inline `$(find ...)` form (rather than a variable)
+# is deliberate — it ensures the file list is word-split into separate args.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "▶ unit suite (fresh coverage)…"
+npx c8 --temp-directory=coverage/tmp --clean=true --reporter=lcov \
+  node --loader ts-node/esm --test \
+  $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)
+
+echo "▶ integration suite (accumulating onto unit coverage)…"
+TESTCONTAINERS_REUSE_ENABLE=true npx c8 --temp-directory=coverage/tmp --clean=false \
+  --reporter=lcov --reporter=text-summary \
+  node --loader ts-node/esm --test --test-concurrency=1 \
+  $(find ./tests/integration -name '*test.ts' -print | sort)
+
+echo "✔ merged coverage written to coverage/lcov.info"

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -1,0 +1,82 @@
+# Test coverage baseline
+
+A point-in-time map of where automated tests do and don't cover the backend,
+used to prioritize testing work by **risk × gap**. Snapshot taken 2026-06-24 on
+`main` (post the god-file split, #57).
+
+This is a reference, not a gate — there is intentionally **no coverage
+threshold blocking PRs**.
+
+## Reproduce
+
+```bash
+npm run coverage:merged
+```
+
+Runs the unit suite and the integration suite (Testcontainers Neo4j — Docker
+required) under one accumulated c8 report, writing `coverage/lcov.info` plus a
+text summary. This is the local equivalent of what CI produces by uploading the
+`unit` and `integration` flags separately and letting Codecov merge them.
+
+## Headline
+
+| Metric | Unit only | **Merged (unit + integration)** |
+|---|---|---|
+| Lines | 47.9% | **68.2%** |
+| Functions | 77% | **85%** |
+| Branches | 62% | **58%** |
+
+The unit-only number badly understates reality: the integration suite covers a
+large share of the resolver and service paths. **Always reason about the merged
+number** — that is what Codecov reports and the README badge shows.
+
+## Where integration is (and isn't) carrying the load
+
+Comparing unit-only → merged shows which areas the integration suite already
+covers, and — more importantly — which it doesn't touch:
+
+| Area | Unit | Merged | Integration adds | Read |
+|---|---|---|---|---|
+| customResolvers/mutations | 44% | 75% | +31 | covered |
+| customResolvers/queries | 49% | 85% | +36 | covered |
+| services/* (non-plugin) | 40% | 73% | +33 | covered |
+| hooks | 69% | 87% | +18 | covered |
+| rules/validation | 71% | 71% | +0 | partial |
+| **rules/permission** | 63% | 64% | **+1** | ⚠️ security-critical, integration barely exercises denial paths |
+| **rules/definitions** | 56% | 56% | **+0** | ⚠️ |
+| **services/plugin** | 27% | 27% | **+0** | 🔴 dark in *both* suites |
+| **middleware** | 5.7% | 5.7% | **+0** | 🔴 dark in *both* suites |
+
+Mutations/queries/hooks are in good shape and need no dedicated effort. The real
+gaps are narrower than the unit view implies.
+
+## Genuinely dark, high-risk files (uncovered by *either* suite)
+
+| Lines uncovered | File | % |
+|---|---|---|
+| 696 | `services/plugin/commentTrigger.ts` | 2.5% |
+| 506 | `services/plugin/channelTrigger.ts` | 3.4% |
+| 423 | `services/plugin/downloadTrigger.ts` | 3.2% |
+| 380 | `middleware/issueActivityFeedMiddleware.ts` | 0% |
+| 277 | `middleware/channelBotsMiddleware.ts` | 0% |
+| 275 | `errorHandling.ts` | 0% |
+| 231 | `middleware/wikiPageVersionHistoryMiddleware.ts` | 0% |
+| 185 | `middleware/discussionVersionHistoryMiddleware.ts` | 0% |
+
+## Risk-ranked priorities (no targets — just order of attack)
+
+1. **Plugin triggers** (`services/plugin/*Trigger.ts`) — execute external plugin
+   code and handle secrets, near-zero in both suites. Approach: unit-test the
+   decision/selection logic with stubbed OGM models (no DB); integration-test the
+   live execution path. *In progress: `commentTrigger.ts` 2.5% → 37.5%.*
+2. **Permission rules** (`rules/permission`, `rules/definitions`) — integration
+   rarely hits denial paths. Approach: the pure `evaluate*`/`resolve*` unit
+   pattern.
+3. **Side-effect infrastructure** (`middleware/*`, `errorHandling.ts`) — extract
+   the callable handler and test that; keep the wrapper thin.
+
+Mutations, queries, and hooks are not priorities at 75–87%.
+
+> Caveat: some middleware is genuinely awkward to unit-test (graphql-middleware
+> wrappers), so its low number partly reflects test difficulty, not neglect —
+> target the extractable logic inside.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:integration": "TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
     "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "coverage:merged": "bash build_scripts/coverage-merged.sh",
     "prepare": "husky",
     "codegen": "node --loader ts-node/esm build_scripts/generateTypes.ts",
     "lint": "eslint .",

--- a/services/plugin/channelTrigger.execution.test.ts
+++ b/services/plugin/channelTrigger.execution.test.ts
@@ -1,0 +1,135 @@
+// Execution-path tests for the channel trigger's per-plugin run lifecycle.
+// The real plugin loader is replaced via the injectable `loadPlugin` dependency
+// with a fake in-memory plugin; models are stubbed and PluginRun create/update
+// calls captured to assert status transitions. No database or network.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { triggerChannelPluginPipeline } from "./channelTrigger.js";
+
+const EVENT = "discussionChannel.created";
+
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+const installedEdge = (name: string) => ({
+  properties: { enabled: true, settingsJson: null },
+  node: {
+    id: `pv-${name}`,
+    version: "1.0.0",
+    repoUrl: null,
+    tarballGsUri: `gs://bucket/${name}.tgz`,
+    entryPath: "dist/index.js",
+    manifest: JSON.stringify({ events: [EVENT] }),
+    settingsDefaults: null,
+    uiSchema: null,
+    Plugin: { id: `p-${name}`, name, displayName: name, description: "", metadata: null },
+  },
+});
+
+const discussionWithFile = {
+  id: "d-1",
+  title: "T",
+  body: "B",
+  DownloadableFile: { id: "f-1", fileName: "a.zip", url: "http://x/a.zip", kind: "zip", size: 10 },
+};
+
+function makeExecModels(steps: unknown[], edges: unknown[]) {
+  const updates: any[] = [];
+  const creates: any[] = [];
+  let seq = 0;
+  const channel = {
+    uniqueName: "cats",
+    displayName: "Cats",
+    description: "",
+    rules: [],
+    pluginPipelines: [{ event: EVENT, steps }],
+    Tags: [],
+    FilterGroups: [],
+    EnabledPluginsConnection: { edges: [] },
+  };
+  const serverConfig = { serverName: "s", InstalledVersionsConnection: { edges } };
+  const PluginRun = {
+    create: async (args: any) => {
+      creates.push(args);
+      seq += 1;
+      return { pluginRuns: [{ id: `run-${seq}` }] };
+    },
+    update: async (args: any) => {
+      updates.push(args);
+      return {};
+    },
+    find: async (args: any) => [{ id: args?.where?.id ?? "run-1" }],
+  };
+  const models: any = {
+    Channel: model([channel]),
+    Discussion: model([discussionWithFile]),
+    ServerConfig: model([serverConfig]),
+    ServerSecret: empty(),
+    DownloadableFile: empty(),
+    PluginRun,
+    Plugin: empty(),
+    PluginVersion: empty(),
+  };
+  return { models, updates, creates };
+}
+
+const pluginReturning = (result: unknown) =>
+  class {
+    constructor(public ctx: unknown) {}
+    async handleEvent() {
+      return result;
+    }
+  };
+const loaderFor = (cls: unknown) => (async () => cls) as any;
+const statusesOf = (updates: any[]) => updates.map((u) => u.update.status);
+
+const execRun = (models: any, loadPlugin: any) =>
+  triggerChannelPluginPipeline(
+    { discussionId: "d-1", channelUniqueName: "cats", event: EVENT, models },
+    { loadPlugin }
+  );
+
+test("runs a pipeline plugin to SUCCEEDED", async () => {
+  const { models, updates, creates } = makeExecModels(
+    [{ pluginId: "mybot", condition: "ALWAYS" }],
+    [installedEdge("mybot")]
+  );
+  const runs = await execRun(models, loaderFor(pluginReturning({ success: true, result: { message: "ok" } })));
+
+  assert.equal(creates.length, 1);
+  assert.equal(creates[0].input[0].status, "PENDING");
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("RUNNING"));
+  assert.ok(statuses.includes("SUCCEEDED"));
+  assert.equal(runs.length, 1);
+});
+
+test("marks the run FAILED when the plugin reports failure", async () => {
+  const { models, updates } = makeExecModels(
+    [{ pluginId: "mybot", condition: "ALWAYS" }],
+    [installedEdge("mybot")]
+  );
+  await execRun(models, loaderFor(pluginReturning({ success: false, error: "nope" })));
+  assert.ok(statusesOf(updates).includes("FAILED"));
+});
+
+test("skips later steps after a failure (stopOnFirstFailure)", async () => {
+  const { models, updates } = makeExecModels(
+    [
+      { pluginId: "a", condition: "ALWAYS" },
+      { pluginId: "b", condition: "ALWAYS" },
+    ],
+    [installedEdge("a"), installedEdge("b")]
+  );
+  let n = 0;
+  const loader = (async () => {
+    n += 1;
+    if (n === 1) throw new Error("load boom");
+    return pluginReturning({ success: true });
+  }) as any;
+  await execRun(models, loader);
+
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("FAILED"));
+  assert.ok(statuses.includes("SKIPPED"));
+});

--- a/services/plugin/channelTrigger.test.ts
+++ b/services/plugin/channelTrigger.test.ts
@@ -1,0 +1,120 @@
+// Unit tests for the channel (discussion-with-download) plugin trigger's
+// decision logic: it fires a configured channel pipeline when a discussion that
+// has a downloadable file is posted. These drive triggerChannelPluginPipeline
+// through every guard and the step-filtering with stubbed OGM models (no DB),
+// stopping before the live plugin-execution path.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isChannelEvent, triggerChannelPluginPipeline } from "./channelTrigger.js";
+
+const EVENT = "discussionChannel.created";
+
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+function makeModels(opts: {
+  channel?: unknown | null;
+  discussion?: unknown | null;
+  serverConfig?: unknown | null;
+} = {}): any {
+  return {
+    Channel: model(opts.channel ? [opts.channel] : []),
+    Discussion: model(opts.discussion ? [opts.discussion] : []),
+    ServerConfig: model(opts.serverConfig ? [opts.serverConfig] : []),
+    DownloadableFile: empty(),
+    PluginRun: empty(),
+    ServerSecret: empty(),
+    Plugin: empty(),
+    PluginVersion: empty(),
+  };
+}
+
+const channelWith = (pluginPipelines: unknown[]) => ({
+  uniqueName: "cats",
+  displayName: "Cats",
+  description: "",
+  rules: [],
+  pluginPipelines,
+  Tags: [],
+  FilterGroups: [],
+  EnabledPluginsConnection: { edges: [] },
+});
+
+const pipelineForEvent = {
+  event: EVENT,
+  steps: [{ pluginId: "p1", condition: "ALWAYS" }],
+};
+
+const discussionWithFile = {
+  id: "d-1",
+  title: "T",
+  body: "B",
+  DownloadableFile: { id: "f-1", fileName: "a.zip", url: "http://x/a.zip", kind: "zip", size: 10 },
+};
+
+const serverConfigNoPlugins = {
+  serverName: "s",
+  InstalledVersionsConnection: { edges: [] },
+};
+
+const run = (models: any, event = EVENT) =>
+  triggerChannelPluginPipeline({ discussionId: "d-1", channelUniqueName: "cats", event, models });
+
+test("isChannelEvent recognizes only discussionChannel.created", () => {
+  assert.equal(isChannelEvent("discussionChannel.created"), true);
+  assert.equal(isChannelEvent("comment.created"), false);
+  assert.equal(isChannelEvent(""), false);
+});
+
+test("throws on an unsupported event", async () => {
+  await assert.rejects(
+    run(makeModels(), "discussionChannel.deleted"),
+    /Unsupported channel plugin event: discussionChannel\.deleted/
+  );
+});
+
+test("throws when the channel does not exist", async () => {
+  await assert.rejects(run(makeModels({ channel: null })), /Channel "cats" not found/);
+});
+
+test("returns [] when no pipeline is configured for the event", async () => {
+  const channel = channelWith([{ event: "some.other.event", steps: [{ pluginId: "p1" }] }]);
+  assert.deepEqual(await run(makeModels({ channel })), []);
+});
+
+test("returns [] when the matching pipeline has no steps", async () => {
+  const channel = channelWith([{ event: EVENT, steps: [] }]);
+  assert.deepEqual(await run(makeModels({ channel })), []);
+});
+
+test("throws when the discussion does not exist", async () => {
+  const channel = channelWith([pipelineForEvent]);
+  await assert.rejects(
+    run(makeModels({ channel, discussion: null })),
+    /Discussion "d-1" not found/
+  );
+});
+
+test("returns [] when the discussion has no downloadable file", async () => {
+  const channel = channelWith([pipelineForEvent]);
+  const discussion = { id: "d-1", title: "T", body: "B", DownloadableFile: null };
+  assert.deepEqual(await run(makeModels({ channel, discussion })), []);
+});
+
+test("returns [] when there is no server config", async () => {
+  const channel = channelWith([pipelineForEvent]);
+  assert.deepEqual(
+    await run(makeModels({ channel, discussion: discussionWithFile, serverConfig: null })),
+    []
+  );
+});
+
+test("returns [] when the pipeline's plugin is not server-installed", async () => {
+  const channel = channelWith([pipelineForEvent]);
+  assert.deepEqual(
+    await run(
+      makeModels({ channel, discussion: discussionWithFile, serverConfig: serverConfigNoPlugins })
+    ),
+    []
+  );
+});

--- a/services/plugin/channelTrigger.ts
+++ b/services/plugin/channelTrigger.ts
@@ -15,12 +15,17 @@ export const isChannelEvent = (event: string) => CHANNEL_EVENTS.has(event)
  * Triggers channel-scoped plugin pipelines when content is submitted to a channel.
  * This runs plugins configured in the Channel's pluginPipelines field.
  */
-export const triggerChannelPluginPipeline = async ({
-  discussionId,
-  channelUniqueName,
-  event,
-  models
-}: ChannelTriggerArgs) => {
+export const triggerChannelPluginPipeline = async (
+  {
+    discussionId,
+    channelUniqueName,
+    event,
+    models
+  }: ChannelTriggerArgs,
+  // Injectable plugin loader so the execution path can be tested without
+  // downloading/running a real plugin tarball. Defaults to the real loader.
+  { loadPlugin = loadPluginImplementation }: { loadPlugin?: typeof loadPluginImplementation } = {}
+) => {
   if (!CHANNEL_EVENTS.has(event)) {
     throw new Error(`Unsupported channel plugin event: ${event}`)
   }
@@ -311,7 +316,7 @@ export const triggerChannelPluginPipeline = async ({
 
     try {
       const tarballUrl = pluginVersionData.tarballGsUri || pluginVersionData.repoUrl
-      const PluginClass = await loadPluginImplementation(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
+      const PluginClass = await loadPlugin(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
 
       const serverSecrets = await ServerSecret.find({
         where: { pluginId },

--- a/services/plugin/commentTrigger.execution.test.ts
+++ b/services/plugin/commentTrigger.execution.test.ts
@@ -1,0 +1,173 @@
+// Execution-path tests for the comment trigger: the per-plugin run lifecycle
+// (PENDING -> RUNNING -> SUCCEEDED/FAILED/SKIPPED). The real plugin loader
+// downloads and runs an untrusted tarball, so it is replaced via the injectable
+// `loadPlugin` dependency with a fake in-memory plugin. Models are stubbed and
+// the PluginRun create/update calls are captured to assert status transitions.
+// No database or network.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { triggerPluginRunsForComment } from "./commentTrigger.js";
+
+const EVENT = "comment.created";
+
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+const discussionComment = () => ({
+  id: "comment-1",
+  text: "hello bot",
+  botMentions: [],
+  isFeedbackComment: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  CommentAuthor: { username: "alice", displayName: "Alice", isBot: false },
+  DiscussionChannel: {
+    id: "dc-1",
+    discussionId: "d-1",
+    channelUniqueName: "cats",
+    Discussion: { id: "d-1", title: "T", body: "B" },
+  },
+  Channel: { uniqueName: "cats", displayName: "Cats", description: "", rules: [] },
+  Event: null,
+  Issue: null,
+  ParentComment: null,
+});
+
+// An enabled, installed plugin version whose manifest handles comment.created.
+const installedEdge = (name: string, manifestEvents: string[] = [EVENT]) => ({
+  properties: { enabled: true, settingsJson: null },
+  node: {
+    id: `pv-${name}`,
+    version: "1.0.0",
+    repoUrl: null,
+    tarballGsUri: `gs://bucket/${name}.tgz`,
+    entryPath: "dist/index.js",
+    manifest: JSON.stringify({ events: manifestEvents }),
+    settingsDefaults: null,
+    uiSchema: null,
+    Plugin: { id: `p-${name}`, name, displayName: name, description: "", metadata: null },
+  },
+});
+
+// Build stubbed models with a valid discussion comment, a channel with no
+// channel-level settings, and a server config whose installed plugins are the
+// given edges (no pipeline -> fallback runs all enabled plugins for the event).
+function makeExecModels(edges: unknown[]) {
+  const updates: any[] = [];
+  const creates: any[] = [];
+  let seq = 0;
+  const channel = {
+    uniqueName: "cats",
+    displayName: "Cats",
+    description: "",
+    rules: [],
+    pluginPipelines: null,
+    EnabledPluginsConnection: { edges: [] },
+  };
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges },
+  };
+  const PluginRun = {
+    create: async (args: any) => {
+      creates.push(args);
+      seq += 1;
+      return { pluginRuns: [{ id: `run-${seq}` }] };
+    },
+    update: async (args: any) => {
+      updates.push(args);
+      return {};
+    },
+    find: async (args: any) => [{ id: args?.where?.id ?? "run-1" }],
+  };
+  const models: any = {
+    Comment: model([discussionComment()]),
+    Channel: model([channel]),
+    ServerConfig: model([serverConfig]),
+    ServerSecret: empty(),
+    PluginRun,
+    Discussion: empty(),
+    Event: empty(),
+    Issue: empty(),
+    User: empty(),
+  };
+  return { models, updates, creates };
+}
+
+// A fake plugin class whose handleEvent returns/throws as configured.
+const pluginReturning = (result: unknown) =>
+  class {
+    constructor(public ctx: unknown) {}
+    async handleEvent() {
+      return result;
+    }
+  };
+const pluginThrowing = (message: string) =>
+  class {
+    constructor(public ctx: unknown) {}
+    async handleEvent(): Promise<never> {
+      throw new Error(message);
+    }
+  };
+const loaderFor = (cls: unknown) => (async () => cls) as any;
+
+const execRun = (models: any, loadPlugin: any) =>
+  triggerPluginRunsForComment(
+    { commentId: "comment-1", event: EVENT, models, driver: {} as any },
+    { loadPlugin }
+  );
+
+const statusesOf = (updates: any[]) => updates.map((u) => u.update.status);
+
+test("runs a matching plugin to SUCCEEDED", async () => {
+  const { models, updates, creates } = makeExecModels([installedEdge("mybot")]);
+  const runs = await execRun(models, loaderFor(pluginReturning({ success: true, result: { message: "ok" } })));
+
+  assert.equal(creates.length, 1);
+  assert.equal(creates[0].input[0].status, "PENDING");
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("RUNNING"), "transitions to RUNNING");
+  assert.ok(statuses.includes("SUCCEEDED"), "ends SUCCEEDED");
+  assert.ok(!statuses.includes("FAILED"));
+  assert.equal(runs.length, 1);
+});
+
+test("marks the run FAILED when the plugin reports failure", async () => {
+  const { models, updates } = makeExecModels([installedEdge("mybot")]);
+  await execRun(models, loaderFor(pluginReturning({ success: false, error: "nope" })));
+  assert.ok(statusesOf(updates).includes("FAILED"));
+});
+
+test("marks the run FAILED when the plugin throws", async () => {
+  const { models, updates } = makeExecModels([installedEdge("mybot")]);
+  await execRun(models, loaderFor(pluginThrowing("handle boom")));
+  const failed = updates.find((u) => u.update.status === "FAILED");
+  assert.ok(failed);
+  assert.match(failed.update.message, /handle boom/);
+});
+
+test("marks the run FAILED when the plugin fails to load", async () => {
+  const { models, updates } = makeExecModels([installedEdge("mybot")]);
+  const badLoader = (async () => {
+    throw new Error("load boom");
+  }) as any;
+  await execRun(models, badLoader);
+  assert.ok(statusesOf(updates).includes("FAILED"));
+});
+
+test("skips later steps after a failure (stopOnFirstFailure)", async () => {
+  const { models, updates } = makeExecModels([installedEdge("a"), installedEdge("b")]);
+  let n = 0;
+  const loader = (async () => {
+    n += 1;
+    if (n === 1) throw new Error("load boom"); // first plugin fails to load
+    return pluginReturning({ success: true }); // second would succeed, but is skipped
+  }) as any;
+  await execRun(models, loader);
+
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("FAILED"), "first plugin FAILED");
+  const skipped = updates.find((u) => u.update.status === "SKIPPED");
+  assert.ok(skipped, "second plugin SKIPPED");
+  assert.match(skipped.update.skippedReason, /Pipeline stopped/);
+});

--- a/services/plugin/commentTrigger.test.ts
+++ b/services/plugin/commentTrigger.test.ts
@@ -1,0 +1,171 @@
+// Unit tests for the comment plugin trigger's decision logic: which comments
+// trigger plugin runs, how the channel/server pipelines are selected, and the
+// early-return guards. These drive triggerPluginRunsForComment through its
+// branching with stubbed OGM models, stopping before the live plugin-execution
+// path (network / bot writes), which is left to integration coverage.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isCommentEvent, triggerPluginRunsForComment } from "./commentTrigger.js";
+
+const EVENT = "comment.created";
+
+// A minimal OGM model stub whose find() returns the supplied rows.
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+// Build the `models` bag triggerPluginRunsForComment destructures. Only
+// Comment/Channel/ServerConfig are read on the decision path; the rest are
+// no-op stubs so unrelated lookups never crash.
+function makeModels(opts: {
+  comment?: unknown | null;
+  channel?: unknown | null;
+  serverConfig?: unknown | null;
+} = {}): any {
+  return {
+    Comment: model(opts.comment ? [opts.comment] : []),
+    Channel: model(opts.channel ? [opts.channel] : []),
+    ServerConfig: model(opts.serverConfig ? [opts.serverConfig] : []),
+    Discussion: empty(),
+    Event: empty(),
+    Issue: empty(),
+    PluginRun: empty(),
+    ServerSecret: empty(),
+    User: empty(),
+  };
+}
+
+// A valid discussion comment that *would* trigger plugins (overridden per test).
+const discussionComment = () => ({
+  id: "comment-1",
+  text: "hello bot",
+  botMentions: [],
+  isFeedbackComment: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  CommentAuthor: { username: "alice", isBot: false },
+  DiscussionChannel: {
+    id: "dc-1",
+    discussionId: "d-1",
+    channelUniqueName: "cats",
+    Discussion: { id: "d-1", title: "T", body: "B" },
+  },
+  Channel: { uniqueName: "cats" },
+  Event: null,
+  Issue: null,
+  ParentComment: null,
+});
+
+const run = (models: any, event = EVENT, commentId = "comment-1") =>
+  triggerPluginRunsForComment({ commentId, event, models, driver: {} as any });
+
+test("isCommentEvent recognizes only comment.created", () => {
+  assert.equal(isCommentEvent("comment.created"), true);
+  assert.equal(isCommentEvent("discussion.created"), false);
+  assert.equal(isCommentEvent(""), false);
+});
+
+test("throws on an unsupported event", async () => {
+  await assert.rejects(
+    run(makeModels(), "comment.deleted"),
+    /Unsupported comment plugin event: comment\.deleted/
+  );
+});
+
+test("throws when the comment does not exist", async () => {
+  await assert.rejects(
+    run(makeModels({ comment: null })),
+    /Comment "comment-1" not found/
+  );
+});
+
+test("ignores feedback comments", async () => {
+  const comment = { ...discussionComment(), isFeedbackComment: true };
+  assert.deepEqual(await run(makeModels({ comment })), []);
+});
+
+test("ignores comments scoped to an event", async () => {
+  const comment = {
+    ...discussionComment(),
+    Event: { id: "e-1", EventChannels: [{ channelUniqueName: "cats" }] },
+  };
+  assert.deepEqual(await run(makeModels({ comment })), []);
+});
+
+test("ignores comments scoped to an issue", async () => {
+  const comment = { ...discussionComment(), Issue: { id: "i-1" } };
+  assert.deepEqual(await run(makeModels({ comment })), []);
+});
+
+test("returns [] when no channel can be resolved", async () => {
+  const comment = {
+    ...discussionComment(),
+    DiscussionChannel: { id: "dc-1", discussionId: "d-1", channelUniqueName: null, Discussion: null },
+    Channel: null,
+    Event: null,
+  };
+  assert.deepEqual(await run(makeModels({ comment })), []);
+});
+
+test("returns [] when there is no server config", async () => {
+  const channel = { uniqueName: "cats", pluginPipelines: null, EnabledPluginsConnection: { edges: [] } };
+  assert.deepEqual(
+    await run(makeModels({ comment: discussionComment(), channel, serverConfig: null })),
+    []
+  );
+});
+
+test("returns [] when no plugins are installed (fallback path)", async () => {
+  const channel = { uniqueName: "cats", pluginPipelines: null, EnabledPluginsConnection: { edges: [] } };
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges: [] },
+  };
+  assert.deepEqual(
+    await run(makeModels({ comment: discussionComment(), channel, serverConfig })),
+    []
+  );
+});
+
+test("returns [] when an installed plugin does not handle comment.created", async () => {
+  const channel = { uniqueName: "cats", pluginPipelines: null, EnabledPluginsConnection: { edges: [] } };
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: {
+      edges: [
+        {
+          properties: { enabled: true, settingsJson: null },
+          node: {
+            id: "pv-1",
+            version: "1.0.0",
+            manifest: JSON.stringify({ events: ["discussion.created"] }),
+            Plugin: { id: "p-1", name: "summarizer" },
+          },
+        },
+      ],
+    },
+  };
+  assert.deepEqual(
+    await run(makeModels({ comment: discussionComment(), channel, serverConfig })),
+    []
+  );
+});
+
+test("returns [] when a channel pipeline references an uninstalled plugin", async () => {
+  const channel = {
+    uniqueName: "cats",
+    pluginPipelines: [
+      { event: "comment.created", steps: [{ pluginId: "ghost", condition: "ALWAYS" }] },
+    ],
+    EnabledPluginsConnection: { edges: [] },
+  };
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges: [] },
+  };
+  assert.deepEqual(
+    await run(makeModels({ comment: discussionComment(), channel, serverConfig })),
+    []
+  );
+});

--- a/services/plugin/commentTrigger.ts
+++ b/services/plugin/commentTrigger.ts
@@ -15,12 +15,17 @@ import { logger } from "../../logger.js";
 
 export const isCommentEvent = (event: string) => COMMENT_EVENTS.has(event)
 
-export const triggerPluginRunsForComment = async ({
-  commentId,
-  event,
-  models,
-  driver
-}: CommentTriggerArgs) => {
+export const triggerPluginRunsForComment = async (
+  {
+    commentId,
+    event,
+    models,
+    driver
+  }: CommentTriggerArgs,
+  // Injectable plugin loader so the execution path can be tested without
+  // downloading/running a real plugin tarball. Defaults to the real loader.
+  { loadPlugin = loadPluginImplementation }: { loadPlugin?: typeof loadPluginImplementation } = {}
+) => {
   if (!COMMENT_EVENTS.has(event)) {
     throw new Error(`Unsupported comment plugin event: ${event}`)
   }
@@ -396,7 +401,7 @@ export const triggerPluginRunsForComment = async ({
 
     try {
       const tarballUrl = pluginVersionData.tarballGsUri || pluginVersionData.repoUrl
-      const PluginClass = await loadPluginImplementation(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
+      const PluginClass = await loadPlugin(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
 
       const serverSecrets = await ServerSecret.find({
         where: { pluginId },

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -1,0 +1,124 @@
+// Execution-path tests for the downloadable-file trigger's per-plugin run
+// lifecycle. The real plugin loader is replaced via the injectable `loadPlugin`
+// dependency with a fake in-memory plugin; models are stubbed and PluginRun
+// create/update calls captured to assert status transitions. No DB or network.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { triggerPluginRunsForDownloadableFile } from "./downloadTrigger.js";
+
+const EVENT = "downloadableFile.created";
+
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+const installedEdge = (name: string) => ({
+  properties: { enabled: true, settingsJson: null },
+  node: {
+    id: `pv-${name}`,
+    version: "1.0.0",
+    repoUrl: null,
+    tarballGsUri: `gs://bucket/${name}.tgz`,
+    entryPath: "dist/index.js",
+    manifest: JSON.stringify({ events: [EVENT] }),
+    settingsDefaults: null,
+    uiSchema: null,
+    Plugin: { id: `p-${name}`, name, displayName: name, description: "", metadata: null },
+  },
+});
+
+const fileNode = {
+  id: "f-1",
+  fileName: "a.zip",
+  url: "http://x/a.zip",
+  kind: "zip",
+  size: 10,
+  Discussion: {
+    id: "d-1",
+    title: "T",
+    body: "B",
+    DiscussionChannels: [
+      { channelUniqueName: "cats", Channel: { uniqueName: "cats", displayName: "Cats", description: "", rules: [] } },
+    ],
+  },
+};
+
+function makeExecModels(edges: unknown[]) {
+  const updates: any[] = [];
+  const creates: any[] = [];
+  let seq = 0;
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges },
+  };
+  const PluginRun = {
+    create: async (args: any) => {
+      creates.push(args);
+      seq += 1;
+      return { pluginRuns: [{ id: `run-${seq}` }] };
+    },
+    update: async (args: any) => {
+      updates.push(args);
+      return {};
+    },
+    find: async (args: any) => [{ id: args?.where?.id ?? "run-1" }],
+  };
+  const models: any = {
+    DownloadableFile: model([fileNode]),
+    ServerConfig: model([serverConfig]),
+    ServerSecret: empty(),
+    PluginRun,
+    Plugin: empty(),
+    PluginVersion: empty(),
+  };
+  return { models, updates, creates };
+}
+
+const pluginReturning = (result: unknown) =>
+  class {
+    constructor(public ctx: unknown) {}
+    async handleEvent() {
+      return result;
+    }
+  };
+const loaderFor = (cls: unknown) => (async () => cls) as any;
+const statusesOf = (updates: any[]) => updates.map((u) => u.update.status);
+
+const execRun = (models: any, loadPlugin: any) =>
+  triggerPluginRunsForDownloadableFile(
+    { downloadableFileId: "f-1", event: EVENT, models },
+    { loadPlugin }
+  );
+
+test("runs a matching plugin to SUCCEEDED", async () => {
+  const { models, updates, creates } = makeExecModels([installedEdge("mybot")]);
+  const runs = await execRun(models, loaderFor(pluginReturning({ success: true, result: { message: "ok" } })));
+
+  assert.equal(creates.length, 1);
+  assert.equal(creates[0].input[0].status, "PENDING");
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("RUNNING"));
+  assert.ok(statuses.includes("SUCCEEDED"));
+  assert.equal(runs.length, 1);
+});
+
+test("marks the run FAILED when the plugin reports failure", async () => {
+  const { models, updates } = makeExecModels([installedEdge("mybot")]);
+  await execRun(models, loaderFor(pluginReturning({ success: false, error: "nope" })));
+  assert.ok(statusesOf(updates).includes("FAILED"));
+});
+
+test("skips later plugins after a failure (stopOnFirstFailure)", async () => {
+  const { models, updates } = makeExecModels([installedEdge("a"), installedEdge("b")]);
+  let n = 0;
+  const loader = (async () => {
+    n += 1;
+    if (n === 1) throw new Error("load boom");
+    return pluginReturning({ success: true });
+  }) as any;
+  await execRun(models, loader);
+
+  const statuses = statusesOf(updates);
+  assert.ok(statuses.includes("FAILED"));
+  assert.ok(statuses.includes("SKIPPED"));
+});

--- a/services/plugin/downloadTrigger.test.ts
+++ b/services/plugin/downloadTrigger.test.ts
@@ -1,0 +1,97 @@
+// Unit tests for the downloadable-file plugin trigger's decision logic: which
+// download events trigger plugin runs and how the server pipeline / enabled
+// plugins are selected. These drive triggerPluginRunsForDownloadableFile through
+// its guards and selection branches with stubbed OGM models (no DB), stopping
+// before the live plugin-execution path.
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isSupportedEvent,
+  triggerPluginRunsForDownloadableFile,
+} from "./downloadTrigger.js";
+
+const EVENT = "downloadableFile.created";
+
+const model = (rows: unknown[]) => ({ find: async () => rows });
+const empty = () => model([]);
+
+function makeModels(opts: {
+  file?: unknown | null;
+  serverConfig?: unknown | null;
+} = {}): any {
+  return {
+    DownloadableFile: model(opts.file ? [opts.file] : []),
+    ServerConfig: model(opts.serverConfig ? [opts.serverConfig] : []),
+    Plugin: empty(),
+    PluginVersion: empty(),
+    PluginRun: empty(),
+    ServerSecret: empty(),
+  };
+}
+
+const fileNode = {
+  id: "f-1",
+  fileName: "a.zip",
+  url: "http://x/a.zip",
+  kind: "zip",
+  size: 10,
+  Discussion: null,
+};
+
+const installedPlugin = (manifestEvents: string[]) => ({
+  properties: { enabled: true, settingsJson: null },
+  node: {
+    id: "pv-1",
+    version: "1.0.0",
+    manifest: JSON.stringify({ events: manifestEvents }),
+    Plugin: { id: "p-1", name: "scanner" },
+  },
+});
+
+const run = (models: any, event = EVENT) =>
+  triggerPluginRunsForDownloadableFile({ downloadableFileId: "f-1", event, models });
+
+test("isSupportedEvent recognizes the download events only", () => {
+  assert.equal(isSupportedEvent("downloadableFile.created"), true);
+  assert.equal(isSupportedEvent("downloadableFile.downloaded"), true);
+  assert.equal(isSupportedEvent("comment.created"), false);
+});
+
+test("throws on an unsupported event", async () => {
+  await assert.rejects(run(makeModels(), "downloadableFile.archived"), /Unsupported plugin event/);
+});
+
+test("throws when the downloadable file does not exist", async () => {
+  await assert.rejects(run(makeModels({ file: null })), /Downloadable file not found/);
+});
+
+test("returns [] when there is no server config", async () => {
+  assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig: null })), []);
+});
+
+test("returns [] when no plugins are installed (fallback path)", async () => {
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges: [] },
+  };
+  assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig })), []);
+});
+
+test("returns [] when an installed plugin does not handle the event", async () => {
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: null,
+    InstalledVersionsConnection: { edges: [installedPlugin(["comment.created"])] },
+  };
+  assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig })), []);
+});
+
+test("returns [] when a pipeline step references an uninstalled plugin", async () => {
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: [{ event: EVENT, steps: [{ pluginId: "ghost", condition: "ALWAYS" }] }],
+    InstalledVersionsConnection: { edges: [] },
+  };
+  assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig })), []);
+});

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -11,11 +11,16 @@ import { logger } from "../../logger.js";
 
 export const isSupportedEvent = (event: string) => DOWNLOAD_EVENTS.has(event)
 
-export const triggerPluginRunsForDownloadableFile = async ({
-  downloadableFileId,
-  event,
-  models
-}: TriggerArgs) => {
+export const triggerPluginRunsForDownloadableFile = async (
+  {
+    downloadableFileId,
+    event,
+    models
+  }: TriggerArgs,
+  // Injectable plugin loader so the execution path can be tested without
+  // downloading/running a real plugin tarball. Defaults to the real loader.
+  { loadPlugin = loadPluginImplementation }: { loadPlugin?: typeof loadPluginImplementation } = {}
+) => {
   if (!DOWNLOAD_EVENTS.has(event)) {
     throw new Error(`Unsupported plugin event: ${event}`)
   }
@@ -277,7 +282,7 @@ export const triggerPluginRunsForDownloadableFile = async ({
 
     try {
       const tarballUrl = pluginVersionData.tarballGsUri || pluginVersionData.repoUrl
-      const PluginClass = await loadPluginImplementation(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
+      const PluginClass = await loadPlugin(tarballUrl, pluginVersionData.entryPath || 'dist/index.js')
 
       const serverSecrets = await ServerSecret.find({
         where: { pluginId },


### PR DESCRIPTION
Completes **priority 1** of the coverage baseline (plugin triggers) and persists the baseline itself.

## Plugin triggers — the three darkest high-risk files

The merged baseline flagged `services/plugin/*Trigger.ts` (all ~3% lines) as the darkest high-risk code. They decide which events trigger plugin runs, resolve the channel/server pipeline, and execute external plugin code. Now covered in two layers — all with **stubbed models, no DB or network**:

1. **Decision logic** — unit tests through every guard and pipeline-selection branch.
2. **Execution lifecycle** — a minimal, behavior-preserving seam (an optional injected `loadPlugin`, defaulting to the real loader; callers go through the `pluginRunner` shim and are unaffected) lets a fake in-memory plugin drive the per-run lifecycle. Tests capture `PluginRun` create/update calls and assert PENDING → RUNNING → SUCCEEDED/FAILED/SKIPPED, load failures, and stopOnFirstFailure skipping.

| File | Before | After |
|---|---|---|
| `commentTrigger.ts` | 2.5% | **80.1%** |
| `channelTrigger.ts` | 3.4% | **88.1%** |
| `downloadTrigger.ts` | 3.2% | **89.4%** |

38 tests, all green. The remaining lines are the `createCommentAsBot`/`reportContentAsBot` callbacks (real bot writes + suspension checks) that only fire when a plugin invokes them — left to integration coverage.

## Coverage baseline + reproducer

- `docs/coverage-baseline.md` — the merged-coverage map (68.2% lines) that prioritizes this work: unit-vs-merged per area, the dark-file list, and the risk-ranked order of attack. **No coverage gate** — a reference, not a threshold.
- `npm run coverage:merged` — reproduces the merged number locally (both suites under one accumulated c8 report).

## Verification
`tsc` clean, `npm run lint` clean, all 38 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)