### PR TITLE
feat: P1 content-locking & download validation rules

### DIFF
--- a/customResolvers/mutations/channelPreferenceGuards.ts
+++ b/customResolvers/mutations/channelPreferenceGuards.ts
@@ -3,6 +3,21 @@ import type { CommentModel, DiscussionChannelModel } from "../../ogm_types.js";
 const emojiDisabledMessage = (channelName: string) =>
   `Emoji reactions are disabled in channel '${channelName}'.`;
 
+// Locked/archived content is frozen: no emoji reactions can be added or
+// removed. Throws with a clear reason when the target (or its discussion) is
+// locked or archived.
+const assertNotLockedOrArchived = (
+  entity: { locked?: boolean | null; archived?: boolean | null } | null | undefined,
+  label: string
+) => {
+  if (entity?.locked) {
+    throw new Error(`Emoji reactions are disabled because this ${label} is locked.`);
+  }
+  if (entity?.archived) {
+    throw new Error(`Emoji reactions are disabled because this ${label} is archived.`);
+  }
+};
+
 const getEmojiEnabledFromChannel = (channel?: {
   uniqueName?: string;
   emojiEnabled?: boolean | null;
@@ -26,6 +41,8 @@ export const assertDiscussionChannelEmojiEnabled = async (
     selectionSet: `{
       id
       emoji
+      locked
+      archived
       channelUniqueName
       Channel {
         uniqueName
@@ -38,6 +55,8 @@ export const assertDiscussionChannelEmojiEnabled = async (
   if (!discussionChannel) {
     throw new Error("DiscussionChannel not found");
   }
+
+  assertNotLockedOrArchived(discussionChannel, "discussion");
 
   const channelPreference = getEmojiEnabledFromChannel(
     discussionChannel.Channel
@@ -62,12 +81,15 @@ export const assertCommentEmojiEnabled = async (
     selectionSet: `{
       id
       emoji
+      archived
       Channel {
         uniqueName
         emojiEnabled
       }
       DiscussionChannel {
         channelUniqueName
+        locked
+        archived
         Channel {
           uniqueName
           emojiEnabled
@@ -80,6 +102,11 @@ export const assertCommentEmojiEnabled = async (
   if (!comment) {
     throw new Error("Comment not found");
   }
+
+  // The comment itself can be archived, and the discussion it lives under can
+  // be locked or archived — any of these freezes reactions on the comment.
+  assertNotLockedOrArchived(comment, "comment");
+  assertNotLockedOrArchived(comment.DiscussionChannel, "discussion");
 
   const channelPreference =
     getEmojiEnabledFromChannel(comment.Channel) ||

--- a/customResolvers/mutations/emojiPreferenceResolvers.test.ts
+++ b/customResolvers/mutations/emojiPreferenceResolvers.test.ts
@@ -39,6 +39,36 @@ const createDisabledDiscussionChannel = () =>
     },
   ]);
 
+const createCommentWith = (overrides: Record<string, unknown>) =>
+  new ModelStub(() => [
+    {
+      id: "comment-1",
+      emoji: "",
+      archived: false,
+      Channel: { uniqueName: "cats", emojiEnabled: true },
+      DiscussionChannel: {
+        channelUniqueName: "cats",
+        locked: false,
+        archived: false,
+        Channel: { uniqueName: "cats", emojiEnabled: true },
+      },
+      ...overrides,
+    },
+  ]);
+
+const createDiscussionChannelWith = (overrides: Record<string, unknown>) =>
+  new ModelStub(() => [
+    {
+      id: "discussion-channel-1",
+      emoji: "",
+      channelUniqueName: "cats",
+      locked: false,
+      archived: false,
+      Channel: { uniqueName: "cats", emojiEnabled: true },
+      ...overrides,
+    },
+  ]);
+
 test("addEmojiToComment rejects disabled emoji channels", async () => {
   const Comment = createDisabledComment();
   const resolver = addEmojiToCommentResolver({ Comment: Comment as any });
@@ -114,5 +144,77 @@ test("removeEmojiFromDiscussionChannel rejects disabled emoji channels", async (
       )
     ),
     /Emoji reactions are disabled in channel 'cats'/
+  );
+});
+
+// Locked/archived content is frozen for reactions (item: "when a comment or
+// discussion is locked, it does not allow emojis").
+
+test("addEmojiToComment rejects when the comment is archived", async () => {
+  const Comment = createCommentWith({ archived: true });
+  const resolver = addEmojiToCommentResolver({ Comment: Comment as any });
+
+  await assert.rejects(
+    withMutedConsoleError(() =>
+      resolver(null, { ...emojiArgs, commentId: "comment-1" }, {} as unknown as GraphQLContext, null as unknown as GraphQLResolveInfo)
+    ),
+    /this comment is archived/
+  );
+});
+
+test("addEmojiToComment rejects when the discussion is locked", async () => {
+  const Comment = createCommentWith({
+    DiscussionChannel: {
+      channelUniqueName: "cats",
+      locked: true,
+      archived: false,
+      Channel: { uniqueName: "cats", emojiEnabled: true },
+    },
+  });
+  const resolver = addEmojiToCommentResolver({ Comment: Comment as any });
+
+  await assert.rejects(
+    withMutedConsoleError(() =>
+      resolver(null, { ...emojiArgs, commentId: "comment-1" }, {} as unknown as GraphQLContext, null as unknown as GraphQLResolveInfo)
+    ),
+    /this discussion is locked/
+  );
+});
+
+test("addEmojiToDiscussionChannel rejects when locked", async () => {
+  const DiscussionChannel = createDiscussionChannelWith({ locked: true });
+  const resolver = addEmojiToDiscussionChannelResolver({
+    DiscussionChannel: DiscussionChannel as any,
+  });
+
+  await assert.rejects(
+    withMutedConsoleError(() =>
+      resolver(
+        null,
+        { ...emojiArgs, discussionChannelId: "discussion-channel-1" },
+        {} as unknown as GraphQLContext,
+        null as unknown as GraphQLResolveInfo
+      )
+    ),
+    /this discussion is locked/
+  );
+});
+
+test("addEmojiToDiscussionChannel rejects when archived", async () => {
+  const DiscussionChannel = createDiscussionChannelWith({ archived: true });
+  const resolver = addEmojiToDiscussionChannelResolver({
+    DiscussionChannel: DiscussionChannel as any,
+  });
+
+  await assert.rejects(
+    withMutedConsoleError(() =>
+      resolver(
+        null,
+        { ...emojiArgs, discussionChannelId: "discussion-channel-1" },
+        {} as unknown as GraphQLContext,
+        null as unknown as GraphQLResolveInfo
+      )
+    ),
+    /this discussion is archived/
   );
 });

--- a/permissions.ts
+++ b/permissions.ts
@@ -232,7 +232,11 @@ const permissionList = shield({
       deleteNotifications: deny,
       updateNotifications: deny,
 
-      updateImages: and(isAuthenticated, isImageUploader),
+      // Image edits (e.g. captions) are allowed for the uploader (OP), an
+      // image mod, or an admin. canArchiveAndUnarchiveImage resolves to the
+      // server-level canArchiveImage mod permission here, since updateImages
+      // carries no channel argument and images aren't channel-scoped.
+      updateImages: and(isAuthenticated, or(isImageUploader, canArchiveAndUnarchiveImage, isAdmin)),
       createImages: deny, // Use createImageWithUploader instead to ensure Uploader is set
       createImageWithUploader: and(isAuthenticated, canUploadFile),
 

--- a/rules/definitions/contentCreationRules.ts
+++ b/rules/definitions/contentCreationRules.ts
@@ -12,6 +12,22 @@ import {
   EventCreateInput,
 } from "../../src/generated/graphql.js";
 
+// Locked content is read-only and archived content is closed: no new comments
+// (or replies) may be created on a locked/archived discussion, event, or
+// comment. Throws with a clear reason. Mods who need to comment must unlock /
+// unarchive first.
+const assertParentNotLockedOrArchived = (
+  entity: { locked?: boolean | null; archived?: boolean | null } | null | undefined,
+  label: string
+) => {
+  if (entity?.locked) {
+    throw new Error(`You cannot comment on a locked ${label}.`);
+  }
+  if (entity?.archived) {
+    throw new Error(`You cannot comment on an archived ${label}.`);
+  }
+};
+
 export async function evaluateCanCreateChannelRule(ctx: GraphQLContext) {
   const hasPermissionToCreateChannels = await hasServerPermission(
     "canCreateChannel",
@@ -107,12 +123,27 @@ export const canCreateComment = rule({ cache: "contextual" })(
       GivesFeedbackOnEvent,
       GivesFeedbackOnDiscussion,
       GivesFeedbackOnComment,
+      ParentComment,
       Channel,
     } = firstItemInInput;
 
     // Throw an error if no Channel is provided; all comments must be in the context of a channel.
     if (!Channel || !Channel.connect?.where?.node?.uniqueName) {
       throw new Error("Comment must be connected to a Channel.");
+    }
+
+    // Replies cannot be made to an archived comment.
+    const parentCommentId = ParentComment?.connect?.where?.node?.id;
+    if (parentCommentId) {
+      const commentModel = ctx.ogm.model("Comment");
+      const parentComments = await commentModel.find({
+        where: { id: parentCommentId },
+        selectionSet: `{ id archived }`,
+      });
+      if (!parentComments || !parentComments[0]) {
+        throw new Error("Could not find the comment being replied to.");
+      }
+      assertParentNotLockedOrArchived(parentComments[0], "comment");
     }
 
     let channelName = '';
@@ -131,12 +162,14 @@ export const canCreateComment = rule({ cache: "contextual" })(
       const discussionChannelModel = ctx.ogm.model("DiscussionChannel");
       const discussionChannel = await discussionChannelModel.find({
         where: { id: discussionChannelId },
-        selectionSet: `{ channelUniqueName }`,
+        selectionSet: `{ channelUniqueName locked archived }`,
       });
 
       if (!discussionChannel || !discussionChannel[0]) {
         throw new Error("No discussion channel found.");
       }
+
+      assertParentNotLockedOrArchived(discussionChannel[0], "discussion");
 
       channelName = discussionChannel[0]?.channelUniqueName;
     }
@@ -157,12 +190,14 @@ export const canCreateComment = rule({ cache: "contextual" })(
           eventId,
           channelUniqueName: Channel?.connect?.where?.node?.uniqueName
         },
-        selectionSet: `{ id }`,
+        selectionSet: `{ id locked archived }`,
       });
 
       if (!event || !event[0]) {
         throw new Error("Could not find the event submission in the given channel.");
       }
+
+      assertParentNotLockedOrArchived(event[0], "event");
 
       channelName = Channel?.connect?.where?.node?.uniqueName
     }

--- a/rules/validation/channelPreferences.test.ts
+++ b/rules/validation/channelPreferences.test.ts
@@ -129,7 +129,7 @@ test("feedback validation ignores regular comments", async () => {
 test("download validation rejects disabled download channels", async () => {
   const result = await validateDiscussionDownloadPreferences(
     {
-      discussionCreateInput: {
+      discussionInput: {
         title: "Download",
         hasDownload: true,
       },
@@ -146,7 +146,7 @@ test("download validation rejects disabled download channels", async () => {
 test("download validation rejects disallowed channel file types", async () => {
   const result = await validateDiscussionDownloadPreferences(
     {
-      discussionCreateInput: {
+      discussionInput: {
         title: "Download",
         hasDownload: true,
         DownloadableFiles: {
@@ -174,7 +174,7 @@ test("download validation rejects disallowed channel file types", async () => {
 test("download validation allows enabled channels with allowed file types", async () => {
   const result = await validateDiscussionDownloadPreferences(
     {
-      discussionCreateInput: {
+      discussionInput: {
         title: "Download",
         hasDownload: true,
         DownloadableFiles: {
@@ -194,6 +194,23 @@ test("download validation allows enabled channels with allowed file types", asyn
   );
 
   assert.equal(result, true);
+});
+
+test("download validation on update resolves the discussion's channels from where", async () => {
+  // The update path passes `where` instead of channelConnections; the
+  // discussion's existing channels are resolved and their download rules apply.
+  const result = await validateDiscussionDownloadPreferences(
+    {
+      discussionInput: { hasDownload: true },
+      where: { id: "discussion-1" },
+    },
+    createContext({
+      channel: { uniqueName: "cats", downloadsEnabled: false },
+      discussion: { DiscussionChannels: [{ channelUniqueName: "cats" }] },
+    })
+  );
+
+  assert.equal(result, "Downloads are disabled in channel 'cats'.");
 });
 
 test("discussion image validation rejects disabled image upload channels on create", async () => {

--- a/rules/validation/discussionIsValid.ts
+++ b/rules/validation/discussionIsValid.ts
@@ -179,19 +179,40 @@ export async function validateDiscussionImagePreferences(
   return validateImageUploadsEnabled(targetChannelConnections, ctx);
 }
 
+// Enforces channel-level download rules when a discussion attaches a download.
+// Works for both create and update: downloads are governed by sitewide rules at
+// upload time, but the channel's rules (downloadsEnabled + allowedFileTypes)
+// only apply once the download is submitted to a channel — which is here. For
+// updates with no explicit channelConnections, the discussion's existing
+// channels are resolved from `where`.
 export async function validateDiscussionDownloadPreferences(
-  item: CreateDiscussionItem,
+  {
+    discussionInput,
+    channelConnections,
+    where,
+  }: {
+    discussionInput: any;
+    channelConnections?: string[];
+    where?: any;
+  },
   ctx: GraphQLContext
 ) {
-  const { discussionCreateInput, channelConnections } = item;
-  const downloadableFileIds = getDownloadableFileIds(discussionCreateInput);
+  const downloadableFileIds = getDownloadableFileIds(discussionInput);
 
-  if (!discussionCreateInput.hasDownload && !downloadableFileIds.length) {
+  if (!discussionInput?.hasDownload && !downloadableFileIds.length) {
     return true;
   }
 
+  const targetChannelConnections = channelConnections?.length
+    ? channelConnections
+    : await getDiscussionChannelNamesByWhere(where, ctx);
+
+  if (!targetChannelConnections.length) {
+    return "No channel specified for this operation.";
+  }
+
   const downloadsEnabledResult = await validateDownloadChannelsEnabled(
-    channelConnections,
+    targetChannelConnections,
     ctx
   );
 
@@ -221,7 +242,7 @@ export async function validateDiscussionDownloadPreferences(
 
     const fileTypeValidation = await validateFileTypePermissions(
       downloadableFile.fileName || "",
-      channelConnections,
+      targetChannelConnections,
       ctx
     );
 
@@ -251,7 +272,10 @@ export const createDiscussionInputIsValid = rule({ cache: "contextual" })(
       }
 
       const downloadValidation = await validateDiscussionDownloadPreferences(
-        item,
+        {
+          discussionInput: item.discussionCreateInput,
+          channelConnections: item.channelConnections,
+        },
         ctx
       );
       if (downloadValidation !== true) {
@@ -290,6 +314,21 @@ export const updateDiscussionInputIsValid = rule({ cache: "contextual" })(
 
     if (discussionValidation !== true) {
       return discussionValidation;
+    }
+
+    // Attaching or changing a download via update must respect the channel's
+    // download rules, same as create. Previously only image preferences were
+    // checked here, so downloads could be added through update unchecked.
+    const downloadValidation = await validateDiscussionDownloadPreferences(
+      {
+        discussionInput: discussionUpdateInput,
+        channelConnections: args.channelConnections,
+        where: (args as any).where,
+      },
+      ctx
+    );
+    if (downloadValidation !== true) {
+      return downloadValidation;
     }
 
     return validateDiscussionImagePreferences(


### PR DESCRIPTION
## Summary

Implements the P1 functional validation rules from the backend roadmap (follow-up to #64).

| Rule | Change |
|---|---|
| **No comments on locked/archived content** | `canCreateComment` now checks the resolved `DiscussionChannel`/`EventChannel` for `locked`/`archived` and the `ParentComment` for `archived`, throwing a clear error. |
| **No emoji reactions on locked/archived content** | The shared emoji guards (`assertDiscussionChannelEmojiEnabled`/`assertCommentEmojiEnabled`) reject when the discussion is locked/archived or the comment is archived — for both add and remove (locked = frozen). |
| **Mods can edit image captions** | `updateImages` was uploader-only → `or(isImageUploader, canArchiveAndUnarchiveImage, isAdmin)`. Images aren't channel-scoped, so `canArchiveAndUnarchiveImage` resolves to the server-level `canArchiveImage` mod permission here. |
| **Channel download rules on discussion *update*** | The create path already enforced channel `downloadsEnabled` + per-file `allowedFileTypes` via `validateDiscussionDownloadPreferences`. The **update** path did not, so a download could be attached on edit unchecked. Generalized the helper (resolves the discussion's channels from `where`) and wired it into `updateDiscussionInputIsValid`. |

## On the "downloads need a Channel/Discussion association" item

The original roadmap wording ("reject uploads without an associated Discussion/Channel/DiscussionChannel") was based on a wrong premise. A `DownloadableFile`, like an `Image`, can legitimately exist with **no** channel — the actual upload flow creates the file standalone, then attaches it to a Discussion later. So:

- **Upload time** → governed by **sitewide** rules (server `allowedFileTypes`), already enforced in `createSignedStorageURL`.
- **Submission to a channel** (via the discussion) → governed by **channel** rules. Already enforced on create; this PR closes the **update** gap.

Enforcing a channel association at file-create time would have broken the upload flow, so it was intentionally not done that way.

## Scope notes
- "Locked" here means the discussion/event/comment level (`DiscussionChannel`/`EventChannel`/`Comment`), which is the roadmap's explicit ask — distinct from whole-channel `lockChannel` (`Channel.locked`).
- Mods who need to comment on locked/archived threads unlock/unarchive first.

## Testing
- `npm run tsc` clean.
- New/updated unit tests: 8/8 emoji guard tests (incl. 4 locked/archived cases), 11/11 `channelPreferences` tests (incl. new download-update path).
- Full unit suite green (pre-commit hook).
- Full integration suite **164/164** against local Neo4j for the comment/emoji/image changes; a final run covering the download-update change is in progress (CI also runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)