### PR TITLE
feat(permissions): PR-3b — finish removing isAdmin

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -2,7 +2,7 @@ import { and, shield, allow, deny, or } from "graphql-shield";
 import rules from "./rules/rules.js";
 
 const {
-  isAdmin,
+  isRoot,
   canManageServerSettings,
   canManagePlugins,
   canManageRoles,
@@ -11,6 +11,7 @@ const {
   canManageSuperAdmins,
   canRemoveDiscussionChannel,
   canRemoveEventChannel,
+  canReportServerContent,
   isAccountOwner,
   isChannelOwner,
   isDiscussionOwner,
@@ -118,8 +119,8 @@ const permissionList = shield({
     },
     Mutation: {
       "*": deny,
-      dropDataForCypressTests: isAdmin,
-      seedDataForCypressTests: isAdmin,
+      dropDataForCypressTests: isRoot,
+      seedDataForCypressTests: isRoot,
       createTags: and(isAuthenticated, allow),
       
       // Role management requires canManageRoles (the updateUsers role-connect
@@ -138,42 +139,51 @@ const permissionList = shield({
       deleteServerRoles: and(isAuthenticated, canManageRoles),
       
       createEmailAndUser: allow, // Keep this as-is since this is for user registration
-      updateUsers: and(isAuthenticated, updateUserInputIsValid, or(isAccountOwner, isAdmin)),
+      // Self-only: a user may edit their own account, never another's. The
+      // role-assignment fields are additionally blocked in the resolver to
+      // prevent privilege escalation. Server admins do NOT get a blanket edit
+      // over other users here (no isAdmin override) — account ownership is
+      // self-scoped by design. See docs/isadmin-phaseout-design.md §8.4.
+      updateUsers: and(isAuthenticated, updateUserInputIsValid, isAccountOwner),
       
       createChannels: and(isAuthenticated, createChannelInputIsValid, canCreateChannel),
       // Owner/admin for general channel-config updates; canEditWikiHomePage
       // additionally grants the wiki-home-page edit path (and now denies, rather
       // than blanket-allows, non-wiki updates — see evaluateCanEditWikiHomePageRule).
-      updateChannels: and(isAuthenticated, updateChannelInputIsValid, or(isChannelOwner, isAdmin, canEditWikiHomePage)),
-      deleteChannels: and(isAuthenticated, or(isAdmin, isChannelOwner)),
+      updateChannels: and(isAuthenticated, updateChannelInputIsValid, or(isChannelOwner, canEditWikiHomePage)),
+      deleteChannels: and(isAuthenticated, isChannelOwner),
 
-      deleteEmails: and(isAuthenticated, or(isAccountOwner, isAdmin)),
-      deleteUsers: and(isAuthenticated, or(isAdmin, isAccountOwner)),
+      // Self-only by design (§8.2/§8.4): account deletion is self-scoped, never a
+      // blanket admin power. isAccountOwner deliberately does NOT carry the
+      // server-admin override. Cross-user admin actions happen through the
+      // invite/suspension flows instead. See docs/isadmin-phaseout-design.md.
+      deleteEmails: and(isAuthenticated, isAccountOwner),
+      deleteUsers: and(isAuthenticated, isAccountOwner),
     
-      createDiscussionWithChannelConnections: and(isAuthenticated, createDiscussionInputIsValid, or(canCreateDiscussion, isAdmin)),
-      updateDiscussionWithChannelConnections: and(isAuthenticated, updateDiscussionInputIsValid, or(isDiscussionOwner, isAdmin, canEditDiscussions)),
-      deleteDiscussions: and(isAuthenticated, or(isAdmin, isDiscussionOwner)),
-      updateDiscussions: and(isAuthenticated, updateDiscussionInputIsValid, or(isAdmin, isDiscussionOwner, canEditDiscussions)),
+      createDiscussionWithChannelConnections: and(isAuthenticated, createDiscussionInputIsValid, canCreateDiscussion),
+      updateDiscussionWithChannelConnections: and(isAuthenticated, updateDiscussionInputIsValid, or(isDiscussionOwner, canEditDiscussions)),
+      deleteDiscussions: and(isAuthenticated, isDiscussionOwner),
+      updateDiscussions: and(isAuthenticated, updateDiscussionInputIsValid, or(isDiscussionOwner, canEditDiscussions)),
       deleteDiscussionChannels: and(isAuthenticated, canRemoveDiscussionChannel),
-      updateDiscussionChannels: and(isAuthenticated, or(isAdmin, isDiscussionChannelOwner)),
+      updateDiscussionChannels: and(isAuthenticated, isDiscussionChannelOwner),
 
       deleteTextVersions: deny,
       deleteCommentRevision: and(isAuthenticated, allow),
       deleteDiscussionBodyRevision: and(isAuthenticated, allow),
       deleteWikiRevision: and(isAuthenticated, allow),
-      deleteWikiPages: and(isAuthenticated, or(isAdmin, canDeleteWikiPages)),
+      deleteWikiPages: and(isAuthenticated, canDeleteWikiPages),
       createWikiPages: and(isAuthenticated, canEditWikiPages),
       updateWikiPages: and(isAuthenticated, canEditWikiPages),
       
       createEventWithChannelConnections: and(isAuthenticated, createEventInputIsValid, canCreateEvent),
-      updateEventWithChannelConnections: and(isAuthenticated, updateEventInputIsValid, or(isEventOwner, isAdmin, canEditEvents)),
-      updateEvents: and(isAuthenticated, or(isAdmin, isEventOwner, canEditEvents)),
-      deleteEvents: and(isAuthenticated, or(isAdmin, isEventOwner)),
+      updateEventWithChannelConnections: and(isAuthenticated, updateEventInputIsValid, or(isEventOwner, canEditEvents)),
+      updateEvents: and(isAuthenticated, or(isEventOwner, canEditEvents)),
+      deleteEvents: and(isAuthenticated, isEventOwner),
       deleteEventChannels: and(isAuthenticated, canRemoveEventChannel),
 
       createComments: and(isAuthenticated, createCommentInputIsValid, canCreateComment),
-      updateComments: and(isAuthenticated, updateCommentInputIsValid, or(isCommentAuthor, isAdmin, canEditComments)),
-      deleteComments: and(isAuthenticated, or(isAdmin, isCommentAuthor)),
+      updateComments: and(isAuthenticated, updateCommentInputIsValid, or(isCommentAuthor, canEditComments)),
+      deleteComments: and(isAuthenticated, isCommentAuthor),
       
       createSignedStorageURL: and(isAuthenticated, canUploadFile),
       addEmojiToComment: and(isAuthenticated, canUpvoteComment),
@@ -199,7 +209,7 @@ const permissionList = shield({
       // (isIssueAuthor resolves the issue from where.id and matches User or
       // ModerationProfile authorship). Previously any authenticated user could
       // delete any moderation issue, e.g. a report filed against themselves.
-      deleteIssues: and(isAuthenticated, or(isAdmin, isIssueAuthor)),
+      deleteIssues: and(isAuthenticated, isIssueAuthor),
       // Issue updates (close/reopen) can be done by:
       // 1. Channel owners (always)
       // 2. Issue author (if issue is not locked)
@@ -214,8 +224,8 @@ const permissionList = shield({
       ),
 
       createAlbums: and(isAuthenticated, allow), // Owner forced server-side in createAlbumsWithOwner
-      updateAlbums: and(isAuthenticated, or(isAlbumOwner, isAdmin)),
-      deleteAlbums: and(isAuthenticated, or(isAlbumOwner, isAdmin)),
+      updateAlbums: and(isAuthenticated, isAlbumOwner),
+      deleteAlbums: and(isAuthenticated, isAlbumOwner),
 
       inviteForumOwner: and(isAuthenticated, isChannelOwner),
       cancelInviteForumOwner: and(isAuthenticated, isChannelOwner),
@@ -239,11 +249,12 @@ const permissionList = shield({
       deleteNotifications: deny,
       updateNotifications: deny,
 
-      // Image edits (e.g. captions) are allowed for the uploader (OP), an
-      // image mod, or an admin. canArchiveAndUnarchiveImage resolves to the
-      // server-level canArchiveImage mod permission here, since updateImages
-      // carries no channel argument and images aren't channel-scoped.
-      updateImages: and(isAuthenticated, or(isImageUploader, canArchiveAndUnarchiveImage, isAdmin)),
+      // Image edits (e.g. captions) are allowed for the uploader (OP) or an
+      // image mod. canArchiveAndUnarchiveImage resolves to the server-level
+      // canArchiveImage mod permission here, since updateImages carries no
+      // channel argument and images aren't channel-scoped; server admins are
+      // covered because the seeded admin bundle grants that mod capability.
+      updateImages: and(isAuthenticated, or(isImageUploader, canArchiveAndUnarchiveImage)),
       createImages: deny, // Use createImageWithUploader instead to ensure Uploader is set
       createImageWithUploader: and(isAuthenticated, canUploadFile),
 
@@ -258,9 +269,9 @@ const permissionList = shield({
       reportChannel: and(isAuthenticated, canReport), // Channel reports require mod profile, no channel owner shortcut
       reportImage: and(isAuthenticated, or(isChannelOwner, canReport)), // mirrors reportComment/reportDiscussion (channel-scoped image content)
       reportChannelImage: and(isAuthenticated, canReport), // server-scoped, but canReport resolves the channel from channelUniqueName (like reportChannel)
-      reportProfilePicture: and(isAuthenticated, isAdmin), // server-scoped, no channel to scope canReport to
-      lockChannel: and(isAuthenticated, or(isAdmin, canLockChannel)),
-      unlockChannel: and(isAuthenticated, or(isAdmin, canLockChannel)),
+      reportProfilePicture: and(isAuthenticated, canReportServerContent), // server-scoped, no channel to scope canReport to
+      lockChannel: and(isAuthenticated, canLockChannel),
+      unlockChannel: and(isAuthenticated, canLockChannel),
       suspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       suspendUser: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       unsuspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),

--- a/rules/definitions/serverRules.ts
+++ b/rules/definitions/serverRules.ts
@@ -6,13 +6,14 @@ import type { GraphQLContext } from "../../types/context.js";
 import type { ServerRole, ModServerRole } from "../../ogm_types.js";
 import { hasServerPermission } from "../permission/hasServerPermission.js";
 import { hasServerModPermission } from "../permission/hasServerModPermission.js";
-import { getServerScopedMembership } from "../permission/getServerScopedMembership.js";
+import { isServerRoot } from "../permission/isServerRoot.js";
 
-export const isAdmin = rule({ cache: "contextual" })(
-  async (parent: unknown, args: unknown, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
-    const membership = await getServerScopedMembership(ctx);
-    return membership.isServerAdmin;
-  }
+// The env break-glass root (and the test super-user) only. Used for the
+// dangerous Cypress test-data mutations, which must never be a delegatable
+// capability. See docs/isadmin-phaseout-design.md.
+export const isRoot = rule({ cache: "contextual" })(
+  async (_parent: unknown, _args: unknown, ctx: GraphQLContext, _info: GraphQLResolveInfo) =>
+    isServerRoot(ctx)
 );
 
 // Factories for capability-named server rules (the isAdmin phase-out). Each
@@ -50,6 +51,10 @@ export const canManageSuperAdmins = serverPermissionRule("canManageSuperAdmins")
 // Destructive structural removals (ModServerRole).
 export const canRemoveDiscussionChannel = serverModPermissionRule("canRemoveDiscussionChannel");
 export const canRemoveEventChannel = serverModPermissionRule("canRemoveEventChannel");
+
+// Server-scoped reporting (e.g. profile pictures, which have no channel to scope
+// to). Covered for server admins via the hasServerModPermission shortcut.
+export const canReportServerContent = serverModPermissionRule("canReport");
 
 export const canUploadFile = rule({ cache: "contextual" })(
   async (parent: unknown, args: unknown, ctx: GraphQLContext, info: GraphQLResolveInfo) => {

--- a/rules/permission/getServerScopedMembership.ts
+++ b/rules/permission/getServerScopedMembership.ts
@@ -8,6 +8,7 @@ type EvaluateServerScopedMembershipInput = {
   email?: string | null;
   cypressAdminTestEmail?: string | null;
   serverAdminUsernames?: string[];
+  serverSuperAdminUsernames?: string[];
   serverModeratorDisplayNames?: string[];
 };
 
@@ -25,6 +26,7 @@ export function evaluateServerScopedMembership(
     email,
     cypressAdminTestEmail,
     serverAdminUsernames = [],
+    serverSuperAdminUsernames = [],
     serverModeratorDisplayNames = [],
   } = input;
 
@@ -34,9 +36,12 @@ export function evaluateServerScopedMembership(
     email === cypressAdminTestEmail;
 
   return {
+    // SuperAdmins are admins too (the apex tier); both count as a server admin.
     isServerAdmin:
       isCypressAdmin ||
-      (Boolean(username) && serverAdminUsernames.includes(username as string)),
+      (Boolean(username) &&
+        (serverAdminUsernames.includes(username as string) ||
+          serverSuperAdminUsernames.includes(username as string))),
     isServerModerator:
       Boolean(modProfileName) &&
       serverModeratorDisplayNames.includes(modProfileName as string),
@@ -62,6 +67,10 @@ export const getServerScopedMembership = async (
     serverAdminUsernames:
       serverConfig?.Admins?.map((admin: { username: string }) => admin.username) ||
       [],
+    serverSuperAdminUsernames:
+      serverConfig?.SuperAdmins?.map(
+        (admin: { username: string }) => admin.username
+      ) || [],
     serverModeratorDisplayNames:
       serverConfig?.Moderators?.map(
         (moderator: { displayName: string }) => moderator.displayName

--- a/rules/permission/hasChannelModPermission.ts
+++ b/rules/permission/hasChannelModPermission.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import { getActiveSuspension } from "./getActiveSuspension.js";
 import { disconnectExpiredSuspensions } from "./disconnectExpiredSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
+import { passesAsServerAdminOrRoot } from "./serverAdminOverride.js";
 import { logger } from "../../logger.js";
 
 // Define the moderator permissions as an enum for type safety
@@ -95,6 +96,13 @@ export const hasChannelModPermission: (
   context.user = await setUserDataOnContext({
     context,
   });
+
+  // Server admins and the env break-glass root hold every channel mod
+  // permission across the whole server (replaces the per-call-site isAdmin
+  // override). See docs/isadmin-phaseout-design.md.
+  if (await passesAsServerAdminOrRoot(context)) {
+    return true;
+  }
 
   // 2. Check if user has a moderation profile
   const hasModProfile = context.user?.data?.ModerationProfile !== null;

--- a/rules/permission/hasChannelPermission.ts
+++ b/rules/permission/hasChannelPermission.ts
@@ -5,6 +5,7 @@ import type { GraphQLContext } from "../../types/context.js";
 import { getActiveSuspension } from "./getActiveSuspension.js";
 import { disconnectExpiredSuspensions } from "./disconnectExpiredSuspensions.js";
 import { createSuspensionNotification } from "./suspensionNotification.js";
+import { passesAsServerAdminOrRoot } from "./serverAdminOverride.js";
 import { logger } from "../../logger.js";
 
 type HasChannelPermissionInput = {
@@ -96,6 +97,13 @@ export const hasChannelPermission: (
 
   if (!context.user) {
     return new Error(ERROR_MESSAGES.channel.noChannelPermission);
+  }
+
+  // Server admins and the env break-glass root hold every channel permission
+  // across the whole server (this replaces the per-call-site isAdmin override).
+  // See docs/isadmin-phaseout-design.md.
+  if (await passesAsServerAdminOrRoot(context)) {
+    return true;
   }
 
   const username = context.user?.username;

--- a/rules/permission/ownership/isAlbumOwner.ts
+++ b/rules/permission/ownership/isAlbumOwner.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../../types/context.js";
 import { ERROR_MESSAGES } from "../../errorMessages.js";
 import { Album, AlbumWhere } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 
 type IsAlbumOwnerArgs = {
   where?: AlbumWhere;
@@ -17,6 +18,11 @@ type IsAlbumOwnerArgs = {
 // rule any authenticated user could edit or delete anyone's album.
 export const isAlbumOwner = rule({ cache: "contextual" })(
   async (parent: { id?: string } | undefined, args: IsAlbumOwnerArgs, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isChannelOwner.ts
+++ b/rules/permission/ownership/isChannelOwner.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../../types/context.js";
 import { ERROR_MESSAGES } from "../../errorMessages.js";
 import { ChannelWhere, Channel } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 import { logger } from "../../../logger.js";
 
 type IsChannelOwnerInput = {
@@ -18,6 +19,11 @@ export const isChannelOwner = rule({ cache: "contextual" })(
     logger.info('🔐 isChannelOwner rule called with args:', JSON.stringify(args));
 
     // set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isCommentAuthor.ts
+++ b/rules/permission/ownership/isCommentAuthor.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../../types/context.js";
 import { ERROR_MESSAGES } from "../../errorMessages.js";
 import { Comment, CommentWhere } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 import { logger } from "../../../logger.js";
 
 type IsCommentAuthorInput = {
@@ -14,10 +15,18 @@ type IsCommentAuthorInput = {
 export const isCommentAuthor = rule({ cache: "contextual" })(
   async (parent: unknown, args: IsCommentAuthorInput, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
     logger.info("isCommentAuthor rule");
+    let commentId;
     const { where } = args;
-    const commentId  = where.id
+    if (where) {
+      commentId = where.id;
+    }
 
     // set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isDiscussionChannelOwner.ts
+++ b/rules/permission/ownership/isDiscussionChannelOwner.ts
@@ -3,6 +3,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../../types/context.js";
 import { DiscussionChannelWhere, User } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 import { logger } from "../../../logger.js";
 
 type IsDiscussionChannelOwnerInput = {
@@ -12,6 +13,11 @@ type IsDiscussionChannelOwnerInput = {
 export const isDiscussionChannelOwner = rule({ cache: "contextual" })(
   async (parent: unknown, args: IsDiscussionChannelOwnerInput, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
     // Set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isDiscussionOwner.ts
+++ b/rules/permission/ownership/isDiscussionOwner.ts
@@ -8,6 +8,7 @@ import {
   DiscussionUpdateInput,
 } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 
 type IsDiscussionOwnerInput = {
   where: DiscussionWhere;
@@ -26,6 +27,11 @@ export const isDiscussionOwner = rule({ cache: "contextual" })(
     }
 
     // set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isEventOwner.ts
+++ b/rules/permission/ownership/isEventOwner.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../../types/context.js";
 import { ERROR_MESSAGES } from "../../errorMessages.js";
 import { Event, EventWhere, EventUpdateInput } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 
 type IsEventOwnerInput = {
   where: EventWhere;
@@ -23,6 +24,11 @@ export const isEventOwner = rule({ cache: "contextual" })(
     }
 
     // set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/ownership/isIssueAuthor.ts
+++ b/rules/permission/ownership/isIssueAuthor.ts
@@ -4,6 +4,7 @@ import type { GraphQLContext } from "../../../types/context.js";
 import { ERROR_MESSAGES } from "../../errorMessages.js";
 import { Issue, IssueWhere } from "../../../src/generated/graphql.js";
 import { setUserDataOnContext } from "../userDataHelperFunctions.js";
+import { passesAsServerAdminOrRoot } from "../serverAdminOverride.js";
 
 type IsIssueAuthorInput = {
   where: IssueWhere;
@@ -19,6 +20,11 @@ export const isIssueAuthor = rule({ cache: "contextual" })(
     const issueId = where?.id;
 
     // Set user data
+    // Server admins and the env root pass any ownership-gated mutation (replaces isAdmin).
+    if (await passesAsServerAdminOrRoot(ctx)) {
+      return true;
+    }
+
     ctx.user = await setUserDataOnContext({
       context: ctx,
     });

--- a/rules/permission/serverAdminOverride.ts
+++ b/rules/permission/serverAdminOverride.ts
@@ -1,0 +1,28 @@
+import type { GraphQLContext } from "../../types/context.js";
+import { isServerRoot } from "./isServerRoot.js";
+import { getServerScopedMembership } from "./getServerScopedMembership.js";
+
+/**
+ * True when the caller is a server admin (incl. SuperAdmins) or the env
+ * break-glass root. This is the override that replaces the per-call-site
+ * `isAdmin` in ownership-gated content/channel mutations, so server admins keep
+ * their cross-server powers and root can do everything.
+ *
+ * Deliberately NOT applied to account ownership (isAccountOwner): editing or
+ * deleting another user's account is self-only by design (only the invite
+ * workflows are cross-user). See docs/isadmin-phaseout-design.md.
+ */
+export const passesAsServerAdminOrRoot = async (
+  ctx: GraphQLContext
+): Promise<boolean> => {
+  // Resolve membership first: getServerScopedMembership populates ctx.user from
+  // the request (email/username) when it isn't set yet. The ownership rules call
+  // this BEFORE their own setUserDataOnContext, and isServerRoot reads
+  // ctx.user.email — so the root check must run only once identity is resolved,
+  // otherwise an env-only root (not in the Admins list) would be missed.
+  const { isServerAdmin } = await getServerScopedMembership(ctx);
+  if (isServerRoot(ctx)) {
+    return true;
+  }
+  return isServerAdmin;
+};

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -67,10 +67,11 @@ import {
 } from "./definitions/wikiRules.js";
 import { canUpvoteComment, canUpvoteDiscussion } from "./definitions/votingRules.js";
 import {
-  isAdmin,
+  isRoot,
   canUploadFile,
   canGiveFeedback,
   canReportContent,
+  canReportServerContent,
   issueIsValid,
   canManageServerSettings,
   canManagePlugins,
@@ -124,7 +125,7 @@ const ruleList = {
   updateDownloadableFileInputIsValid,
   updateUserInputIsValid,
   hasChannelPermission,
-  isAdmin,
+  isRoot,
   canManageServerSettings,
   canManagePlugins,
   canManageRoles,
@@ -139,6 +140,7 @@ const ruleList = {
   canUpvoteDiscussion,
   canGiveFeedback,
   canReportContent,
+  canReportServerContent,
   canArchiveAndUnarchiveDiscussion,
   canArchiveAndUnarchiveEvent,
   canArchiveAndUnarchiveComment,

--- a/rules/validation/userIsValid.ts
+++ b/rules/validation/userIsValid.ts
@@ -19,7 +19,7 @@ type UserInput = {
 };
 
 // Role relationships must never be assigned through the generic updateUsers
-// mutation: it is gated to `isAccountOwner OR isAdmin`, so a non-admin can edit
+// mutation: it is gated to `isAccountOwner` (self-only), so a user can edit
 // their OWN user node. Without this guard a user could connect (or create) an
 // elevated ServerRole/ModServerRole/ChannelRole/ModChannelRole on themselves
 // and self-escalate to admin/mod. Role assignment must go through the dedicated


### PR DESCRIPTION
## Summary

Completes the **isAdmin phase-out** (`docs/isadmin-phaseout-design.md`). PR-3a (#72) converted the server-administration call sites to capability rules; this PR removes the last remaining `isAdmin` from the content/channel/ownership mutations and deletes the rule entirely.

Instead of an `isAdmin` OR-branch on every owner-gated mutation, a server-admin + root short-circuit now lives **inside** the channel and ownership rules. A server admin (incl. SuperAdmins) and the env break-glass root pass any channel permission / mod / ownership check server-wide — preserving admins' existing cross-channel powers — without a standalone rule.

## Changes

- **`rules/permission/serverAdminOverride.ts` (new)** — `passesAsServerAdminOrRoot(ctx)`: true for the env root (`SUPERADMIN_EMAIL` / `CYPRESS_ADMIN_TEST_EMAIL`) and for server admins. Resolves membership first so `ctx.user` (hence the root email) is populated before the root check — the ownership rules call it before their own `setUserDataOnContext`.
- **`hasChannelPermission` / `hasChannelModPermission`** — short-circuit via the override.
- **Ownership rules** (`isChannelOwner`, `isDiscussionOwner`, `isEventOwner`, `isCommentAuthor`, `isDiscussionChannelOwner`, `isAlbumOwner`, `isIssueAuthor`) — pass when the override holds. **Not** applied to `isAccountOwner`: account edit/delete stays self-only (§8.2/§8.4).
- **`getServerScopedMembership`** — SuperAdmins now count as server admins.
- **`serverRules`** — drop the `isAdmin` rule; add `isRoot` (env root only, for the dangerous `dropData`/`seedData` Cypress seams) and `canReportServerContent` (server-scoped `canReport`, for `reportProfilePicture`).
- **`permissions.ts`** — drop `isAdmin` from every Category-B OR; `updateUsers` / `deleteUsers` / `deleteEmails` become self-only; `dropDataForCypressTests` / `seedDataForCypressTests` → `isRoot`; `reportProfilePicture` → `canReportServerContent`.
- **`isCommentAuthor`** — guard a missing `where` (return `false`) instead of throwing a raw `TypeError`, matching the other ownership rules, so an unauthenticated `deleteComments` surfaces the not-authenticated error rather than a TypeError.

## Behavior notes

- **Admins keep moderating**: the seeded admin bundle grants the mod capabilities, so `canEdit*` / `canArchive*` / `canLockChannel` etc. resolve for admins; root always passes via the override.
- **Account actions are self-only by design**: `updateUsers`/`deleteUsers`/`deleteEmails` no longer carry an admin override. Cross-user admin actions go through the invite/suspension flows. The `updateUsers` role-connect block (privilege-escalation guard from #64) is unchanged.

## Testing

- `npm run tsc` — clean.
- Full unit suite — **671/671 pass** (incl. the `mutationAuth` auth-wiring tests, which now pass for `deleteComments`).
- No integration tests on this branch; CI sharded integration run is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
