### PR TITLE
docs: hosted-docs link + architecture overview with diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 The GraphQL/Neo4j backend for Multiforum. The frontend lives in a separate
 repository: [gennit-project/multiforum-nuxt](https://github.com/gennit-project/multiforum-nuxt).
 
+📖 **Hosted documentation: [docs.multiforum.net](https://docs.multiforum.net/)** — product
+docs and guides. This README and the [`docs/`](./docs) folder cover the backend
+internals.
+
 > Multiforum is under active development; test coverage is being expanded as core features stabilize.
 
 ## About
@@ -19,19 +23,92 @@ The frontend is a Nuxt/Vue application that makes GraphQL queries to this server
 For a full product overview, see the
 [frontend README](https://github.com/gennit-project/multiforum-nuxt).
 
+## Architecture
+
+A request flows through distinct layers, each with a single responsibility —
+transport, authentication, authorization, side effects, data resolution, and
+storage:
+
+```mermaid
+flowchart TD
+    Client["Nuxt / Vue client"] -->|GraphQL over HTTP| Apollo
+
+    subgraph Server["Apollo Server on Express"]
+        Apollo["Apollo Server<br/>(centralized error-handling plugin)"]
+        Auth["Per-request context<br/>Auth0 JWT verification"]
+        Apollo --> Auth
+    end
+
+    Auth --> Shield
+
+    subgraph MW["graphql-middleware pipeline"]
+        Shield["Authorization<br/>declarative graphql-shield rules"]
+        Effects["Side effects<br/>version history · mentions ·<br/>activity feed · plugin pipeline · bots"]
+        Shield --> Effects
+    end
+
+    Effects --> Schema
+
+    subgraph Schema["Executable GraphQL schema"]
+        Auto["Auto-generated resolvers<br/>Neo4j GraphQL — CRUD, filtering, pagination"]
+        Custom["Custom resolvers<br/>OGM + hand-written Cypher"]
+    end
+
+    Auto --> OGM
+    Custom --> OGM
+    OGM["Neo4j OGM / driver"] --> DB[("Neo4j graph database")]
+
+    Effects -. triggers .-> Plugins["Plugin runtime<br/>(server &amp; channel plugins)"]
+    DB -. change data capture .-> BG
+
+    subgraph BG["Event-driven background services"]
+        Notif["Notifications"]
+        Versions["Version history"]
+    end
+```
+
+**Why this stack.** A forum is a relationship-dense domain — threaded comments,
+channel memberships, role hierarchies, votes, mentions, moderation actions. A
+[graph database](https://neo4j.com/) models those relationships as first-class
+edges, so questions like *"which mods govern this channel"* or *"the parent
+chain of this comment"* are traversals rather than multi-table joins. The
+[Neo4j GraphQL library](https://neo4j.com/docs/graphql/current/) derives most of
+the API — typed CRUD, filtering, and nested relationship resolution — directly
+from the schema, which reserves hand-written code for genuinely custom logic
+(custom Cypher, transactions, cross-entity workflows). [GraphQL](https://graphql.org/)
+gives clients precise, typed data fetching against a single schema contract, and
+those types flow end-to-end into TypeScript via code generation.
+
+**Separation of concerns.** Authorization is expressed as composable
+[graphql-shield](https://www.npmjs.com/package/graphql-shield) rules applied as a
+middleware layer, kept out of resolver logic. Cross-cutting side effects —
+version history, @-mentions, activity feeds, plugin pipelines — are isolated in
+their own middleware, and asynchronous work (notifications, version snapshots)
+runs in event-driven background services fed by Neo4j change data capture, so it
+never blocks the request path. Behavior is extended at runtime through a
+[plugin system](./PLUGIN_REQUIREMENTS.md) rather than by modifying the core.
+
+→ **[Full architecture overview](./docs/architecture.md)** — layer-by-layer
+breakdown, request lifecycle, data model, and the testing strategy.
+
 ## Technology Summary
 
-- **API**: Apollo Server (GraphQL)
+- **API**: Apollo Server (GraphQL) on Express
 - **Database**: Neo4j (Neo4j GraphQL library + OGM + custom Cypher)
-- **Authentication**: Auth0
+- **Authorization**: graphql-shield (declarative, role-based)
+- **Authentication**: Auth0 (JWT)
 - **Email**: Resend or SendGrid
 - **File storage**: Google Cloud Storage
+- **Types**: TypeScript (strict) with generated GraphQL types
+- **Testing**: Node's test runner, [Testcontainers](https://testcontainers.com/) (integration against real Neo4j), c8 coverage
 
 ## Developer Docs
 
+- [Architecture overview](./docs/architecture.md)
 - [Environment variables and running the app](./docs/environment-variables.md)
 - [Permission system architecture](./docs/permission-system.md)
 - [Comment notification system](./docs/notifications.md)
+- [Test coverage baseline](./docs/coverage-baseline.md)
 - [Plugin requirements](./PLUGIN_REQUIREMENTS.md)
 - [Enhanced error handling](./ENHANCED_ERROR_HANDLING_USAGE.md)
 - [`hasDownload` filter logic](./HASDOWNLOAD_FILTER_LOGIC.md)
@@ -45,6 +122,8 @@ For a full product overview, see the
 | `npm run tsc` | Run the TypeScript compiler |
 | `npm run build` | Build the project (tsc + copy Cypher files) |
 | `npm run start` | Start the server |
+| `npm test` | Run the unit test suite |
+| `npm run test:integration` | Run integration tests against a real Neo4j (Testcontainers) |
 | `npm run logSchema` | Log the GraphQL schema to the console |
 
 See [Environment variables and running the app](./docs/environment-variables.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,185 @@
+# Architecture
+
+This document describes how the Multiforum backend is structured and the
+reasoning behind its main technology choices. For the permission model in
+detail, see [permission-system.md](./permission-system.md); for running the
+service, see [environment-variables.md](./environment-variables.md).
+
+## Overview
+
+The backend is a [GraphQL](https://graphql.org/) API over a
+[Neo4j](https://neo4j.com/) graph database. A request passes through a series of
+layers, each responsible for one concern:
+
+| Layer | Responsibility | Where it lives |
+| --- | --- | --- |
+| Transport | HTTP, GraphQL protocol, error formatting | `index.ts`, `errorHandling.ts` |
+| Authentication | Verify the caller's identity | request context, `rules/permission/` |
+| Authorization | Decide whether the action is allowed | `permissions.ts`, `rules/` |
+| Side effects | Cross-cutting work tied to mutations | `middleware/`, `hooks/` |
+| Resolution | Turn GraphQL operations into data | `customResolvers/`, Neo4j GraphQL |
+| Persistence | Store and traverse the graph | Neo4j OGM + driver |
+| Async work | Notifications, version history | `services/` |
+
+Keeping these concerns in separate layers means each can be read, changed, and
+tested on its own — authorization rules without touching resolvers, resolvers
+without touching the HTTP layer, side effects without touching either.
+
+## Request lifecycle
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Nuxt)
+    participant A as Apollo / Express
+    participant X as Auth (context)
+    participant S as graphql-shield
+    participant M as Side-effect middleware
+    participant R as Resolvers (auto + custom)
+    participant N as Neo4j
+
+    C->>A: GraphQL operation (+ JWT)
+    A->>X: Build per-request context
+    X->>X: Verify Auth0 JWT (jwks-rsa)
+    A->>S: Execute through middleware pipeline
+    S->>S: Evaluate authorization rules
+    alt Not permitted
+        S-->>C: Authorization error
+    else Permitted
+        S->>M: Continue
+        M->>R: resolve()
+        R->>N: Cypher / OGM
+        N-->>R: Records
+        R-->>M: Result
+        M->>M: Record version / mentions / activity, trigger plugins
+        M-->>C: Response
+    end
+    N-->>N: Change data capture → background services
+```
+
+## Layers in detail
+
+### Transport — Apollo Server on Express
+
+[`index.ts`](../index.ts) wires an [Apollo Server](https://www.apollographql.com/docs/apollo-server/)
+into an Express app. Two Apollo plugins are registered: the standard HTTP-drain
+plugin for graceful shutdown, and a project error-handling plugin
+([`errorHandling.ts`](../errorHandling.ts)) that formats GraphQL errors
+consistently, enriches them for debugging in development, redacts sensitive
+fields, and flags critical errors for monitoring.
+
+### Authentication — Auth0
+
+Each request carries an Auth0-issued JWT. The token is verified against Auth0's
+signing keys ([jwks-rsa](https://github.com/auth0/node-jwks-rsa) +
+[jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)) when the per-request
+context is built, establishing *who* the caller is. The caller's roles and
+permissions are loaded lazily — only when an authorization rule needs them — so
+unauthenticated and public operations pay no database cost.
+
+### Authorization — graphql-shield
+
+Authorization is a dedicated layer, not logic sprinkled through resolvers. It is
+expressed as [graphql-shield](https://www.npmjs.com/package/graphql-shield) rules in
+[`permissions.ts`](../permissions.ts) and [`rules/`](../rules), applied to the
+schema as middleware so a denied request never reaches a resolver.
+
+The permission model is role-based across two scopes (server-wide and
+per-channel) and two audiences (regular users and moderators), with suspension
+handling and server-level fallbacks. Rules are composed from small, focused
+pieces, and the pure decision in each rule (for example, *given these fetched
+roles, is this permission granted?*) is separated from the data fetching so it
+can be unit-tested directly. See [permission-system.md](./permission-system.md).
+
+### Resolution — Neo4j GraphQL + custom resolvers
+
+The executable schema is produced by the
+[Neo4j GraphQL library](https://neo4j.com/docs/graphql/current/) from a single
+set of type definitions ([`typeDefs.ts`](../typeDefs.ts)). For the majority of
+the API — CRUD, filtering, ordering, pagination, and nested relationship
+resolution — the library generates resolvers directly from the schema, so that
+behavior is defined declaratively rather than written by hand.
+
+Operations that need genuinely custom behavior (multi-step transactions,
+hand-tuned Cypher, cross-entity workflows) are implemented as custom resolvers,
+organized by domain under [`customResolvers/`](../customResolvers) with their
+Cypher kept in dedicated `.cypher` files. These use the
+[OGM](https://neo4j.com/docs/graphql/current/ogm/) for typed, programmatic graph
+access. A single composition root assembles the type, query, and mutation
+resolvers from per-concern builders.
+
+### Side effects — middleware and hooks
+
+Work that must happen alongside a mutation but is not part of its core result is
+handled in the [`middleware/`](../middleware) pipeline and
+[`hooks/`](../hooks): version history snapshots, @-mention extraction, issue
+activity feeds, the plugin pipeline, and channel bots. Isolating these as
+separate middleware keeps resolvers focused on their own job and makes each side
+effect independently changeable.
+
+### Async work — event-driven background services
+
+Latency-sensitive callers should not wait on email or history bookkeeping. The
+Neo4j GraphQL library's subscriptions are enabled as a change-data-capture
+stream that feeds [`services/`](../services): notification delivery and
+version-history services react to data changes out of band, off the request
+path.
+
+### Extensibility — the plugin system
+
+Server- and channel-level [plugins](../PLUGIN_REQUIREMENTS.md) extend behavior
+without changing the core. Events (a new comment, a new download, channel
+changes) flow through configurable pipelines that invoke plugins in order, with
+per-step conditions and failure handling. New capabilities are added by
+installing a plugin rather than editing the application.
+
+## Data model: why a graph
+
+A forum is dense with relationships: comments thread into replies, users belong
+to channels, channels grant roles, content accrues votes and reports, and
+moderation spans both server and channel scope. A graph database stores these
+relationships as first-class, directly traversable edges:
+
+```cypher
+(:User)-[:AUTHORED_COMMENT]->(:Comment)-[:POSTED_IN_CHANNEL]->(:Channel)
+(:User)-[:UPVOTED_COMMENT]->(:Comment)
+(:Comment)-[:IS_REPLY_TO]->(:Comment)
+(:Channel)-[:HAS_MOD_ROLE]->(:ModChannelRole)
+```
+
+(These are real relationship types from the schema.)
+
+Traversals such as "the parent chain of a comment", "the moderators who govern a
+channel", or "a user's contributions across channels" are local graph walks
+rather than recursive joins across many tables. The relational shape of the
+domain maps onto the storage model instead of fighting it.
+
+## Reliability and developer experience
+
+- **End-to-end types.** The codebase is TypeScript in strict mode. GraphQL and
+  OGM types are generated from the schema, so the API contract and the code that
+  implements it cannot silently drift apart. Type generation runs from
+  `typeDefs.ts` with no database or running server required, so a clean checkout
+  builds deterministically.
+- **Tested against a real database.** Unit tests run on Node's built-in test
+  runner; integration tests in [`tests/integration/`](../tests/integration) run
+  against a real Neo4j instance provisioned by
+  [Testcontainers](https://testcontainers.com/), so the actual Cypher and
+  transactions are exercised — not a mock. Coverage is tracked; see
+  [coverage-baseline.md](./coverage-baseline.md).
+- **Continuous integration.** Every change is type-checked, unit- and
+  integration-tested with coverage, and built before merge.
+- **Observability.** A structured, leveled logger replaces ad-hoc logging, and
+  GraphQL errors pass through one centralized formatter.
+
+## Repository map
+
+| Path | Contents |
+| --- | --- |
+| [`index.ts`](../index.ts) | Server bootstrap: schema assembly, middleware, Apollo/Express |
+| [`typeDefs.ts`](../typeDefs.ts) | GraphQL schema definition |
+| [`customResolvers/`](../customResolvers) | Custom queries, mutations, field resolvers, and Cypher |
+| [`permissions.ts`](../permissions.ts), [`rules/`](../rules) | Authorization rules (graphql-shield) |
+| [`middleware/`](../middleware), [`hooks/`](../hooks) | Mutation side effects |
+| [`services/`](../services) | Background services and the plugin runtime |
+| [`tests/`](../tests) | Unit and Testcontainers-backed integration tests |
+| [`docs/`](.) | This documentation |


### PR DESCRIPTION
## What

- **Hosted docs link** near the top of the README → [docs.multiforum.net](https://docs.multiforum.net/).
- **README "Architecture" section** — a Mermaid diagram of the layered request flow, a short rationale for the graph + GraphQL stack, and a note on how concerns are separated, with a link to the detailed doc.
- **New `docs/architecture.md`** — layer-by-layer breakdown, a request-lifecycle sequence diagram, the graph data model, the testing strategy, and a repository map.

## Notes

- Both diagrams use Mermaid, which GitHub renders natively in Markdown.
- Technical claims were checked against the code: middleware chain and background services from `index.ts`, the relationship types in the data-model example are real names from `typeDefs.ts`, and the dependency links point to the actual packages.
- Docs-only change — no code touched.