### PR TITLE
feat(tags): membership-derived authorIsChannelModerator @cypher field (expand 1/N)

### DIFF
--- a/tests/integration/authorIsChannelModerator.test.ts
+++ b/tests/integration/authorIsChannelModerator.test.ts
@@ -1,0 +1,109 @@
+// Verifies the membership-derived `authorIsChannelModerator` @cypher field on
+// Discussion (the replacement for the legacy ChannelRole.showModTag MOD badge).
+// The flag must be true when the content author is a channel owner
+// (ADMIN_OF_CHANNEL) or a channel moderator (MODERATION_PROFILE ->
+// MODERATOR_OF_CHANNEL), and false otherwise. See docs/isadmin-phaseout-design.md.
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import { graphql, type GraphQLSchema } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
+
+const SERVER_CONFIG_NAME = "ModTagTestServer";
+const CHANNEL = "cats";
+
+let container: StartedNeo4jContainer;
+let schema: GraphQLSchema;
+let driver: Driver;
+let ogm: any;
+
+before(async () => {
+  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  process.env.NEO4J_URI = container.getBoltUri();
+  process.env.NEO4J_USER = container.getUsername();
+  process.env.NEO4J_PASSWORD = container.getPassword();
+  process.env.SERVER_CONFIG_NAME = SERVER_CONFIG_NAME;
+
+  const { buildPermissionedSchema } = await import(
+    "../helpers/buildPermissionedSchema.js"
+  );
+  ({ schema, driver, ogm } = await buildPermissionedSchema());
+  await ogm.init();
+
+  const session = driver.session();
+  try {
+    await session.run("CREATE (:Channel { uniqueName: $ch })", { ch: CHANNEL });
+
+    // Owner: ADMIN_OF_CHANNEL
+    await session.run(
+      `MATCH (ch:Channel { uniqueName: $ch })
+       CREATE (u:User { username: 'owner' })-[:ADMIN_OF_CHANNEL]->(ch)
+       CREATE (u)-[:POSTED_DISCUSSION]->(:Discussion { id: 'd-owner', title: 'o' })`,
+      { ch: CHANNEL }
+    );
+
+    // Moderator: MODERATION_PROFILE -> MODERATOR_OF_CHANNEL
+    await session.run(
+      `MATCH (ch:Channel { uniqueName: $ch })
+       CREATE (u:User { username: 'mod' })-[:MODERATION_PROFILE]->(mp:ModerationProfile { displayName: 'mod-prof' })
+       CREATE (mp)-[:MODERATOR_OF_CHANNEL]->(ch)
+       CREATE (u)-[:POSTED_DISCUSSION]->(:Discussion { id: 'd-mod', title: 'm' })`,
+      { ch: CHANNEL }
+    );
+
+    // Regular user: no channel role
+    await session.run(
+      `CREATE (u:User { username: 'regular' })
+       CREATE (u)-[:POSTED_DISCUSSION]->(:Discussion { id: 'd-regular', title: 'r' })`
+    );
+  } finally {
+    await session.close();
+  }
+}, { timeout: 240000 });
+
+after(async () => {
+  await driver?.close();
+  await container?.stop();
+});
+
+const QUERY = /* GraphQL */ `
+  query ($id: ID!, $channelUniqueName: String) {
+    discussions(where: { id: $id }) {
+      id
+      authorIsChannelModerator(channelUniqueName: $channelUniqueName)
+    }
+  }
+`;
+
+const run = async (id: string, channelUniqueName: string | null) => {
+  const result = await graphql({
+    schema,
+    source: QUERY,
+    contextValue: { driver, ogm, req: { headers: {} } },
+    variableValues: { id, channelUniqueName },
+  });
+  assert.equal(result.errors, undefined, JSON.stringify(result.errors));
+  const data = result.data as any;
+  return data?.discussions?.[0]?.authorIsChannelModerator;
+};
+
+test("channel owner's discussion -> authorIsChannelModerator true", async () => {
+  assert.equal(await run("d-owner", CHANNEL), true);
+});
+
+test("channel moderator's discussion -> authorIsChannelModerator true", async () => {
+  assert.equal(await run("d-mod", CHANNEL), true);
+});
+
+test("regular user's discussion -> authorIsChannelModerator false", async () => {
+  assert.equal(await run("d-regular", CHANNEL), false);
+});
+
+test("a different channel does not grant the badge", async () => {
+  assert.equal(await run("d-owner", "dogs"), false);
+});
+
+test("null channelUniqueName -> false", async () => {
+  assert.equal(await run("d-owner", null), false);
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -590,6 +590,20 @@ const typeDefinitions = gql`
       END AS isFavorited
     """, columnName: "isFavorited")
 
+    # Membership-derived display flag: is this discussion's author a moderator or
+    # owner of the given channel? Replaces the legacy ChannelRole.showModTag for
+    # the MOD badge. See docs/isadmin-phaseout-design.md.
+    authorIsChannelModerator(channelUniqueName: String): Boolean @cypher(statement: """
+      OPTIONAL MATCH (this)<-[:POSTED_DISCUSSION]-(author:User)
+      RETURN CASE
+        WHEN author IS NULL OR $channelUniqueName IS NULL THEN false
+        WHEN EXISTS { (author)-[:ADMIN_OF_CHANNEL]->(:Channel {uniqueName: $channelUniqueName}) }
+          OR EXISTS { (author)-[:MODERATION_PROFILE]->(:ModerationProfile)-[:MODERATOR_OF_CHANNEL]->(:Channel {uniqueName: $channelUniqueName}) }
+        THEN true
+        ELSE false
+      END AS authorIsChannelModerator
+    """, columnName: "authorIsChannelModerator")
+
     # Shared collections
     SharedCollection: Collection @relationship(type: "SHARES_COLLECTION", direction: OUT)
   }
@@ -756,6 +770,18 @@ const typeDefinitions = gql`
       @relationship(type: "SUBSCRIBED_TO_NOTIFICATIONS", direction: IN)
     SubscribedToEventUpdates: [User!]!
       @relationship(type: "SUBSCRIBED_TO_EVENT_UPDATES", direction: IN)
+    # Membership-derived display flag: is this event's author a moderator or
+    # owner of the given channel? Replaces the legacy ChannelRole.showModTag.
+    authorIsChannelModerator(channelUniqueName: String): Boolean @cypher(statement: """
+      OPTIONAL MATCH (this)<-[:POSTED_BY]-(author:User)
+      RETURN CASE
+        WHEN author IS NULL OR $channelUniqueName IS NULL THEN false
+        WHEN EXISTS { (author)-[:ADMIN_OF_CHANNEL]->(:Channel {uniqueName: $channelUniqueName}) }
+          OR EXISTS { (author)-[:MODERATION_PROFILE]->(:ModerationProfile)-[:MODERATOR_OF_CHANNEL]->(:Channel {uniqueName: $channelUniqueName}) }
+        THEN true
+        ELSE false
+      END AS authorIsChannelModerator
+    """, columnName: "authorIsChannelModerator")
   }
 
   type Comment {


### PR DESCRIPTION
## Summary

First slice of the **membership-derived display-tag refactor** — replacing the legacy `ChannelRole.showModTag` MOD badge (and removing the vestigial `ServerRole.showAdminTag`) so roles are permissions-only and tags derive from membership. This is the **"expand"** phase: add the new mechanism, keep the legacy fields until the frontend switches.

## Why a `@cypher` field
The discussion/event detail views read the tag via the **auto-generated** query path (`Author.ChannelRoles(where: { channelUniqueName }) { showModTag }`), which can't compute membership. A `@cypher` computed field on the content type solves this uniformly:

- `Discussion.authorIsChannelModerator(channelUniqueName): Boolean`
- `Event.authorIsChannelModerator(channelUniqueName): Boolean`

Each returns, from membership, whether the content's author is a channel **owner** (`ADMIN_OF_CHANNEL`) or **moderator** (`MODERATION_PROFILE → MODERATOR_OF_CHANNEL`) of the given channel. The flag lives on the **content** (never on `User` — it's channel-contextual).

The **admin** tag is already membership-derived on the frontend (`serverAdminUsernames`), so `showAdminTag` is purely vestigial and is dropped in the contract phase.

## Testing
- Schema compiles (codegen).
- Integration test against Testcontainers Neo4j — **5/5**: owner → true, mod → true, regular → false, wrong channel → false, null channel → false.
- Full unit suite green in pre-commit.

## Remaining in this refactor (tracked)
1. **Comment / list custom-cypher resolvers** — compute the flag inline (those return custom maps, so `@cypher` fields don't auto-apply).
2. **Frontend** — switch `getCommentAuthorStatus` + the 4 components to the new field; stop selecting `showAdminTag`/`showModTag`.
3. **Contract** — remove `showAdminTag` (`ServerRole`) / `showModTag` (`ChannelRole`) from the schema + cypher once nothing selects them.

No behavior change in this PR (legacy fields untouched; new field additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)