### PR TITLE
test: provisionServerDefaults integration test (+ re-land orphaned PR-2 seedData)

### DIFF
--- a/build_scripts/provisionServerDefaults.ts
+++ b/build_scripts/provisionServerDefaults.ts
@@ -1,0 +1,49 @@
+// Runnable entry point for provisioning a Multiforum server's default roles and
+// config. Idempotent — safe to run on a fresh install or an existing instance.
+//
+//   NEO4J_PASSWORD=... SERVER_CONFIG_NAME="My Server" \
+//     node --loader ts-node/esm build_scripts/provisionServerDefaults.ts
+//
+// Also backfills existing admins into SuperAdmins (isAdmin phase-out). See
+// docs/isadmin-phaseout-design.md and seedData/.
+import neo4j from "neo4j-driver";
+import { createOgmAndModels } from "../customResolvers/resolverDeps.js";
+import { provisionServerDefaults } from "../seedData/provisionServerDefaults.js";
+
+const uri = process.env.NEO4J_URI || "bolt://localhost:7687";
+const user = process.env.NEO4J_USER || "neo4j";
+const password = process.env.NEO4J_PASSWORD;
+const serverName = process.env.SERVER_CONFIG_NAME;
+
+if (!password) {
+  throw new Error("NEO4J_PASSWORD is required to run provisioning");
+}
+if (!serverName) {
+  throw new Error("SERVER_CONFIG_NAME is required to run provisioning");
+}
+
+const run = async () => {
+  const driver = neo4j.driver(uri, neo4j.auth.basic(user, password as string));
+  const deps = createOgmAndModels(driver);
+  await deps.ogm.init();
+
+  try {
+    const result = await provisionServerDefaults({
+      ServerRole: deps.ServerRole,
+      ModServerRole: deps.ModServerRole,
+      ServerConfig: deps.ServerConfig,
+      serverName: serverName as string,
+      log: (message) => console.log(`[provision] ${message}`),
+    });
+    console.log("[provision] Done:", JSON.stringify(result, null, 2));
+  } finally {
+    await driver.close();
+  }
+};
+
+run()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("Provisioning failed", error);
+    process.exit(1);
+  });

--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -169,6 +169,25 @@ SuperAdmins section.
 4. Suspension handling stays; ensure a **suspended admin** resolves the suspended
    role (symmetric with suspended users).
 
+### Seed-data architecture (single source of truth)
+
+The default roles are defined once, in **`seedData/`**, and consumed by every
+caller that needs them — so a fresh self-hosted instance, the migration, and the
+integration tests all use the *same* definitions instead of three drifting copies
+(previously: frontend Cypress fixtures, inline per-test seeding, and nothing for
+production):
+
+- `seedData/defaultRoles.ts` — canonical `ServerRole` / `ModServerRole` /
+  `ChannelRole` definitions (incl. the **Administrator** vs **Super Administrator**
+  split) and the `ServerConfig` tier→role wiring map.
+- `seedData/provisionServerDefaults.ts` — **idempotent** (upsert by role name,
+  `overwrite` on the config links), so it is safe to run on every boot/deploy and
+  in test setup. Also performs the admin→SuperAdmin backfill.
+- `npm run provision` (`build_scripts/provisionServerDefaults.ts`) — runnable
+  entry for bootstrapping/upgrading an instance.
+- Integration tests call `provisionServerDefaults` in setup (incremental
+  adoption) so they exercise the real defaults.
+
 ### Migration (one-time; root is the safety net)
 1. Seed two server roles: **Super Administrator** (admin caps *with*
    `canManageAdmins`/`canManageSuperAdmins`) and **Administrator** (admin caps
@@ -203,9 +222,13 @@ SuperAdmins section.
      `Channel.ElevatedChannelRole` field added (codegen run); `hasChannelPermission`
      resolves owners via `evaluateChannelOwnerPermission` (fallback to all-perms
      until a role is configured). Unit test added.
-2. **PR-2 (migration)** — seed roles (Administrator without `canManageAdmins`,
-   Super Administrator with it; channel elevated role), backfill existing admins
-   into `SuperAdmins`, wire env root; maintenance window.
+2. **PR-2 (seed defaults + migration). 🟡 IN PROGRESS.**
+   - ✅ `seedData/` single-source-of-truth module + idempotent
+     `provisionServerDefaults` (roles, config wiring, admin→SuperAdmin backfill);
+     `npm run provision` entry; unit tests.
+   - 🔲 Adopt `provisionServerDefaults` in integration-test setup (incremental).
+   - 🔲 Wire env root (`SUPERADMIN_EMAIL`) in deploy config; run provisioning per
+     environment in a maintenance window.
 3. **PR-3** — convert Category-A call sites to capability checks; drop `isAdmin`
    from Category-B ORs; tier-based mod resolution for admins in
    `hasServerModPermission`; remove the `isAdmin` rule. Integration coverage for a

--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -271,6 +271,18 @@ it. Frontend: none required until PR-5.
 5. **`deleteDiscussionChannels` / `deleteEventChannels`** → destructive caps on
    **`ModServerRole`** (`canRemoveDiscussionChannel` / `canRemoveEventChannel`).
    (Schema added in PR-1; call sites convert in PR-3.)
+6. **Roles are permissions-only; display tags derive from membership.** The
+   ADMIN/MOD tag must come from the user's relationship to `ServerConfig`
+   (`Admins`/`SuperAdmins`) / `Channel` (`Moderators`), **not** from a role flag.
+   The seed roles no longer set `showAdminTag` / `showModTag` (PR-2). The legacy
+   schema fields are slated for removal in a dedicated follow-up — they are
+   currently read by ~5 backend cypher queries and several frontend components,
+   so the removal is a coordinated backend+frontend change:
+   - Backend: derive the tag in the comment/post queries from membership; drop
+     `showAdminTag` (`ServerRole`) and `showModTag` (`ChannelRole`) from the schema
+     and `getServerConfigForPermissions`'s fetch.
+   - Frontend: have the tag-rendering components/queries read membership-derived
+     data instead of the role flag.
 
 Note: items 2 and 4 mean the earlier `canManageServerMembers` capability is
 dropped from the taxonomy (§4).

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:circular": "madge --circular --extensions ts --exclude 'ogm_types.ts|src/generated' index.ts customResolvers.ts permissions.ts",
     "tsc": "tsc",
     "logSchema": "node build_scripts/logSchema.js",
+    "provision": "node --loader ts-node/esm build_scripts/provisionServerDefaults.ts",
     "build": "npm run codegen && tsc && node build_scripts/copyCypherFiles.js",
     "heroku-postbuild": "npm run build",
     "start": "node ./ts_emitted/index.js"

--- a/seedData/defaultRoles.ts
+++ b/seedData/defaultRoles.ts
@@ -49,13 +49,17 @@ const ALL_CONTENT_CAPS = {
   canGiveFeedback: true,
 };
 
+// Note: roles are permissions-only. The ADMIN/MOD display tag is NOT set here —
+// it should derive from the user's membership relationship to ServerConfig /
+// Channel (e.g. in ServerConfig.Admins/SuperAdmins), not from a role flag. The
+// legacy `showAdminTag` / `showModTag` schema fields are slated for removal once
+// the tag is membership-derived. See docs/isadmin-phaseout-design.md.
 export const DEFAULT_SERVER_ROLES = [
   {
     // Standard signed-in user: can create/participate, no administration.
     name: ROLE_NAMES.serverStandard,
     description: "Default role for a standard signed-in user.",
     ...ALL_CONTENT_CAPS,
-    showAdminTag: false,
     ...NO_SERVER_ADMIN_CAPS,
   },
   {
@@ -70,7 +74,6 @@ export const DEFAULT_SERVER_ROLES = [
     canUpvoteComment: false,
     canUploadFile: false,
     canGiveFeedback: false,
-    showAdminTag: false,
     ...NO_SERVER_ADMIN_CAPS,
   },
   {
@@ -79,7 +82,6 @@ export const DEFAULT_SERVER_ROLES = [
     description:
       "Restricted administrator: full administration except creating/removing admins.",
     ...ALL_CONTENT_CAPS,
-    showAdminTag: true,
     canManageServerSettings: true,
     canManagePlugins: true,
     canManageRoles: true,
@@ -93,7 +95,6 @@ export const DEFAULT_SERVER_ROLES = [
     description:
       "Super administrator: full administration including managing admins and super-admins.",
     ...ALL_CONTENT_CAPS,
-    showAdminTag: true,
     canManageServerSettings: true,
     canManagePlugins: true,
     canManageRoles: true,
@@ -170,6 +171,8 @@ export const DEFAULT_MOD_SERVER_ROLES = [
 // time; defined here so the source of truth is shared. The elevated role is the
 // channel-owner tier (see hasChannelPermission).
 // ---------------------------------------------------------------------------
+// As with server roles, the MOD display tag is not set here — it should derive
+// from Channel membership (Moderators), not a role flag.
 export const DEFAULT_CHANNEL_ROLES = [
   {
     name: ROLE_NAMES.channelDefault,
@@ -181,7 +184,6 @@ export const DEFAULT_CHANNEL_ROLES = [
     canUpvoteComment: true,
     canUploadFile: true,
     canUpdateChannel: false,
-    showModTag: false,
   },
   {
     name: ROLE_NAMES.channelElevated,
@@ -193,7 +195,6 @@ export const DEFAULT_CHANNEL_ROLES = [
     canUpvoteComment: true,
     canUploadFile: true,
     canUpdateChannel: true,
-    showModTag: true,
   },
   {
     name: ROLE_NAMES.channelSuspended,
@@ -205,7 +206,6 @@ export const DEFAULT_CHANNEL_ROLES = [
     canUpvoteComment: false,
     canUploadFile: false,
     canUpdateChannel: false,
-    showModTag: false,
   },
 ] as const;
 

--- a/seedData/defaultRoles.ts
+++ b/seedData/defaultRoles.ts
@@ -1,0 +1,224 @@
+// Canonical default seed data for a newly-provisioned Multiforum instance.
+//
+// This is the single source of truth for the default roles. It is consumed by:
+//   - seedData/provisionServerDefaults.ts (bootstrap a fresh instance + the
+//     isAdmin-phase-out migration)
+//   - integration tests (so they exercise the real defaults instead of
+//     re-seeding inline)
+//
+// Roles are keyed by their unique `name`; provisioning is idempotent (MERGE by
+// name), so editing a value here and re-running provisioning updates it.
+// See docs/isadmin-phaseout-design.md.
+
+// ---------------------------------------------------------------------------
+// Role names (stable identifiers used for wiring + MERGE).
+// ---------------------------------------------------------------------------
+export const ROLE_NAMES = {
+  serverStandard: "Standard User Role",
+  serverSuspended: "Suspended Server Role",
+  administrator: "Administrator", // restricted admin: cannot make admins
+  superAdministrator: "Super Administrator", // can make admins
+  modBasic: "Basic Server Mod Role",
+  modElevated: "Elevated Server Mod Role",
+  modSuspended: "Suspended Server Mod Role",
+  channelDefault: "Default Channel Role",
+  channelElevated: "Elevated Channel Role", // channel owner tier
+  channelSuspended: "Suspended Channel Role",
+} as const;
+
+// ---------------------------------------------------------------------------
+// ServerRole defaults (user/admin "creative" capabilities).
+// ---------------------------------------------------------------------------
+const NO_SERVER_ADMIN_CAPS = {
+  canManageServerSettings: false,
+  canManagePlugins: false,
+  canManageRoles: false,
+  canManageMods: false,
+  canManageAdmins: false,
+  canManageSuperAdmins: false,
+};
+
+const ALL_CONTENT_CAPS = {
+  canCreateChannel: true,
+  canCreateDiscussion: true,
+  canCreateEvent: true,
+  canCreateComment: true,
+  canUpvoteDiscussion: true,
+  canUpvoteComment: true,
+  canUploadFile: true,
+  canGiveFeedback: true,
+};
+
+export const DEFAULT_SERVER_ROLES = [
+  {
+    // Standard signed-in user: can create/participate, no administration.
+    name: ROLE_NAMES.serverStandard,
+    description: "Default role for a standard signed-in user.",
+    ...ALL_CONTENT_CAPS,
+    showAdminTag: false,
+    ...NO_SERVER_ADMIN_CAPS,
+  },
+  {
+    // Server-suspended user: read-only.
+    name: ROLE_NAMES.serverSuspended,
+    description: "Applied to a server-suspended user; no capabilities.",
+    canCreateChannel: false,
+    canCreateDiscussion: false,
+    canCreateEvent: false,
+    canCreateComment: false,
+    canUpvoteDiscussion: false,
+    canUpvoteComment: false,
+    canUploadFile: false,
+    canGiveFeedback: false,
+    showAdminTag: false,
+    ...NO_SERVER_ADMIN_CAPS,
+  },
+  {
+    // Restricted admin: permissive, but CANNOT create other admins.
+    name: ROLE_NAMES.administrator,
+    description:
+      "Restricted administrator: full administration except creating/removing admins.",
+    ...ALL_CONTENT_CAPS,
+    showAdminTag: true,
+    canManageServerSettings: true,
+    canManagePlugins: true,
+    canManageRoles: true,
+    canManageMods: true,
+    canManageAdmins: false,
+    canManageSuperAdmins: false,
+  },
+  {
+    // Super administrator: everything, including making/removing admins.
+    name: ROLE_NAMES.superAdministrator,
+    description:
+      "Super administrator: full administration including managing admins and super-admins.",
+    ...ALL_CONTENT_CAPS,
+    showAdminTag: true,
+    canManageServerSettings: true,
+    canManagePlugins: true,
+    canManageRoles: true,
+    canManageMods: true,
+    canManageAdmins: true,
+    canManageSuperAdmins: true,
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// ModServerRole defaults (moderation / destructive capabilities).
+// ---------------------------------------------------------------------------
+const NO_MOD_CAPS = {
+  canLockChannel: false,
+  canHideComment: false,
+  canHideEvent: false,
+  canHideDiscussion: false,
+  canEditComments: false,
+  canEditDiscussions: false,
+  canEditEvents: false,
+  canGiveFeedback: false,
+  canOpenSupportTickets: false,
+  canCloseSupportTickets: false,
+  canReport: false,
+  canSuspendUser: false,
+  canArchiveImage: false,
+  canDeleteWiki: false,
+  canPermanentlyRemoveImage: false,
+  canRemoveDiscussionChannel: false,
+  canRemoveEventChannel: false,
+};
+
+export const DEFAULT_MOD_SERVER_ROLES = [
+  {
+    // Baseline mod: can report and triage support, no destructive actions.
+    name: ROLE_NAMES.modBasic,
+    description: "Baseline server moderator capabilities.",
+    ...NO_MOD_CAPS,
+    canReport: true,
+    canGiveFeedback: true,
+    canOpenSupportTickets: true,
+  },
+  {
+    // Elevated mod: every moderation capability, including structural removals.
+    name: ROLE_NAMES.modElevated,
+    description: "Elevated server moderator: all moderation capabilities.",
+    canLockChannel: true,
+    canHideComment: true,
+    canHideEvent: true,
+    canHideDiscussion: true,
+    canEditComments: true,
+    canEditDiscussions: true,
+    canEditEvents: true,
+    canGiveFeedback: true,
+    canOpenSupportTickets: true,
+    canCloseSupportTickets: true,
+    canReport: true,
+    canSuspendUser: true,
+    canArchiveImage: true,
+    canDeleteWiki: true,
+    canPermanentlyRemoveImage: true,
+    canRemoveDiscussionChannel: true,
+    canRemoveEventChannel: true,
+  },
+  {
+    name: ROLE_NAMES.modSuspended,
+    description: "Applied to a suspended moderator; no capabilities.",
+    ...NO_MOD_CAPS,
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// ChannelRole defaults. Channels are provisioned with these at channel-creation
+// time; defined here so the source of truth is shared. The elevated role is the
+// channel-owner tier (see hasChannelPermission).
+// ---------------------------------------------------------------------------
+export const DEFAULT_CHANNEL_ROLES = [
+  {
+    name: ROLE_NAMES.channelDefault,
+    description: "Default role for a standard member of a channel.",
+    canCreateDiscussion: true,
+    canCreateEvent: true,
+    canCreateComment: true,
+    canUpvoteDiscussion: true,
+    canUpvoteComment: true,
+    canUploadFile: true,
+    canUpdateChannel: false,
+    showModTag: false,
+  },
+  {
+    name: ROLE_NAMES.channelElevated,
+    description: "Channel owner tier: every channel capability.",
+    canCreateDiscussion: true,
+    canCreateEvent: true,
+    canCreateComment: true,
+    canUpvoteDiscussion: true,
+    canUpvoteComment: true,
+    canUploadFile: true,
+    canUpdateChannel: true,
+    showModTag: true,
+  },
+  {
+    name: ROLE_NAMES.channelSuspended,
+    description: "Applied to a channel-suspended user; no capabilities.",
+    canCreateDiscussion: false,
+    canCreateEvent: false,
+    canCreateComment: false,
+    canUpvoteDiscussion: false,
+    canUpvoteComment: false,
+    canUploadFile: false,
+    canUpdateChannel: false,
+    showModTag: false,
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// ServerConfig tier -> default-role wiring. Maps each ServerConfig default-role
+// relationship to the role name that should fill it.
+// ---------------------------------------------------------------------------
+export const SERVER_CONFIG_ROLE_WIRING = {
+  DefaultServerRole: ROLE_NAMES.serverStandard,
+  DefaultSuspendedRole: ROLE_NAMES.serverSuspended,
+  DefaultAdminRole: ROLE_NAMES.administrator,
+  DefaultSuperAdminRole: ROLE_NAMES.superAdministrator,
+  DefaultModRole: ROLE_NAMES.modBasic,
+  DefaultElevatedModRole: ROLE_NAMES.modElevated,
+  DefaultSuspendedModRole: ROLE_NAMES.modSuspended,
+} as const;

--- a/seedData/provisionServerDefaults.test.ts
+++ b/seedData/provisionServerDefaults.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { provisionServerDefaults } from "./provisionServerDefaults.js";
+import {
+  DEFAULT_SERVER_ROLES,
+  DEFAULT_MOD_SERVER_ROLES,
+  ROLE_NAMES,
+} from "./defaultRoles.js";
+
+// Minimal recording model. `existing` decides whether find() reports the role
+// as already present (drives the upsert branch).
+const makeRoleModel = (existing: boolean) => {
+  const calls = { create: [] as any[], update: [] as any[], find: 0 };
+  return {
+    calls,
+    model: {
+      find: async () => {
+        calls.find += 1;
+        return existing ? [{ name: "x" }] : [];
+      },
+      create: async (args: any) => {
+        calls.create.push(args);
+        return {};
+      },
+      update: async (args: any) => {
+        calls.update.push(args);
+        return {};
+      },
+    },
+  };
+};
+
+const makeServerConfigModel = (
+  config: { Admins?: any[]; SuperAdmins?: any[] } | null
+) => {
+  const calls = { create: [] as any[], update: [] as any[] };
+  return {
+    calls,
+    model: {
+      find: async () => (config ? [config] : []),
+      create: async (args: any) => {
+        calls.create.push(args);
+        return {};
+      },
+      update: async (args: any) => {
+        calls.update.push(args);
+        return {};
+      },
+    },
+  };
+};
+
+test("the seeded admin roles encode the restricted-vs-super distinction", () => {
+  const admin = DEFAULT_SERVER_ROLES.find((r) => r.name === ROLE_NAMES.administrator)!;
+  const superAdmin = DEFAULT_SERVER_ROLES.find(
+    (r) => r.name === ROLE_NAMES.superAdministrator
+  )!;
+
+  // Restricted admin is permissive but cannot make admins.
+  assert.equal(admin.canManageServerSettings, true);
+  assert.equal(admin.canManagePlugins, true);
+  assert.equal(admin.canManageAdmins, false);
+  assert.equal(admin.canManageSuperAdmins, false);
+
+  // Super admin can.
+  assert.equal(superAdmin.canManageAdmins, true);
+  assert.equal(superAdmin.canManageSuperAdmins, true);
+});
+
+test("the elevated mod role grants the destructive structural caps", () => {
+  const elevated = DEFAULT_MOD_SERVER_ROLES.find(
+    (r) => r.name === ROLE_NAMES.modElevated
+  )!;
+  assert.equal(elevated.canRemoveDiscussionChannel, true);
+  assert.equal(elevated.canRemoveEventChannel, true);
+});
+
+test("fresh provisioning creates roles and the server config", async () => {
+  const ServerRole = makeRoleModel(false);
+  const ModServerRole = makeRoleModel(false);
+  const ServerConfig = makeServerConfigModel(null);
+
+  const result = await provisionServerDefaults({
+    ServerRole: ServerRole.model as any,
+    ModServerRole: ModServerRole.model as any,
+    ServerConfig: ServerConfig.model as any,
+    serverName: "Test Server",
+  });
+
+  assert.equal(ServerRole.calls.create.length, DEFAULT_SERVER_ROLES.length);
+  assert.equal(ServerRole.calls.update.length, 0);
+  assert.equal(ModServerRole.calls.create.length, DEFAULT_MOD_SERVER_ROLES.length);
+  assert.equal(result.serverConfigCreated, true);
+  // The config is created, then updated to wire the default-role links.
+  assert.equal(ServerConfig.calls.create.length, 1);
+  assert.ok(result.rolesWired.includes("DefaultSuperAdminRole"));
+  assert.ok(result.rolesWired.includes("DefaultAdminRole"));
+});
+
+test("re-running provisioning updates existing roles (idempotent upsert)", async () => {
+  const ServerRole = makeRoleModel(true);
+  const ModServerRole = makeRoleModel(true);
+  const ServerConfig = makeServerConfigModel({ Admins: [], SuperAdmins: [] });
+
+  const result = await provisionServerDefaults({
+    ServerRole: ServerRole.model as any,
+    ModServerRole: ModServerRole.model as any,
+    ServerConfig: ServerConfig.model as any,
+    serverName: "Test Server",
+  });
+
+  assert.equal(ServerRole.calls.create.length, 0);
+  assert.equal(ServerRole.calls.update.length, DEFAULT_SERVER_ROLES.length);
+  assert.equal(result.serverConfigCreated, false);
+});
+
+test("backfill promotes only admins that are not already super-admins", async () => {
+  const ServerRole = makeRoleModel(true);
+  const ModServerRole = makeRoleModel(true);
+  const ServerConfig = makeServerConfigModel({
+    Admins: [{ username: "alice" }, { username: "bob" }],
+    SuperAdmins: [{ username: "bob" }],
+  });
+
+  const result = await provisionServerDefaults({
+    ServerRole: ServerRole.model as any,
+    ModServerRole: ModServerRole.model as any,
+    ServerConfig: ServerConfig.model as any,
+    serverName: "Test Server",
+  });
+
+  assert.deepEqual(result.adminsBackfilledToSuperAdmins, ["alice"]);
+  // One update wires roles; a second update performs the backfill.
+  const backfillUpdate = ServerConfig.calls.update.find(
+    (u) => u.update?.SuperAdmins
+  );
+  assert.ok(backfillUpdate, "expected a SuperAdmins backfill update");
+});
+
+test("backfill is a no-op when all admins are already super-admins", async () => {
+  const ServerRole = makeRoleModel(true);
+  const ModServerRole = makeRoleModel(true);
+  const ServerConfig = makeServerConfigModel({
+    Admins: [{ username: "bob" }],
+    SuperAdmins: [{ username: "bob" }],
+  });
+
+  const result = await provisionServerDefaults({
+    ServerRole: ServerRole.model as any,
+    ModServerRole: ModServerRole.model as any,
+    ServerConfig: ServerConfig.model as any,
+    serverName: "Test Server",
+  });
+
+  assert.deepEqual(result.adminsBackfilledToSuperAdmins, []);
+  const backfillUpdate = ServerConfig.calls.update.find(
+    (u) => u.update?.SuperAdmins
+  );
+  assert.equal(backfillUpdate, undefined);
+});

--- a/seedData/provisionServerDefaults.ts
+++ b/seedData/provisionServerDefaults.ts
@@ -1,0 +1,141 @@
+// Idempotent provisioning of a Multiforum server's default roles + config.
+//
+// Safe to run on every boot/deploy and in integration-test setup: roles are
+// upserted by their unique name and the ServerConfig default-role links use
+// `overwrite`, so re-running converges to the definitions in defaultRoles.ts.
+//
+// Also performs the isAdmin-phase-out backfill: existing ServerConfig.Admins are
+// connected to ServerConfig.SuperAdmins so they keep their current full power
+// (operators then demote individuals to restricted Admins as desired).
+// See docs/isadmin-phaseout-design.md.
+
+import type {
+  ServerRoleModel,
+  ModServerRoleModel,
+  ServerConfigModel,
+} from "../ogm_types.js";
+import {
+  DEFAULT_SERVER_ROLES,
+  DEFAULT_MOD_SERVER_ROLES,
+  SERVER_CONFIG_ROLE_WIRING,
+} from "./defaultRoles.js";
+
+type AnyModel = {
+  find: (args: any) => Promise<any[]>;
+  create: (args: any) => Promise<any>;
+  update: (args: any) => Promise<any>;
+};
+
+export type ProvisionServerDefaultsInput = {
+  ServerRole: ServerRoleModel;
+  ModServerRole: ModServerRoleModel;
+  ServerConfig: ServerConfigModel;
+  serverName: string;
+  log?: (message: string) => void;
+};
+
+export type ProvisionServerDefaultsResult = {
+  serverRolesUpserted: number;
+  modServerRolesUpserted: number;
+  serverConfigCreated: boolean;
+  rolesWired: string[];
+  adminsBackfilledToSuperAdmins: string[];
+};
+
+// Upsert a role by its unique `name`: update when present, create otherwise.
+const upsertByName = async (
+  model: AnyModel,
+  role: Record<string, unknown> & { name: string }
+) => {
+  const existing = await model.find({ where: { name: role.name } });
+  const { name, ...rest } = role;
+  if (existing.length > 0) {
+    await model.update({ where: { name }, update: rest });
+  } else {
+    await model.create({ input: [role] });
+  }
+};
+
+export const provisionServerDefaults = async (
+  input: ProvisionServerDefaultsInput
+): Promise<ProvisionServerDefaultsResult> => {
+  const { ServerRole, ModServerRole, ServerConfig, serverName } = input;
+  const log = input.log ?? (() => {});
+
+  // 1. Upsert the default roles (idempotent by name).
+  for (const role of DEFAULT_SERVER_ROLES) {
+    await upsertByName(ServerRole as unknown as AnyModel, { ...role });
+  }
+  for (const role of DEFAULT_MOD_SERVER_ROLES) {
+    await upsertByName(ModServerRole as unknown as AnyModel, { ...role });
+  }
+  log(
+    `Upserted ${DEFAULT_SERVER_ROLES.length} server roles and ${DEFAULT_MOD_SERVER_ROLES.length} mod server roles.`
+  );
+
+  // 2. Ensure the ServerConfig exists.
+  const existingConfigs = await ServerConfig.find({
+    where: { serverName },
+    selectionSet: `{
+      serverName
+      Admins { username }
+      SuperAdmins { username }
+    }`,
+  });
+  let serverConfigCreated = false;
+  let adminUsernames: string[] = [];
+  let superAdminUsernames: string[] = [];
+
+  if (existingConfigs.length === 0) {
+    await ServerConfig.create({ input: [{ serverName }] });
+    serverConfigCreated = true;
+    log(`Created ServerConfig '${serverName}'.`);
+  } else {
+    adminUsernames = (existingConfigs[0].Admins ?? [])
+      .map((a: { username?: string | null }) => a?.username)
+      .filter((u: unknown): u is string => typeof u === "string");
+    superAdminUsernames = (existingConfigs[0].SuperAdmins ?? [])
+      .map((a: { username?: string | null }) => a?.username)
+      .filter((u: unknown): u is string => typeof u === "string");
+  }
+
+  // 3. Wire each ServerConfig default-role link to its role (overwrite -> idempotent).
+  const rolesWired: string[] = [];
+  const wiringUpdate: Record<string, unknown> = {};
+  for (const [relationship, roleName] of Object.entries(
+    SERVER_CONFIG_ROLE_WIRING
+  )) {
+    wiringUpdate[relationship] = {
+      connect: { where: { node: { name: roleName } }, overwrite: true },
+    };
+    rolesWired.push(relationship);
+  }
+  await ServerConfig.update({ where: { serverName }, update: wiringUpdate });
+  log(`Wired ${rolesWired.length} default-role links on '${serverName}'.`);
+
+  // 4. Backfill: existing Admins that are not yet SuperAdmins get connected, so
+  // they keep their current full power after the move to role-based admin.
+  const superAdminSet = new Set(superAdminUsernames);
+  const adminsToPromote = adminUsernames.filter((u) => !superAdminSet.has(u));
+  if (adminsToPromote.length > 0) {
+    await ServerConfig.update({
+      where: { serverName },
+      update: {
+        SuperAdmins: adminsToPromote.map((username) => ({
+          connect: [{ where: { node: { username } } }],
+        })),
+      },
+    });
+    log(
+      `Backfilled ${adminsToPromote.length} admin(s) into SuperAdmins: ${adminsToPromote.join(", ")}.`
+    );
+  }
+
+  return {
+    serverRolesUpserted: DEFAULT_SERVER_ROLES.length,
+    modServerRolesUpserted: DEFAULT_MOD_SERVER_ROLES.length,
+    serverConfigCreated,
+    rolesWired,
+    adminsBackfilledToSuperAdmins: adminsToPromote,
+  };
+};

--- a/tests/integration/provisionServerDefaults.test.ts
+++ b/tests/integration/provisionServerDefaults.test.ts
@@ -1,0 +1,118 @@
+// Runs provisionServerDefaults against a real Neo4j (Testcontainers) — the
+// provisioning code otherwise only has mock-based unit tests. Verifies that a
+// fresh provision creates the default roles, wires the ServerConfig tier links,
+// and backfills existing Admins into SuperAdmins, and that re-running is
+// idempotent. See seedData/ and docs/isadmin-phaseout-design.md.
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { Driver } from "neo4j-driver";
+import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
+import { ROLE_NAMES } from "../../seedData/defaultRoles.js";
+
+const SERVER_CONFIG_NAME = "ProvisionTestServer";
+
+let container: StartedNeo4jContainer;
+let driver: Driver;
+let ogm: any;
+let provisionServerDefaults: any;
+
+const provision = () =>
+  provisionServerDefaults({
+    ServerRole: ogm.model("ServerRole"),
+    ModServerRole: ogm.model("ModServerRole"),
+    ServerConfig: ogm.model("ServerConfig"),
+    serverName: SERVER_CONFIG_NAME,
+  });
+
+before(async () => {
+  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  process.env.NEO4J_URI = container.getBoltUri();
+  process.env.NEO4J_USER = container.getUsername();
+  process.env.NEO4J_PASSWORD = container.getPassword();
+  process.env.SERVER_CONFIG_NAME = SERVER_CONFIG_NAME;
+
+  const { buildPermissionedSchema } = await import(
+    "../helpers/buildPermissionedSchema.js"
+  );
+  ({ driver, ogm } = await buildPermissionedSchema());
+  await ogm.init();
+  ({ provisionServerDefaults } = await import(
+    "../../seedData/provisionServerDefaults.js"
+  ));
+
+  // Seed a ServerConfig with two existing admins to exercise the backfill.
+  const session = driver.session();
+  try {
+    await session.run(
+      `CREATE (sc:ServerConfig { serverName: $name })
+       CREATE (a:User { username: 'alice' })-[:ADMIN_OF_SERVER]->(sc)
+       CREATE (b:User { username: 'bob' })-[:ADMIN_OF_SERVER]->(sc)`,
+      { name: SERVER_CONFIG_NAME }
+    );
+  } finally {
+    await session.close();
+  }
+}, { timeout: 240000 });
+
+after(async () => {
+  await driver?.close();
+  await container?.stop();
+});
+
+const findRole = async (name: string) => {
+  const roles = await ogm.model("ServerRole").find({
+    where: { name },
+    selectionSet: `{ name canManageAdmins canManageSuperAdmins canManageServerSettings }`,
+  });
+  return roles[0];
+};
+
+test("fresh provisioning creates the default roles with the restricted/super split", async () => {
+  const result = await provision();
+  assert.equal(result.serverConfigCreated, false, "config already existed");
+
+  const admin = await findRole(ROLE_NAMES.administrator);
+  const superAdmin = await findRole(ROLE_NAMES.superAdministrator);
+  assert.equal(admin.canManageServerSettings, true);
+  assert.equal(admin.canManageAdmins, false, "restricted admin cannot manage admins");
+  assert.equal(superAdmin.canManageAdmins, true, "super admin can");
+});
+
+test("the ServerConfig tier role links are wired", async () => {
+  const configs = await ogm.model("ServerConfig").find({
+    where: { serverName: SERVER_CONFIG_NAME },
+    selectionSet: `{
+      DefaultAdminRole { name }
+      DefaultSuperAdminRole { name }
+      DefaultServerRole { name }
+    }`,
+  });
+  const sc = configs[0];
+  assert.equal(sc.DefaultAdminRole?.name, ROLE_NAMES.administrator);
+  assert.equal(sc.DefaultSuperAdminRole?.name, ROLE_NAMES.superAdministrator);
+  assert.equal(sc.DefaultServerRole?.name, ROLE_NAMES.serverStandard);
+});
+
+test("existing admins are backfilled into SuperAdmins", async () => {
+  const configs = await ogm.model("ServerConfig").find({
+    where: { serverName: SERVER_CONFIG_NAME },
+    selectionSet: `{ SuperAdmins { username } }`,
+  });
+  const superAdmins = (configs[0].SuperAdmins ?? [])
+    .map((u: { username: string }) => u.username)
+    .sort();
+  assert.deepEqual(superAdmins, ["alice", "bob"]);
+});
+
+test("re-running is idempotent (no duplicate roles, backfill no-op)", async () => {
+  const result = await provision();
+  assert.deepEqual(result.adminsBackfilledToSuperAdmins, [], "already super-admins");
+
+  // Exactly one Administrator role exists (upsert, not duplicate-create).
+  const admins = await ogm.model("ServerRole").find({
+    where: { name: ROLE_NAMES.administrator },
+    selectionSet: `{ name }`,
+  });
+  assert.equal(admins.length, 1);
+});


### PR DESCRIPTION
## Summary

Two things:

1. **Re-lands the `seedData` provisioning module from #68.** That PR was merged into the **PR-1 branch** (`feat/permissions-pr1-foundation`) rather than `main` — and since #67 had already merged the PR-1 branch to main, PR-2's `seedData/` got stranded and **never reached main**. This replays those two commits (`provisionServerDefaults` + the permissions-only seed roles) onto main.
2. **Integration-test adoption of `provisionServerDefaults`.**

## On the adoption

There were **no integration tests seeding roles inline** to convert — they create a bare `ServerConfig` and rely on membership. And `provisionServerDefaults` previously had only **mock-based unit tests**. So the meaningful adoption is the missing **real-database verification**:

- Fresh provisioning creates the default roles with the **restricted** (`canManageAdmins: false`) vs **super-admin** (`canManageAdmins: true`) split.
- The `ServerConfig` tier role links (`DefaultAdminRole` / `DefaultSuperAdminRole` / `DefaultServerRole`) are wired.
- Existing `ServerConfig.Admins` are **backfilled into `SuperAdmins`**.
- Re-running is **idempotent** (upsert, no duplicate roles; backfill no-op).

## Testing
- Provisioning integration test (Testcontainers Neo4j): **4/4 pass**.
- Seed unit tests: 6/6. `npm run tsc` clean. Full unit suite green in pre-commit.

## Note
Because this re-lands #68's content, the diff includes `seedData/`, the `npm run provision` script, and the related doc note in addition to the new integration test. Going forward, new tests that need the default roles should call `provisionServerDefaults` rather than hand-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)