### PR TITLE
ci: shard integration tests for parallel execution (~30min → ~11min CI)

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -53,6 +53,13 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    # The integration suite is the CI bottleneck (serial, real Neo4j). Split it
+    # into parallel shards — each matrix job runs ~1/N of the files against its
+    # own Testcontainers Neo4j — so wall-clock is roughly the suite divided by N.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,18 +78,23 @@ jobs:
         run: npm run codegen
 
       # Testcontainers manages the Neo4j container itself via the Docker daemon
-      # that is available on GitHub-hosted Ubuntu runners. Run under c8 so the
-      # resolver coverage these tests provide is reported too.
-      - name: Run integration tests against live Neo4j (with coverage)
-        run: npm run coverage:integration
+      # available on GitHub-hosted Ubuntu runners. Run under c8 so the resolver
+      # coverage these tests provide is reported too.
+      - name: Run integration shard ${{ matrix.shard }}/4 against live Neo4j (with coverage)
+        run: npm run test:integration:shard
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARD_TOTAL: 4
 
-      # Uploaded under the `integration` flag; Codecov merges it with the unit
-      # upload so a line covered by either suite counts as covered.
+      # Each shard uploads under the `integration` flag with a distinct name;
+      # Codecov unions the shards (and merges with the unit upload), so a line
+      # covered by any shard or the unit suite counts as covered.
       - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           flags: integration
+          name: integration-shard-${{ matrix.shard }}
           fail_ci_if_error: false
           verbose: true

--- a/build_scripts/integration-shard.sh
+++ b/build_scripts/integration-shard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Run one shard of the integration suite. The sorted integration test files are
+# partitioned round-robin across SHARD_TOTAL shards, so each shard runs roughly
+# 1/SHARD_TOTAL of them. CI runs the shards in parallel (a matrix job), each
+# against its own Testcontainers Neo4j. Coverage (lcov) is written for this
+# shard's subset; CI uploads each shard under the `integration` Codecov flag and
+# Codecov unions them, so a line covered by any shard counts as covered.
+#
+# Env:
+#   SHARD       1-based shard index   (default 1)
+#   SHARD_TOTAL number of shards      (default 1 -> runs everything)
+#
+# Run via `npm run test:integration:shard` so node_modules/.bin (c8) is on PATH.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SHARD="${SHARD:-1}"
+SHARD_TOTAL="${SHARD_TOTAL:-1}"
+
+# Round-robin: the file on line NR goes to shard ((NR-1) % SHARD_TOTAL) + 1.
+list_files() {
+  find ./tests/integration -name '*test.ts' -print | sort \
+    | awk "NR % ${SHARD_TOTAL} == (${SHARD} - 1)"
+}
+
+if [ -z "$(list_files)" ]; then
+  echo "Shard ${SHARD}/${SHARD_TOTAL}: no files assigned; nothing to run."
+  exit 0
+fi
+
+echo "Shard ${SHARD}/${SHARD_TOTAL} running $(list_files | wc -l | tr -d ' ') file(s):"
+list_files
+
+# One Neo4j container per shard (reuse keeps the shard's files sharing it). The
+# inline $(list_files) word-splits the newline-separated paths into args, the
+# same way the other coverage scripts use $(find ...).
+export TESTCONTAINERS_REUSE_ENABLE=true
+c8 --reporter=lcov --reporter=text-summary \
+  node --loader ts-node/esm --test --test-concurrency=1 $(list_files)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:integration": "TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
     "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "test:integration:shard": "bash build_scripts/integration-shard.sh",
     "coverage:merged": "bash build_scripts/coverage-merged.sh",
     "prepare": "husky",
     "codegen": "node --loader ts-node/esm build_scripts/generateTypes.ts",


### PR DESCRIPTION
## Why

The integration job is the entire CI bottleneck. Per-job durations from recent `main` runs:

| Job | Duration |
|---|---|
| **integration-tests** | **~28–31 min** |
| unit-tests | ~11–12 min |

The jobs run in parallel, so wall-clock = the integration job ≈ **30 min**. Almost all of that is the 32 integration files running **serially** (`--test-concurrency=1`) against a single Neo4j container.

## What

Split the integration suite into **4 parallel shards**. The `integration-tests` job is now a matrix (`shard: [1,2,3,4]`); each shard:
- runs ~1/4 of the files (round-robin partition over the sorted file list, `awk "NR % 4 == shard-1"`),
- against **its own** Testcontainers Neo4j,
- and uploads coverage under the `integration` flag with a distinct `name`.

Codecov **unions** the shards (and merges with the unit upload), so merged coverage is unchanged — a line covered by any shard counts.

- `build_scripts/integration-shard.sh` — partitions and runs the subset under c8 (lcov).
- `npm run test:integration:shard` — reads `SHARD` / `SHARD_TOTAL` from env.

## Verification (local)
- The 4-way partition covers **all 32 files with zero overlap** (verified each shard = 8 files, union = 32, no duplicates).
- A shard runs end-to-end via `npm run test:integration:shard` → tests pass, `coverage/lcov.info` produced.

## Expected impact
Integration wall-clock **~30 min → ~8–10 min** (each shard: ~8 files + fixed setup), bringing total CI **~30 min → ~11 min** — now bounded by the unit job, which can be trimmed next (the `build` step re-runs codegen+tsc redundantly).

**Trade-off:** uses 4 parallel runners instead of 1. If your Actions concurrency tier is tight, shards may queue; drop `SHARD_TOTAL`/the matrix to 2–3 if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)