### PR TITLE
fix(provision): idempotent wiring of to-one default-role links

### DIFF
--- a/seedData/provisionServerDefaults.ts
+++ b/seedData/provisionServerDefaults.ts
@@ -73,24 +73,35 @@ export const provisionServerDefaults = async (
     `Upserted ${DEFAULT_SERVER_ROLES.length} server roles and ${DEFAULT_MOD_SERVER_ROLES.length} mod server roles.`
   );
 
-  // 2. Ensure the ServerConfig exists.
+  // 2. Ensure the ServerConfig exists, and read the current tier-role links so
+  // wiring can be idempotent (the default-role relationships are to-one, so a
+  // blind `connect` on an already-linked config violates cardinality).
+  const linkSelection = Object.keys(SERVER_CONFIG_ROLE_WIRING)
+    .map((relationship) => `${relationship} { name }`)
+    .join("\n      ");
   const existingConfigs = await ServerConfig.find({
     where: { serverName },
     selectionSet: `{
       serverName
       Admins { username }
       SuperAdmins { username }
+      ${linkSelection}
     }`,
   });
   let serverConfigCreated = false;
   let adminUsernames: string[] = [];
   let superAdminUsernames: string[] = [];
+  let currentConfig: Record<string, { name?: string | null } | null> = {};
 
   if (existingConfigs.length === 0) {
     await ServerConfig.create({ input: [{ serverName }] });
     serverConfigCreated = true;
     log(`Created ServerConfig '${serverName}'.`);
   } else {
+    currentConfig = existingConfigs[0] as unknown as Record<
+      string,
+      { name?: string | null } | null
+    >;
     adminUsernames = (existingConfigs[0].Admins ?? [])
       .map((a: { username?: string | null }) => a?.username)
       .filter((u: unknown): u is string => typeof u === "string");
@@ -99,18 +110,31 @@ export const provisionServerDefaults = async (
       .filter((u: unknown): u is string => typeof u === "string");
   }
 
-  // 3. Wire each ServerConfig default-role link to its role (overwrite -> idempotent).
+  // 3. Wire each to-one default-role link to its role, idempotently: skip when
+  // it already points at the right role; otherwise disconnect any wrong target
+  // first, then connect the right one.
   const rolesWired: string[] = [];
   const wiringUpdate: Record<string, unknown> = {};
   for (const [relationship, roleName] of Object.entries(
     SERVER_CONFIG_ROLE_WIRING
   )) {
-    wiringUpdate[relationship] = {
-      connect: { where: { node: { name: roleName } }, overwrite: true },
+    const currentName = currentConfig[relationship]?.name ?? null;
+    if (currentName === roleName) {
+      continue; // already correct
+    }
+    const linkUpdate: Record<string, unknown> = {
+      connect: { where: { node: { name: roleName } } },
     };
+    if (currentName) {
+      // Remove the existing (wrong) target before connecting the new one.
+      linkUpdate.disconnect = { where: { node: { name: currentName } } };
+    }
+    wiringUpdate[relationship] = linkUpdate;
     rolesWired.push(relationship);
   }
-  await ServerConfig.update({ where: { serverName }, update: wiringUpdate });
+  if (Object.keys(wiringUpdate).length > 0) {
+    await ServerConfig.update({ where: { serverName }, update: wiringUpdate });
+  }
   log(`Wired ${rolesWired.length} default-role links on '${serverName}'.`);
 
   // 4. Backfill: existing Admins that are not yet SuperAdmins get connected, so

--- a/tests/integration/provisionServerDefaults.test.ts
+++ b/tests/integration/provisionServerDefaults.test.ts
@@ -41,13 +41,18 @@ before(async () => {
     "../../seedData/provisionServerDefaults.js"
   ));
 
-  // Seed a ServerConfig with two existing admins to exercise the backfill.
+  // Seed a ServerConfig with two existing admins (to exercise the backfill) and
+  // a pre-existing DefaultServerRole pointing at a DIFFERENT role, so wiring must
+  // disconnect+reconnect a to-one link rather than blind-connect (regression for
+  // "DefaultServerRole must be less than or equal to one").
   const session = driver.session();
   try {
     await session.run(
       `CREATE (sc:ServerConfig { serverName: $name })
        CREATE (a:User { username: 'alice' })-[:ADMIN_OF_SERVER]->(sc)
-       CREATE (b:User { username: 'bob' })-[:ADMIN_OF_SERVER]->(sc)`,
+       CREATE (b:User { username: 'bob' })-[:ADMIN_OF_SERVER]->(sc)
+       CREATE (old:ServerRole { name: 'Legacy Default Role' })
+       CREATE (sc)-[:HAS_DEFAULT_SERVER_ROLE]->(old)`,
       { name: SERVER_CONFIG_NAME }
     );
   } finally {


### PR DESCRIPTION
## Summary

Fixes `npm run provision` failing on an **existing** instance with:

```
Provisioning failed Error: ServerConfig.DefaultServerRole must be less than or equal to one
```

## Cause

`provisionServerDefaults` blind-`connect`ed each `ServerConfig` default-role link. Those relationships are **to-one**, so when the config already had (say) a `DefaultServerRole` connected, `connect` tried to add a *second* one → cardinality violation. The fresh-DB integration test passed only because its config had no pre-existing links.

## Fix

The wiring now reads the current link target per relationship and:
- **skips** when it already points at the right role,
- **disconnects** the wrong target before **connecting** the right one,
- **connects** when absent.

Fully idempotent and safe on both fresh and existing instances.

## Testing
- `npm run tsc` clean; unit tests 6/6.
- Integration test (Testcontainers Neo4j) now **pre-wires a different `DefaultServerRole`** to exercise the disconnect+reconnect path — **4/4 pass**, including the previously-uncovered case.

Re-running `npm run provision` after this re-points existing legacy default-role links to the seeded defaults without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)