### PR TITLE
test(p3): cover error handling + side-effect middleware

### DIFF
--- a/errorHandling.test.ts
+++ b/errorHandling.test.ts
@@ -1,0 +1,121 @@
+// Unit tests for the GraphQL error formatter and the Apollo error-handling
+// plugin. formatGraphQLError is pure (aside from logging); the plugin's
+// didEncounterErrors is invoked directly. No server or database.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatGraphQLError, errorHandlingPlugin } from "./errorHandling.js";
+
+// Build an EnhancedError-shaped object (Error + GraphQL fields).
+const makeError = (
+  message: string,
+  extra: { code?: string; locations?: any; path?: any; stack?: string } = {}
+): any => {
+  const err: any = new Error(message);
+  if (extra.code) err.extensions = { code: extra.code };
+  if (extra.locations) err.locations = extra.locations;
+  if (extra.path) err.path = extra.path;
+  if (extra.stack !== undefined) err.stack = extra.stack;
+  return err;
+};
+
+// Run formatGraphQLError with NODE_ENV forced, restoring it afterward.
+const formatWithEnv = (env: string | undefined, error: any, context?: any) => {
+  const original = process.env.NODE_ENV;
+  if (env === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = env;
+  try {
+    return formatGraphQLError(error, context);
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+};
+
+test("defaults to UNKNOWN_ERROR and leaves the message unchanged", () => {
+  const out = formatGraphQLError(makeError("something broke"));
+  assert.equal(out.extensions?.code, "UNKNOWN_ERROR");
+  assert.equal(out.message, "something broke");
+  assert.ok(out.extensions?.errorId);
+  assert.ok(out.extensions?.timestamp);
+});
+
+test("enhances the message per error code", () => {
+  const cases: Array<[string, RegExp]> = [
+    ["GRAPHQL_VALIDATION_FAILED", /^Schema Validation Error:/],
+    ["GRAPHQL_PARSE_FAILED", /^Query Parse Error:/],
+    ["BAD_USER_INPUT", /^Invalid Input:/],
+    ["UNAUTHENTICATED", /^Authentication Required:/],
+    ["FORBIDDEN", /^Permission Denied:/],
+    ["INTERNAL_SERVER_ERROR", /^Internal Server Error:/],
+  ];
+  for (const [code, re] of cases) {
+    const out = formatGraphQLError(makeError("boom", { code }));
+    assert.match(out.message, re, `code ${code}`);
+    assert.equal(out.extensions?.code, code);
+  }
+});
+
+test("attaches the right debug hint by error category", () => {
+  const validation = formatGraphQLError(makeError("x", { code: "BAD_USER_INPUT" }));
+  assert.match(String(validation.extensions?.debugHint), /schema/i);
+
+  const auth = formatGraphQLError(makeError("x", { code: "UNAUTHENTICATED" }));
+  assert.match(String(auth.extensions?.debugHint), /[Aa]uthentication/);
+
+  const perm = formatGraphQLError(makeError("x", { code: "FORBIDDEN" }));
+  assert.match(String(perm.extensions?.debugHint), /permission/i);
+
+  const unknown = formatGraphQLError(makeError("x"));
+  assert.equal(unknown.extensions?.debugHint, undefined);
+});
+
+test("passes through locations and path", () => {
+  const locations = [{ line: 2, column: 5 }];
+  const path = ["createComment", 0, "text"];
+  const out = formatGraphQLError(makeError("x", { code: "BAD_USER_INPUT", locations, path }));
+  assert.deepEqual(out.locations, locations);
+  assert.deepEqual(out.path, path);
+});
+
+test("includes extra debugging fields only in development", () => {
+  const error = makeError("raw message", { code: "INTERNAL_SERVER_ERROR", stack: "STACK" });
+  const context = { operationName: "DoThing", variables: { a: 1 } };
+
+  const dev = formatWithEnv("development", error, context);
+  assert.equal(dev.extensions?.originalMessage, "raw message");
+  assert.equal(dev.extensions?.stack, "STACK");
+  assert.equal(dev.extensions?.operationName, "DoThing");
+
+  const prod = formatWithEnv("production", error, context);
+  assert.equal(prod.extensions?.originalMessage, undefined);
+  assert.equal(prod.extensions?.stack, undefined);
+  assert.equal(prod.extensions?.operationName, undefined);
+});
+
+test("redacts sensitive variables (development output)", () => {
+  const error = makeError("x", { code: "BAD_USER_INPUT" });
+  const context = {
+    variables: { username: "alice", password: "hunter2", authToken: "abc", secretKey: "s" },
+  };
+  const dev: any = formatWithEnv("development", error, context);
+  assert.equal(dev.extensions.variables.username, "alice");
+  assert.equal(dev.extensions.variables.password, "[REDACTED]");
+  assert.equal(dev.extensions.variables.authToken, "[REDACTED]");
+  assert.equal(dev.extensions.variables.secretKey, "[REDACTED]");
+});
+
+test("errorHandlingPlugin processes errors without throwing", async () => {
+  const handlers: any = await errorHandlingPlugin.requestDidStart();
+  assert.equal(typeof handlers.didEncounterErrors, "function");
+
+  await assert.doesNotReject(
+    handlers.didEncounterErrors({
+      request: { operationName: "Op", variables: { x: 1 }, query: "{ x }" },
+      errors: [
+        makeError("normal", { code: "BAD_USER_INPUT" }),
+        makeError("Cannot connect to database"), // critical path via message
+        makeError("boom", { code: "INTERNAL_SERVER_ERROR" }), // critical path via code
+      ],
+      contextValue: { user: { id: "u1" } },
+    })
+  );
+});

--- a/middleware/channelBotsMiddleware.test.ts
+++ b/middleware/channelBotsMiddleware.test.ts
@@ -1,0 +1,40 @@
+// Unit tests for the pure helpers in the channel-bots middleware: settings JSON
+// parsing and bot-plugin detection. The middleware's DB orchestration is not
+// exercised here (it runs through the live graphql-middleware layer).
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseSettingsJson, isBotPlugin } from "./channelBotsMiddleware.js";
+
+test("parseSettingsJson parses a JSON string", () => {
+  assert.deepEqual(parseSettingsJson('{"a":1,"b":"x"}'), { a: 1, b: "x" });
+});
+
+test("parseSettingsJson returns {} for invalid JSON", () => {
+  assert.deepEqual(parseSettingsJson("{not json"), {});
+});
+
+test("parseSettingsJson returns {} for empty/null/undefined", () => {
+  assert.deepEqual(parseSettingsJson(""), {});
+  assert.deepEqual(parseSettingsJson(null), {});
+  assert.deepEqual(parseSettingsJson(undefined), {});
+});
+
+test("parseSettingsJson passes a non-string object through unchanged", () => {
+  const obj = { already: "parsed" };
+  assert.equal(parseSettingsJson(obj), obj);
+});
+
+test("isBotPlugin detects bot tags case-insensitively", () => {
+  assert.equal(isBotPlugin({ tags: ["bot"] }), true);
+  assert.equal(isBotPlugin({ tags: ["BOTS"] }), true);
+  assert.equal(isBotPlugin({ tags: ["ai", "Bot"] }), true);
+});
+
+test("isBotPlugin is false for non-bot, missing, or malformed tags", () => {
+  assert.equal(isBotPlugin({ tags: ["ai", "summarizer"] }), false);
+  assert.equal(isBotPlugin({ tags: [] }), false);
+  assert.equal(isBotPlugin({ tags: "bot" }), false); // not an array
+  assert.equal(isBotPlugin({}), false);
+  assert.equal(isBotPlugin(null), false);
+  assert.equal(isBotPlugin(undefined), false);
+});

--- a/middleware/channelBotsMiddleware.ts
+++ b/middleware/channelBotsMiddleware.ts
@@ -39,7 +39,7 @@ interface ServerPluginEdge {
 
 const BOT_TAGS = new Set(['bot', 'bots']);
 
-const parseSettingsJson = (settingsJson: unknown): Record<string, unknown> => {
+export const parseSettingsJson = (settingsJson: unknown): Record<string, unknown> => {
   if (!settingsJson || typeof settingsJson !== 'string') {
     return (settingsJson as Record<string, unknown>) || {};
   }
@@ -50,7 +50,7 @@ const parseSettingsJson = (settingsJson: unknown): Record<string, unknown> => {
   }
 };
 
-const isBotPlugin = (plugin: { tags?: unknown } | null | undefined) => {
+export const isBotPlugin = (plugin: { tags?: unknown } | null | undefined) => {
   const tags = Array.isArray(plugin?.tags) ? plugin.tags : [];
   return tags.some((tag: unknown) => BOT_TAGS.has(String(tag).toLowerCase()));
 };

--- a/middleware/commentVersionHistoryMiddleware.test.ts
+++ b/middleware/commentVersionHistoryMiddleware.test.ts
@@ -1,0 +1,86 @@
+// Unit tests for the comment version-history middleware. Same approach as the
+// discussion middleware: drive its branching (pass-through vs. snapshot fetch on
+// a text change) with a stubbed resolver and a permissive in-memory OGM; the
+// delegated hook writes run against the stub. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import middleware from "./commentVersionHistoryMiddleware.js";
+
+const M: any = (middleware as any).Mutation;
+const RESULT = { comments: [{ id: "c-1" }] };
+
+function makeCtx(models: Record<string, any> = {}) {
+  const calls: string[] = [];
+  const ogm = {
+    model(name: string) {
+      calls.push(name);
+      const o = models[name] || {};
+      return {
+        find: o.find ?? (async () => []),
+        create: o.create ?? (async () => ({})),
+        update: o.update ?? (async () => ({})),
+        delete: o.delete ?? (async () => ({})),
+      };
+    },
+  };
+  return { ctx: { ogm, driver: {}, user: { username: "alice" } } as any, calls };
+}
+
+function countingResolve() {
+  const state = { calls: 0 };
+  const resolve = async () => {
+    state.calls += 1;
+    return RESULT;
+  };
+  return { resolve, state };
+}
+
+const snapshot = {
+  id: "c-1",
+  text: "old text",
+  CommentAuthor: { username: "alice" },
+  DiscussionChannel: { discussionId: "d-1", channelUniqueName: "cats", Discussion: { id: "d-1", title: "T" } },
+  Event: null,
+  PastVersions: [],
+};
+
+test("passes through to the resolver when there is no update", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateComments(resolve, null, { where: { id: "c-1" } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []);
+});
+
+test("does nothing extra when the text is not being updated", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateComments(resolve, null, { where: { id: "c-1" }, update: { pinned: true } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []);
+});
+
+test("fetches a snapshot and runs the version path on a text change", async () => {
+  const { ctx, calls } = makeCtx({ Comment: { find: async () => [snapshot] } });
+  const { resolve, state } = countingResolve();
+  const out = await M.updateComments(
+    resolve,
+    null,
+    { where: { id: "c-1" }, update: { text: "new text" } },
+    ctx,
+    {}
+  );
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.ok(calls.includes("Comment"), "fetched the pre-update snapshot");
+});
+
+test("still runs after the resolver even when the snapshot is missing (no id)", async () => {
+  const { ctx } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateComments(resolve, null, { where: {}, update: { text: "new text" } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+});

--- a/middleware/discussionVersionHistoryMiddleware.test.ts
+++ b/middleware/discussionVersionHistoryMiddleware.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for the discussion version-history middleware. The middleware wraps
+// the update resolvers, captures a pre-update snapshot, and delegates the actual
+// version/notification writes to hooks (tested separately). These tests drive
+// its own branching — when it short-circuits to the resolver vs. when it fetches
+// a snapshot — with a stubbed resolver and a permissive in-memory OGM. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import middleware from "./discussionVersionHistoryMiddleware.js";
+
+const M: any = (middleware as any).Mutation;
+const RESULT = { discussions: [{ id: "d-1" }] };
+
+// A permissive OGM: any model resolves to safe no-ops, with overrides per model.
+// `calls` records which models were looked up so we can assert whether the
+// middleware fetched a snapshot.
+function makeCtx(models: Record<string, any> = {}) {
+  const calls: string[] = [];
+  const ogm = {
+    model(name: string) {
+      calls.push(name);
+      const o = models[name] || {};
+      return {
+        find: o.find ?? (async () => []),
+        create: o.create ?? (async () => ({})),
+        update: o.update ?? (async () => ({})),
+        delete: o.delete ?? (async () => ({})),
+      };
+    },
+  };
+  return { ctx: { ogm, driver: {}, user: { username: "alice" } } as any, calls };
+}
+
+function countingResolve() {
+  const state = { calls: 0 };
+  const resolve = async () => {
+    state.calls += 1;
+    return RESULT;
+  };
+  return { resolve, state };
+}
+
+const snapshot = {
+  id: "d-1",
+  title: "old title",
+  body: "old body",
+  Author: { username: "alice", displayName: "Alice" },
+  BodyLastEditedBy: { username: "alice" },
+  DiscussionChannels: [{ channelUniqueName: "cats" }],
+  PastTitleVersions: [],
+  PastBodyVersions: [],
+};
+
+test("updateDiscussions: passes through to the resolver when there is no update", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussions(resolve, null, { where: { id: "d-1" } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []); // no snapshot fetch
+});
+
+test("updateDiscussions: does not fetch a snapshot when neither title nor body changes", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussions(resolve, null, { where: { id: "d-1" }, update: { pinned: true } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []);
+});
+
+test("updateDiscussions: skips snapshot/hooks when no discussion id is given", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussions(resolve, null, { where: {}, update: { title: "new" } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []);
+});
+
+test("updateDiscussions: fetches a snapshot and runs the update path on a title/body change", async () => {
+  const { ctx, calls } = makeCtx({ Discussion: { find: async () => [snapshot] } });
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussions(
+    resolve,
+    null,
+    { where: { id: "d-1" }, update: { title: "new title", body: "new body" } },
+    ctx,
+    {}
+  );
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.ok(calls.includes("Discussion"), "fetched the pre-update snapshot");
+});
+
+test("updateDiscussionWithChannelConnections: passes through when there is no update input", async () => {
+  const { ctx, calls } = makeCtx();
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussionWithChannelConnections(resolve, null, { where: { id: "d-1" } }, ctx, {});
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.deepEqual(calls, []);
+});
+
+test("updateDiscussionWithChannelConnections: fetches a snapshot on a body change", async () => {
+  const { ctx, calls } = makeCtx({ Discussion: { find: async () => [snapshot] } });
+  const { resolve, state } = countingResolve();
+  const out = await M.updateDiscussionWithChannelConnections(
+    resolve,
+    null,
+    { where: { id: "d-1" }, discussionUpdateInput: { body: "new body" } },
+    ctx,
+    {}
+  );
+  assert.equal(out, RESULT);
+  assert.equal(state.calls, 1);
+  assert.ok(calls.includes("Discussion"));
+});

--- a/middleware/issueActivityFeedMiddleware.test.ts
+++ b/middleware/issueActivityFeedMiddleware.test.ts
@@ -1,0 +1,100 @@
+// Unit tests for the issue activity-feed middleware, which records "deleted"/
+// "edited" activity on the related issue around delete/update mutations. Each
+// wrapper is invoked with a stubbed resolver and a permissive in-memory OGM,
+// asserting result pass-through and exercising the record / no-record branches.
+// The delegated activity-feed writes run against the stub. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import middleware from "./issueActivityFeedMiddleware.js";
+
+const M: any = (middleware as any).Mutation;
+
+function makeCtx() {
+  const ogm = {
+    model() {
+      return {
+        find: async () => [],
+        create: async () => ({}),
+        update: async () => ({}),
+        delete: async () => ({}),
+      };
+    },
+  };
+  return { ogm, driver: {}, user: { username: "alice" } } as any;
+}
+
+// Resolver returning a fixed value, counting invocations.
+function resolveWith(value: unknown) {
+  const state = { calls: 0 };
+  const resolve = async () => {
+    state.calls += 1;
+    return value;
+  };
+  return { resolve, state };
+}
+
+test("deleteComments records activity when a comment is deleted", async () => {
+  const { resolve, state } = resolveWith({ nodesDeleted: 1 });
+  const out = await M.deleteComments(resolve, null, { where: { id: "c-1" } }, makeCtx(), {});
+  assert.deepEqual(out, { nodesDeleted: 1 });
+  assert.equal(state.calls, 1);
+});
+
+test("deleteComments does not record when nothing was deleted", async () => {
+  const { resolve, state } = resolveWith({ nodesDeleted: 0 });
+  const out = await M.deleteComments(resolve, null, { where: { id: "c-1" } }, makeCtx(), {});
+  assert.deepEqual(out, { nodesDeleted: 0 });
+  assert.equal(state.calls, 1);
+});
+
+test("deleteComments passes through when no id is supplied", async () => {
+  const { resolve, state } = resolveWith({ nodesDeleted: 1 });
+  const out = await M.deleteComments(resolve, null, { where: {} }, makeCtx(), {});
+  assert.deepEqual(out, { nodesDeleted: 1 });
+  assert.equal(state.calls, 1);
+});
+
+test("deleteDiscussions records activity when a discussion is deleted", async () => {
+  const { resolve, state } = resolveWith({ nodesDeleted: 1 });
+  const out = await M.deleteDiscussions(resolve, null, { where: { id: "d-1" } }, makeCtx(), {});
+  assert.deepEqual(out, { nodesDeleted: 1 });
+  assert.equal(state.calls, 1);
+});
+
+test("deleteEvents records activity when an event is deleted", async () => {
+  const { resolve, state } = resolveWith({ nodesDeleted: 1 });
+  const out = await M.deleteEvents(resolve, null, { where: { id: "e-1" } }, makeCtx(), {});
+  assert.deepEqual(out, { nodesDeleted: 1 });
+  assert.equal(state.calls, 1);
+});
+
+test("updateEvents records an edit when there are updates", async () => {
+  const { resolve, state } = resolveWith({ events: [{ id: "e-1" }] });
+  const out = await M.updateEvents(resolve, null, { where: { id: "e-1" }, update: { title: "new" } }, makeCtx(), {});
+  assert.deepEqual(out, { events: [{ id: "e-1" }] });
+  assert.equal(state.calls, 1);
+});
+
+test("updateEvents does not record when the update is empty", async () => {
+  const { resolve, state } = resolveWith({ events: [] });
+  await M.updateEvents(resolve, null, { where: { id: "e-1" }, update: {} }, makeCtx(), {});
+  assert.equal(state.calls, 1);
+});
+
+test("updateEvents passes through when no id is supplied", async () => {
+  const { resolve, state } = resolveWith({ events: [] });
+  await M.updateEvents(resolve, null, { where: {}, update: { title: "new" } }, makeCtx(), {});
+  assert.equal(state.calls, 1);
+});
+
+test("updateEventWithChannelConnections records an edit when an id is present", async () => {
+  const { resolve, state } = resolveWith({ id: "e-1" });
+  await M.updateEventWithChannelConnections(resolve, null, { where: { id: "e-1" } }, makeCtx(), {});
+  assert.equal(state.calls, 1);
+});
+
+test("updateEventWithChannelConnections passes through with no id", async () => {
+  const { resolve, state } = resolveWith({ id: null });
+  await M.updateEventWithChannelConnections(resolve, null, { where: {} }, makeCtx(), {});
+  assert.equal(state.calls, 1);
+});


### PR DESCRIPTION
**Priority 3** from the coverage baseline: side-effect infrastructure (`errorHandling.ts` and `middleware/*`, all previously at 0%).

## Error handling — `errorHandling.ts` 0% → 93.8%

Unit tests (no server/DB) for the pure `formatGraphQLError` (message enhancement per error code, debug hints, `locations`/`path` passthrough, dev-vs-prod fields, sensitive-variable redaction) and the Apollo `errorHandlingPlugin.didEncounterErrors` (critical-error detection via code and message).

## Middleware

The `middleware/*` files were dark (~5.7% **merged**) because they delegate to hooks/utils (already tested) and the integration suite calls those underlying services directly, bypassing the live `graphql-middleware` layer — so the wrappers were never executed. These tests drive each wrapper's own branching by invoking it with a stubbed resolver and a permissive in-memory OGM; the delegated hook writes run against the stub. No database.

| File | Before | After |
|---|---|---|
| `errorHandling.ts` | 0% | **93.8%** |
| `discussionVersionHistoryMiddleware.ts` | 0% | **100%** |
| `commentVersionHistoryMiddleware.ts` | 0% | **100%** |
| `issueActivityFeedMiddleware.ts` | 0% | **~75%** |
| `channelBotsMiddleware.ts` (pure helpers) | 0% | helpers covered |

Each middleware test exercises the pass-through vs. record/snapshot branches and asserts the resolver result is returned unchanged. For `issueActivityFeedMiddleware` all five delete/update wrappers are covered; the remaining lines are DB-helper internals that short-circuit on empty stub data.

## Verification
Full unit suite **598/598**; `tsc` + `npm run lint` clean.

## Remaining
A few smaller middleware (mentions, plugin-pipeline, subscription-notification, wiki) follow the same pattern and could be covered next; `wikiPageVersionHistoryMiddleware`'s user extraction is currently a hardcoded placeholder (`TODO`), so its real coverage waits on that being implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)