### PR TITLE
feat(permissions): PR-4 — enforce no-privilege-escalation on role authoring

### DIFF
--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -233,7 +233,23 @@ production):
    from Category-B ORs; tier-based mod resolution for admins in
    `hasServerModPermission`; remove the `isAdmin` rule. Integration coverage for a
    restricted admin.
-4. **PR-4** — enforce the no-escalation invariant on invite / assign / role-edit.
+4. **PR-4 — no-privilege-escalation invariant. ✅ DONE (server roles).** Role
+   authoring is now gated by a capability-superset check in addition to
+   `canManageRoles`: `createServerRoles` / `createModServerRoles` /
+   `updateModServerRoles` reject any input that sets a capability `true` the actor
+   does not hold (so a restricted admin with `canManageRoles` cannot mint
+   `canManageAdmins`). Root bypasses; if the actor's role can't be resolved the
+   guard fails closed. Implemented as `rules/permission/actorCapabilities.ts`
+   (effective-role resolution, reusing the tier logic) + a pure, unit-tested
+   `findEscalatedCapabilities` in `rules/validation/roleEscalation.ts`. Assignment
+   is already covered: `updateUsers` role-connect is blocked (#64), and the invite
+   flows grant fixed tier roles (the inviter never chooses capabilities).
+   - 🔲 **Follow-up (PR-4b):** extend the guard to channel-scoped role authoring
+     (`createChannelRoles` / `createModChannelRoles`) and to **nested** role
+     create/update reachable through other mutations (e.g. a role `create`/`update`
+     embedded in `updateServerConfigs`). Channel-role capabilities carry no
+     server-administration power, so this is lower-risk than the server-role paths
+     closed here.
 5. **PR-5 (later)** — role-management UI; SuperAdmins section in
    `ServerMembershipEditor`.
 

--- a/permissions.ts
+++ b/permissions.ts
@@ -39,6 +39,8 @@ const {
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
   updateUserInputIsValid,
+  serverRoleInputDoesNotEscalate,
+  modServerRoleInputDoesNotEscalate,
   canReport,
   canSuspendAndUnsuspendUser,
   canArchiveAndUnarchiveComment,
@@ -124,17 +126,22 @@ const permissionList = shield({
       createTags: and(isAuthenticated, allow),
       
       // Role management requires canManageRoles (the updateUsers role-connect
-      // block still prevents self-escalation via assignment).
+      // block still prevents self-escalation via assignment). The server-role
+      // create/update paths additionally enforce the no-privilege-escalation
+      // invariant: you cannot author a role granting a capability you lack
+      // (e.g. a restricted admin cannot mint canManageAdmins). Channel-role
+      // creation carries no server-administration capability, so it is not
+      // guarded here — see docs/isadmin-phaseout-design.md §5.
       createChannelRoles: and(isAuthenticated, canManageRoles),
       createModChannelRoles: and(isAuthenticated, canManageRoles),
 
-      createModServerRoles: and(isAuthenticated, canManageRoles),
-      createServerRoles: and(isAuthenticated, canManageRoles),
+      createModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
+      createServerRoles: and(isAuthenticated, canManageRoles, serverRoleInputDoesNotEscalate),
       createServerConfigs: and(isAuthenticated, canManageServerSettings),
       deleteServerConfigs: and(isAuthenticated, canManageServerSettings),
 
       updateServerConfigs: and(isAuthenticated, canManageServerSettings),
-      updateModServerRoles: and(isAuthenticated, canManageRoles),
+      updateModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       deleteChannelRoles: and(isAuthenticated, or(canManageRoles, isChannelOwner)),
       deleteServerRoles: and(isAuthenticated, canManageRoles),
       

--- a/rules/permission/actorCapabilities.test.ts
+++ b/rules/permission/actorCapabilities.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveEffectiveServerRole,
+  resolveEffectiveModServerRole,
+} from "./actorCapabilities.js";
+
+// Pure tier selection for the actor's effective role (used by the
+// no-privilege-escalation guard). Mirrors hasServerPermission /
+// hasServerModPermission. See docs/isadmin-phaseout-design.md.
+
+const serverRoles = {
+  defaultServerRole: { canCreateChannel: true, canManageAdmins: false },
+  defaultSuspendedRole: { canCreateChannel: false, canManageAdmins: false },
+  adminRole: { canManageRoles: true, canManageAdmins: false },
+  superAdminRole: { canManageRoles: true, canManageAdmins: true },
+};
+
+test("resolveEffectiveServerRole: root holds everything", () => {
+  assert.equal(
+    resolveEffectiveServerRole({
+      isRoot: true,
+      isSuperAdmin: false,
+      isAdmin: false,
+      hasActiveSuspension: false,
+      ...serverRoles,
+    }),
+    "all"
+  );
+});
+
+test("resolveEffectiveServerRole: super-admin resolves the super-admin role", () => {
+  assert.equal(
+    resolveEffectiveServerRole({
+      isRoot: false,
+      isSuperAdmin: true,
+      isAdmin: false,
+      hasActiveSuspension: false,
+      ...serverRoles,
+    }),
+    serverRoles.superAdminRole
+  );
+});
+
+test("resolveEffectiveServerRole: admin resolves the (restricted) admin role", () => {
+  assert.equal(
+    resolveEffectiveServerRole({
+      isRoot: false,
+      isSuperAdmin: false,
+      isAdmin: true,
+      hasActiveSuspension: false,
+      ...serverRoles,
+    }),
+    serverRoles.adminRole
+  );
+});
+
+test("resolveEffectiveServerRole: suspension beats tier", () => {
+  assert.equal(
+    resolveEffectiveServerRole({
+      isRoot: false,
+      isSuperAdmin: true,
+      isAdmin: true,
+      hasActiveSuspension: true,
+      ...serverRoles,
+    }),
+    serverRoles.defaultSuspendedRole
+  );
+});
+
+test("resolveEffectiveServerRole: a plain user resolves the default role", () => {
+  assert.equal(
+    resolveEffectiveServerRole({
+      isRoot: false,
+      isSuperAdmin: false,
+      isAdmin: false,
+      hasActiveSuspension: false,
+      ...serverRoles,
+    }),
+    serverRoles.defaultServerRole
+  );
+});
+
+const modRoles = {
+  defaultModRole: { canReport: true, canRemoveDiscussionChannel: false },
+  defaultElevatedModRole: { canReport: true, canRemoveDiscussionChannel: true },
+  defaultSuspendedModRole: { canReport: false, canRemoveDiscussionChannel: false },
+};
+
+test("resolveEffectiveModServerRole: root and admin hold every mod capability", () => {
+  assert.equal(
+    resolveEffectiveModServerRole({
+      isRoot: true,
+      isAdmin: false,
+      isModerator: false,
+      hasActiveSuspension: false,
+      ...modRoles,
+    }),
+    "all"
+  );
+  assert.equal(
+    resolveEffectiveModServerRole({
+      isRoot: false,
+      isAdmin: true,
+      isModerator: false,
+      hasActiveSuspension: false,
+      ...modRoles,
+    }),
+    "all"
+  );
+});
+
+test("resolveEffectiveModServerRole: a suspended admin loses the full bundle", () => {
+  assert.equal(
+    resolveEffectiveModServerRole({
+      isRoot: false,
+      isAdmin: true,
+      isModerator: false,
+      hasActiveSuspension: true,
+      ...modRoles,
+    }),
+    modRoles.defaultSuspendedModRole
+  );
+});
+
+test("resolveEffectiveModServerRole: a moderator resolves the elevated role", () => {
+  assert.equal(
+    resolveEffectiveModServerRole({
+      isRoot: false,
+      isAdmin: false,
+      isModerator: true,
+      hasActiveSuspension: false,
+      ...modRoles,
+    }),
+    modRoles.defaultElevatedModRole
+  );
+});
+
+test("resolveEffectiveModServerRole: a plain user resolves the default mod role", () => {
+  assert.equal(
+    resolveEffectiveModServerRole({
+      isRoot: false,
+      isAdmin: false,
+      isModerator: false,
+      hasActiveSuspension: false,
+      ...modRoles,
+    }),
+    modRoles.defaultModRole
+  );
+});

--- a/rules/permission/actorCapabilities.ts
+++ b/rules/permission/actorCapabilities.ts
@@ -1,0 +1,213 @@
+// Resolves the *full* effective role (every capability flag) for the current
+// caller, so the no-privilege-escalation guard can compare a requested role
+// input against what the caller actually holds. The existing has*Permission
+// helpers only answer a single-capability yes/no; this returns the whole role.
+//
+// The tier-selection logic mirrors hasServerPermission.evaluateServerPermission
+// and hasServerModPermission (root > super-admin > admin > moderator > default,
+// with suspension taking precedence over tier). Kept here as a separate, pure,
+// unit-tested function so the guard never has to re-implement it ad hoc.
+import type { GraphQLContext } from "../../types/context.js";
+import { isServerRoot } from "./isServerRoot.js";
+import { setUserDataOnContext } from "./userDataHelperFunctions.js";
+import { getServerConfigForPermissions } from "./getServerConfigForPermissions.js";
+import { getActiveServerSuspension } from "./getActiveServerSuspension.js";
+
+// A role is a flat map of capability name -> granted, modeled loosely so this is
+// decoupled from the generated OGM role types.
+type RoleLike = Record<string, boolean | null | undefined> | null | undefined;
+
+// "all" means the caller holds every capability (the env break-glass root, and
+// — for mod capabilities — a non-suspended server admin). `null` means no
+// governing role could be resolved (treated as "grants nothing" by the guard,
+// i.e. fail closed).
+export type EffectiveRole = RoleLike | "all";
+
+// Real capabilities only — display-only flags (showAdminTag / showModTag) are
+// intentionally excluded: granting a tag is not a privilege escalation.
+export const SERVER_ROLE_CAPABILITY_FIELDS = [
+  "canCreateChannel",
+  "canCreateDiscussion",
+  "canCreateEvent",
+  "canCreateComment",
+  "canUpvoteDiscussion",
+  "canUpvoteComment",
+  "canUploadFile",
+  "canGiveFeedback",
+  "canManageServerSettings",
+  "canManagePlugins",
+  "canManageRoles",
+  "canManageMods",
+  "canManageAdmins",
+  "canManageSuperAdmins",
+] as const;
+
+export const MOD_SERVER_ROLE_CAPABILITY_FIELDS = [
+  "canLockChannel",
+  "canHideComment",
+  "canHideEvent",
+  "canHideDiscussion",
+  "canEditComments",
+  "canEditDiscussions",
+  "canEditEvents",
+  "canGiveFeedback",
+  "canOpenSupportTickets",
+  "canCloseSupportTickets",
+  "canReport",
+  "canSuspendUser",
+  "canArchiveImage",
+  "canDeleteWiki",
+  "canPermanentlyRemoveImage",
+  "canRemoveDiscussionChannel",
+  "canRemoveEventChannel",
+] as const;
+
+// --- Pure tier selection (extracted for unit testing) ---
+
+export function resolveEffectiveServerRole(input: {
+  isRoot: boolean;
+  isSuperAdmin: boolean;
+  isAdmin: boolean;
+  hasActiveSuspension: boolean;
+  defaultServerRole: RoleLike;
+  defaultSuspendedRole: RoleLike;
+  adminRole: RoleLike;
+  superAdminRole: RoleLike;
+}): EffectiveRole {
+  if (input.isRoot) {
+    return "all";
+  }
+  // Suspension takes precedence over tier (mirrors evaluateServerPermission).
+  if (input.hasActiveSuspension) {
+    return input.defaultSuspendedRole ?? null;
+  }
+  return (
+    (input.isSuperAdmin ? input.superAdminRole : null) ??
+    (input.isAdmin ? input.adminRole : null) ??
+    input.defaultServerRole ??
+    null
+  );
+}
+
+export function resolveEffectiveModServerRole(input: {
+  isRoot: boolean;
+  isAdmin: boolean;
+  isModerator: boolean;
+  hasActiveSuspension: boolean;
+  defaultModRole: RoleLike;
+  defaultElevatedModRole: RoleLike;
+  defaultSuspendedModRole: RoleLike;
+}): EffectiveRole {
+  if (input.isRoot) {
+    return "all";
+  }
+  // Suspension takes precedence over tier (mirrors hasServerModPermission).
+  if (input.hasActiveSuspension) {
+    return input.defaultSuspendedModRole ?? null;
+  }
+  // A non-suspended server admin holds every mod capability.
+  if (input.isAdmin) {
+    return "all";
+  }
+  if (input.isModerator) {
+    return input.defaultElevatedModRole ?? input.defaultModRole ?? null;
+  }
+  return input.defaultModRole ?? null;
+}
+
+// --- Context wrappers (fetch data, then select) ---
+
+export async function getActorServerRoleCaps(
+  context: GraphQLContext
+): Promise<EffectiveRole> {
+  if (!context.user?.data) {
+    context.user = await setUserDataOnContext({ context });
+  }
+  if (isServerRoot(context)) {
+    return "all";
+  }
+
+  const username = context.user?.username;
+  const serverConfig = await getServerConfigForPermissions(context);
+  if (!serverConfig) {
+    return null;
+  }
+
+  let hasActiveSuspension = false;
+  if (username) {
+    const suspension = await getActiveServerSuspension({ context, username });
+    hasActiveSuspension = suspension.isSuspended;
+  }
+
+  const isSuperAdmin =
+    !!username &&
+    (serverConfig.SuperAdmins ?? []).some(
+      (member: { username?: string | null }) => member?.username === username
+    );
+  const isAdmin =
+    !!username &&
+    (serverConfig.Admins ?? []).some(
+      (member: { username?: string | null }) => member?.username === username
+    );
+
+  return resolveEffectiveServerRole({
+    isRoot: false,
+    isSuperAdmin,
+    isAdmin,
+    hasActiveSuspension,
+    defaultServerRole: serverConfig.DefaultServerRole as RoleLike,
+    defaultSuspendedRole: serverConfig.DefaultSuspendedRole as RoleLike,
+    adminRole: serverConfig.DefaultAdminRole as RoleLike,
+    superAdminRole: serverConfig.DefaultSuperAdminRole as RoleLike,
+  });
+}
+
+export async function getActorModServerRoleCaps(
+  context: GraphQLContext
+): Promise<EffectiveRole> {
+  if (!context.user?.data) {
+    context.user = await setUserDataOnContext({ context });
+  }
+  if (isServerRoot(context)) {
+    return "all";
+  }
+
+  const username = context.user?.username;
+  const modProfileName = context.user?.data?.ModerationProfile?.displayName;
+  const serverConfig = await getServerConfigForPermissions(context);
+  if (!serverConfig) {
+    return null;
+  }
+
+  let hasActiveSuspension = false;
+  if (username || modProfileName) {
+    const suspension = await getActiveServerSuspension({
+      context,
+      username: username ?? undefined,
+      modProfileName: modProfileName ?? undefined,
+    });
+    hasActiveSuspension = suspension.isSuspended;
+  }
+
+  const isAdmin =
+    !!username &&
+    (serverConfig.Admins ?? []).some(
+      (member: { username?: string | null }) => member?.username === username
+    );
+  const isModerator =
+    !!modProfileName &&
+    (serverConfig.Moderators ?? []).some(
+      (member: { displayName?: string | null }) =>
+        member?.displayName === modProfileName
+    );
+
+  return resolveEffectiveModServerRole({
+    isRoot: false,
+    isAdmin,
+    isModerator,
+    hasActiveSuspension,
+    defaultModRole: serverConfig.DefaultModRole as RoleLike,
+    defaultElevatedModRole: serverConfig.DefaultElevatedModRole as RoleLike,
+    defaultSuspendedModRole: serverConfig.DefaultSuspendedModRole as RoleLike,
+  });
+}

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -55,6 +55,10 @@ import {
 } from "./validation/downloadableFileIsValid.js";
 import { updateUserInputIsValid } from "./validation/userIsValid.js";
 import {
+  serverRoleInputDoesNotEscalate,
+  modServerRoleInputDoesNotEscalate,
+} from "./validation/roleEscalation.js";
+import {
   canCreateChannel,
   canCreateComment,
   canCreateDiscussion,
@@ -124,6 +128,8 @@ const ruleList = {
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
   updateUserInputIsValid,
+  serverRoleInputDoesNotEscalate,
+  modServerRoleInputDoesNotEscalate,
   hasChannelPermission,
   isRoot,
   canManageServerSettings,

--- a/rules/validation/roleEscalation.test.ts
+++ b/rules/validation/roleEscalation.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  findEscalatedCapabilities,
+  collectRequestedRoles,
+} from "./roleEscalation.js";
+
+// The no-privilege-escalation guard (docs/isadmin-phaseout-design.md §5).
+// findEscalatedCapabilities returns the capabilities an input tries to grant
+// that the actor does not hold.
+
+const SERVER_CAPS = [
+  "canManageRoles",
+  "canManageAdmins",
+  "canCreateChannel",
+] as const;
+
+test("root (actorRole 'all') never escalates", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [{ canManageAdmins: true, canManageRoles: true }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: "all",
+  });
+  assert.deepEqual(escalated, []);
+});
+
+test("flags a capability the actor lacks", () => {
+  // Restricted admin: has canManageRoles, NOT canManageAdmins.
+  const escalated = findEscalatedCapabilities({
+    requested: [{ canManageRoles: true, canManageAdmins: true }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: { canManageRoles: true, canManageAdmins: false, canCreateChannel: true },
+  });
+  assert.deepEqual(escalated, ["canManageAdmins"]);
+});
+
+test("allows granting capabilities the actor holds", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [{ canManageRoles: true, canCreateChannel: true }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: { canManageRoles: true, canManageAdmins: false, canCreateChannel: true },
+  });
+  assert.deepEqual(escalated, []);
+});
+
+test("a null actor role grants nothing (fail closed)", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [{ canManageRoles: true }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: null,
+  });
+  assert.deepEqual(escalated, ["canManageRoles"]);
+});
+
+test("setting a capability to false or null is never an escalation", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [{ canManageAdmins: false, canManageRoles: null }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: null,
+  });
+  assert.deepEqual(escalated, []);
+});
+
+test("deduplicates across multiple requested role items", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [
+      { canManageAdmins: true },
+      { canManageAdmins: true, canCreateChannel: true },
+      null,
+    ],
+    capabilityFields: SERVER_CAPS,
+    actorRole: { canCreateChannel: true },
+  });
+  assert.deepEqual(escalated.sort(), ["canManageAdmins"]);
+});
+
+test("ignores non-capability fields in the input (name, description, …)", () => {
+  const escalated = findEscalatedCapabilities({
+    requested: [{ name: "Editor", description: "x", canManageAdmins: true }],
+    capabilityFields: SERVER_CAPS,
+    actorRole: { canManageRoles: true },
+  });
+  assert.deepEqual(escalated, ["canManageAdmins"]);
+});
+
+test("collectRequestedRoles: reads create `input` array items", () => {
+  const collected = collectRequestedRoles({
+    input: [{ name: "A", canManageRoles: true }, { name: "B" }],
+  });
+  assert.deepEqual(collected, [
+    { name: "A", canManageRoles: true },
+    { name: "B" },
+  ]);
+});
+
+test("collectRequestedRoles: reads the update object", () => {
+  const collected = collectRequestedRoles({
+    update: { canManageAdmins: true },
+    where: { name: "Editor" },
+  });
+  assert.deepEqual(collected, [{ canManageAdmins: true }]);
+});
+
+test("collectRequestedRoles: no input or update yields an empty list", () => {
+  assert.deepEqual(collectRequestedRoles({ where: { name: "Editor" } }), []);
+});

--- a/rules/validation/roleEscalation.ts
+++ b/rules/validation/roleEscalation.ts
@@ -1,0 +1,120 @@
+// No-privilege-escalation guard (docs/isadmin-phaseout-design.md §5).
+//
+// The role create/update mutations are gated by `canManageRoles`, but that only
+// asks "may you manage roles?" — not "may you grant THIS capability?". Without a
+// further check, a restricted admin with `canManageRoles` could author a role
+// that grants `canManageAdmins` (or any capability they lack) and escalate.
+//
+// This guard rejects any role input that sets a capability flag to `true` which
+// the actor does not themselves hold. Root holds everything and always passes;
+// if the actor's own role cannot be resolved, the guard fails closed (every
+// requested capability counts as an escalation).
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  SERVER_ROLE_CAPABILITY_FIELDS,
+  MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+  getActorServerRoleCaps,
+  getActorModServerRoleCaps,
+  type EffectiveRole,
+} from "../permission/actorCapabilities.js";
+
+// --- Pure decision (extracted for unit testing) ---
+
+/**
+ * Returns the capabilities the input tries to grant that the actor does not
+ * hold. An empty array means no escalation. `actorRole === "all"` (root / full
+ * admin) never escalates; a `null` actor role grants nothing, so every requested
+ * capability is flagged (fail closed).
+ */
+export function findEscalatedCapabilities(input: {
+  requested: Array<Record<string, unknown> | null | undefined>;
+  capabilityFields: readonly string[];
+  actorRole: EffectiveRole;
+}): string[] {
+  const { requested, capabilityFields, actorRole } = input;
+
+  if (actorRole === "all") {
+    return [];
+  }
+
+  const granted = actorRole ?? {};
+  const escalated = new Set<string>();
+
+  for (const item of requested) {
+    if (!item) {
+      continue;
+    }
+    for (const field of capabilityFields) {
+      if (item[field] === true && granted[field] !== true) {
+        escalated.add(field);
+      }
+    }
+  }
+
+  return [...escalated];
+}
+
+// Collects the role objects carried by a create (`input: [...]`) or update
+// (`update: {...}`) mutation.
+export function collectRequestedRoles(
+  args: Record<string, unknown>
+): Array<Record<string, unknown>> {
+  const requested: Array<Record<string, unknown>> = [];
+  if (Array.isArray(args.input)) {
+    requested.push(...(args.input as Array<Record<string, unknown>>));
+  }
+  if (args.update && typeof args.update === "object") {
+    requested.push(args.update as Record<string, unknown>);
+  }
+  return requested;
+}
+
+type RoleEscalationRuleInput = {
+  capabilityFields: readonly string[];
+  getActorRole: (ctx: GraphQLContext) => Promise<EffectiveRole>;
+};
+
+const roleEscalationRule = ({
+  capabilityFields,
+  getActorRole,
+}: RoleEscalationRuleInput) =>
+  rule({ cache: "contextual" })(
+    async (
+      _parent: unknown,
+      args: Record<string, unknown>,
+      ctx: GraphQLContext,
+      _info: GraphQLResolveInfo
+    ) => {
+      const requested = collectRequestedRoles(args);
+      if (requested.length === 0) {
+        return true;
+      }
+
+      const actorRole = await getActorRole(ctx);
+      const escalated = findEscalatedCapabilities({
+        requested,
+        capabilityFields,
+        actorRole,
+      });
+
+      if (escalated.length > 0) {
+        return `You cannot grant capabilities you do not have yourself: ${escalated.join(
+          ", "
+        )}.`;
+      }
+
+      return true;
+    }
+  );
+
+export const serverRoleInputDoesNotEscalate = roleEscalationRule({
+  capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+  getActorRole: getActorServerRoleCaps,
+});
+
+export const modServerRoleInputDoesNotEscalate = roleEscalationRule({
+  capabilityFields: MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+  getActorRole: getActorModServerRoleCaps,
+});


### PR DESCRIPTION
## Summary

Implements the **no-privilege-escalation invariant** (`docs/isadmin-phaseout-design.md` §5) — the last load-bearing security gap in the isAdmin phase-out.

`canManageRoles` only asks *"may you manage roles?"*, not *"may you grant THIS capability?"*. Without a further check, a restricted admin with `canManageRoles` could author a role that grants `canManageAdmins` (a capability they lack) and escalate to the apex tier. This PR closes that.

**Guard:** the server-scoped role-authoring mutations now reject any input that sets a capability flag `true` which the actor does not themselves hold:
- `createServerRoles` → `serverRoleInputDoesNotEscalate`
- `createModServerRoles`, `updateModServerRoles` → `modServerRoleInputDoesNotEscalate`

Root holds everything and always passes. If the actor's own role can't be resolved, the guard **fails closed** (every requested capability counts as an escalation).

## Why these mutations

These are the only reachable paths where a caller *chooses* capabilities:
- `updateServerRoles` / `updateChannelRoles` / `updateModChannelRoles` are already default-denied (`Mutation: { "*": deny }`).
- **Assignment** is already covered: `updateUsers` role-connect is blocked (#64), and the invite flows (`inviteServerAdmin`, …) only connect membership — the inviter never picks capabilities; the invitee resolves the fixed `DefaultAdminRole`/`DefaultModRole` tier.

## Implementation

- **`rules/permission/actorCapabilities.ts` (new)** — resolves the actor's *full* effective `ServerRole`/`ModServerRole` (the existing `has*Permission` helpers only answer a single-capability yes/no). Pure, unit-tested tier selection (`resolveEffectiveServerRole` / `resolveEffectiveModServerRole`) mirroring `hasServerPermission`/`hasServerModPermission` — root → all, super-admin → super-admin role, admin → admin role (or full mod bundle), suspension beats tier. Capability field lists live here as the single source of truth (display-only `showAdminTag`/`showModTag` excluded — granting a tag isn't escalation).
- **`rules/validation/roleEscalation.ts` (new)** — pure `findEscalatedCapabilities(...)` + the two graphql-shield rules; `collectRequestedRoles` handles both the create `input: [...]` and update `update: {...}` shapes.
- **`permissions.ts` / `rules.ts`** — wire the rules into the three mutations.

This PR does **not** modify `hasServerPermission.ts` / `hasServerModPermission.ts`, so it's independent of #73/#74 (no conflicts).

## Scoped follow-up (PR-4b)

Documented in §5: extend the guard to channel-scoped role authoring (`createChannelRoles`/`createModChannelRoles`) and to **nested** role create/update reachable via other mutations (e.g. a role embedded in `updateServerConfigs`). Channel-role capabilities carry no server-administration power, so they're lower-risk than the server-role paths closed here.

## Testing

- `npm run tsc` clean.
- 19 new unit tests (`roleEscalation.test.ts` + `actorCapabilities.test.ts`): root bypass, exact-match allow, escalation flagged, fail-closed null role, false/null caps ignored, dedup across items, non-capability fields ignored, create-vs-update arg parsing, and the full tier-selection matrix.
- Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
