### PR TITLE
feat(permissions): PR-4b — close nested role-escalation via updateServerConfigs

### DIFF
--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -244,12 +244,24 @@ production):
    `findEscalatedCapabilities` in `rules/validation/roleEscalation.ts`. Assignment
    is already covered: `updateUsers` role-connect is blocked (#64), and the invite
    flows grant fixed tier roles (the inviter never chooses capabilities).
-   - 🔲 **Follow-up (PR-4b):** extend the guard to channel-scoped role authoring
-     (`createChannelRoles` / `createModChannelRoles`) and to **nested** role
-     create/update reachable through other mutations (e.g. a role `create`/`update`
-     embedded in `updateServerConfigs`). Channel-role capabilities carry no
-     server-administration power, so this is lower-risk than the server-role paths
-     closed here.
+   - ✅ **PR-4b — nested ServerConfig escalation closed.** The generated
+     `ServerConfig` create/update input allows nested role writes on the tier
+     relationships (`DefaultAdminRole`, `DefaultServerRole`, …), reachable via
+     `updateServerConfigs`/`createServerConfigs` (gated only by
+     `canManageServerSettings`) — e.g.
+     `updateServerConfigs(update: { DefaultAdminRole: { update: { node: { canManageAdmins: true } } } })`.
+     `serverConfigInputDoesNotEscalate` (`rules/validation/nestedRoleEscalation.ts`)
+     now walks those relationships and rejects any nested `create`/`update`/
+     `connectOrCreate` node — and resolves `connect`/`connectOrCreate` targets from
+     the DB — that grants a capability the actor lacks (so connecting an existing
+     `DefaultSuperAdminRole` into a lower tier slot is caught too). Root / full
+     admin bypass; lookup failures fail closed.
+   - 🔲 **Follow-up (PR-4c, low risk):** channel-scoped role authoring
+     (`createChannelRoles`/`createModChannelRoles` and nested role writes in
+     `createChannels`/`updateChannels`). `Channel` only links `ChannelRole`/
+     `ModChannelRole`, which carry **no** server-administration capability, so they
+     cannot reach the apex tier; channel role definition is also a legitimate
+     channel-owner operation. Tracked as defense-in-depth, not an open apex hole.
 5. **PR-5 (later)** — role-management UI; SuperAdmins section in
    `ServerMembershipEditor`.
 

--- a/permissions.ts
+++ b/permissions.ts
@@ -41,6 +41,7 @@ const {
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
+  serverConfigInputDoesNotEscalate,
   canReport,
   canSuspendAndUnsuspendUser,
   canArchiveAndUnarchiveComment,
@@ -137,10 +138,12 @@ const permissionList = shield({
 
       createModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       createServerRoles: and(isAuthenticated, canManageRoles, serverRoleInputDoesNotEscalate),
-      createServerConfigs: and(isAuthenticated, canManageServerSettings),
+      createServerConfigs: and(isAuthenticated, canManageServerSettings, serverConfigInputDoesNotEscalate),
       deleteServerConfigs: and(isAuthenticated, canManageServerSettings),
 
-      updateServerConfigs: and(isAuthenticated, canManageServerSettings),
+      // canManageServerSettings additionally must not be used to escalate a tier
+      // role via a nested role create/update/connect (see §5 / PR-4b).
+      updateServerConfigs: and(isAuthenticated, canManageServerSettings, serverConfigInputDoesNotEscalate),
       updateModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       deleteChannelRoles: and(isAuthenticated, or(canManageRoles, isChannelOwner)),
       deleteServerRoles: and(isAuthenticated, canManageRoles),

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -58,6 +58,7 @@ import {
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
 } from "./validation/roleEscalation.js";
+import { serverConfigInputDoesNotEscalate } from "./validation/nestedRoleEscalation.js";
 import {
   canCreateChannel,
   canCreateComment,
@@ -130,6 +131,7 @@ const ruleList = {
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
+  serverConfigInputDoesNotEscalate,
   hasChannelPermission,
   isRoot,
   canManageServerSettings,

--- a/rules/validation/nestedRoleEscalation.test.ts
+++ b/rules/validation/nestedRoleEscalation.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractNestedRoleWrites } from "./nestedRoleEscalation.js";
+import { findEscalatedCapabilities } from "./roleEscalation.js";
+import {
+  SERVER_ROLE_CAPABILITY_FIELDS,
+  type EffectiveRole,
+} from "../permission/actorCapabilities.js";
+
+// PR-4b: the nested role-escalation guard for ServerConfig mutations.
+// extractNestedRoleWrites pulls capability-bearing role nodes and connect
+// `where`s out of the (auto-generated) ServerConfig create/update input, across
+// all create/update/connect/connectOrCreate shapes.
+
+test("extracts a nested update node on a ServerRole tier relationship", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true } } },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canManageAdmins: true }]);
+  assert.deepEqual(writes.modServerRoleNodes, []);
+});
+
+test("extracts a nested create node on a ServerRole tier relationship", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultServerRole: { create: { node: { canCreateChannel: true } } },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canCreateChannel: true }]);
+});
+
+test("extracts connectOrCreate onCreate nodes and connect wheres", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: {
+      connectOrCreate: {
+        where: { node: { name: "Super Administrator" } },
+        onCreate: { node: { canManageSuperAdmins: true } },
+      },
+    },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canManageSuperAdmins: true }]);
+  assert.deepEqual(writes.serverRoleConnectWheres, [{ name: "Super Administrator" }]);
+});
+
+test("extracts a connect where (connecting an existing role into a tier slot)", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultServerRole: { connect: { where: { node: { name: "Super Administrator" } } } },
+  });
+  assert.deepEqual(writes.serverRoleConnectWheres, [{ name: "Super Administrator" }]);
+  assert.deepEqual(writes.serverRoleNodes, []);
+});
+
+test("routes mod-role relationships to the mod buckets", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultModRole: { update: { node: { canRemoveDiscussionChannel: true } } },
+    DefaultElevatedModRole: { connect: { where: { node: { name: "Full Mod" } } } },
+  });
+  assert.deepEqual(writes.modServerRoleNodes, [{ canRemoveDiscussionChannel: true }]);
+  assert.deepEqual(writes.modServerRoleConnectWheres, [{ name: "Full Mod" }]);
+  assert.deepEqual(writes.serverRoleNodes, []);
+});
+
+test("handles array-shaped relationship inputs defensively", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: [
+      { update: { node: { canManageAdmins: true } } },
+      { create: { node: { canManageRoles: true } } },
+    ],
+  });
+  assert.deepEqual(writes.serverRoleNodes, [
+    { canManageAdmins: true },
+    { canManageRoles: true },
+  ]);
+});
+
+test("ignores non-role fields and empty/invalid input", () => {
+  assert.deepEqual(extractNestedRoleWrites({ name: "My Server", description: "x" }), {
+    serverRoleNodes: [],
+    modServerRoleNodes: [],
+    serverRoleConnectWheres: [],
+    modServerRoleConnectWheres: [],
+  });
+  assert.deepEqual(extractNestedRoleWrites(null).serverRoleNodes, []);
+  assert.deepEqual(extractNestedRoleWrites("nope").serverRoleNodes, []);
+});
+
+test("end to end: a nested DefaultAdminRole.update escalates for a restricted admin", () => {
+  // The exact apex-escalation attack: a restricted admin (canManageRoles but not
+  // canManageAdmins) edits the shared admin tier role to grant canManageAdmins.
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true, canManageRoles: true } } },
+  });
+  const restrictedAdmin: EffectiveRole = {
+    canManageRoles: true,
+    canManageAdmins: false,
+  };
+  const escalated = findEscalatedCapabilities({
+    requested: writes.serverRoleNodes,
+    capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+    actorRole: restrictedAdmin,
+  });
+  assert.deepEqual(escalated, ["canManageAdmins"]);
+});
+
+test("end to end: the same nested edit is allowed for root ('all')", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true } } },
+  });
+  const escalated = findEscalatedCapabilities({
+    requested: writes.serverRoleNodes,
+    capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+    actorRole: "all",
+  });
+  assert.deepEqual(escalated, []);
+});

--- a/rules/validation/nestedRoleEscalation.ts
+++ b/rules/validation/nestedRoleEscalation.ts
@@ -1,0 +1,277 @@
+// No-privilege-escalation guard for NESTED role writes (PR-4b; extends PR-4 /
+// docs/isadmin-phaseout-design.md §5).
+//
+// PR-4 guards the top-level role-authoring mutations, but the auto-generated
+// `ServerConfigUpdateInput` / `ServerConfigCreateInput` also allow nested
+// role writes on the tier relationships:
+//
+//   updateServerConfigs(update: {
+//     DefaultAdminRole: { update: { node: { canManageAdmins: true } } }
+//   })
+//
+// That path is gated only by `canManageServerSettings`, so without this guard a
+// restricted admin could edit the shared `DefaultAdminRole` (or connect an
+// existing powerful role into a tier slot) and escalate the whole admin tier.
+//
+// This guard walks the ServerConfig input's role relationships and rejects any
+// nested create/update/connectOrCreate role node — and any connect target
+// resolved from the database — that grants a capability the actor lacks. Root /
+// full admin bypass; resolution failures fail closed.
+//
+// Channel mutations are intentionally out of scope: Channel only links
+// ChannelRole / ModChannelRole, which carry no server-administration capability,
+// so they cannot reach the apex tier (see §5 follow-up notes).
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  SERVER_ROLE_CAPABILITY_FIELDS,
+  MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+  getActorServerRoleCaps,
+  getActorModServerRoleCaps,
+  type EffectiveRole,
+} from "../permission/actorCapabilities.js";
+import { findEscalatedCapabilities } from "./roleEscalation.js";
+
+// ServerConfig tier relationships, by the role type they connect.
+export const SERVER_CONFIG_SERVER_ROLE_RELATIONSHIPS = [
+  "DefaultServerRole",
+  "DefaultAdminRole",
+  "DefaultSuperAdminRole",
+  "DefaultSuspendedRole",
+] as const;
+
+export const SERVER_CONFIG_MOD_ROLE_RELATIONSHIPS = [
+  "DefaultModRole",
+  "DefaultElevatedModRole",
+  "DefaultSuspendedModRole",
+] as const;
+
+type RoleNode = Record<string, unknown>;
+type WhereNode = Record<string, unknown>;
+
+export type ExtractedRoleWrites = {
+  // Capability-bearing nodes (create / update / connectOrCreate.onCreate).
+  serverRoleNodes: RoleNode[];
+  modServerRoleNodes: RoleNode[];
+  // `where` clauses that connect an EXISTING role (connect / connectOrCreate),
+  // whose capabilities must be resolved from the database.
+  serverRoleConnectWheres: WhereNode[];
+  modServerRoleConnectWheres: WhereNode[];
+};
+
+const toArray = <T>(value: T | T[] | null | undefined): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+
+// Pulls the capability-bearing nodes and connect `where`s out of a single
+// relationship field input (create | update | connect | connectOrCreate), for
+// both the create-input and update-input shapes.
+function collectFromRelationshipField(
+  fieldInput: unknown,
+  nodes: RoleNode[],
+  connectWheres: WhereNode[]
+): void {
+  for (const op of toArray(fieldInput) as Array<Record<string, unknown>>) {
+    if (!op || typeof op !== "object") {
+      continue;
+    }
+
+    for (const create of toArray(op.create) as Array<Record<string, unknown>>) {
+      if (create?.node && typeof create.node === "object") {
+        nodes.push(create.node as RoleNode);
+      }
+    }
+
+    for (const update of toArray(op.update) as Array<Record<string, unknown>>) {
+      if (update?.node && typeof update.node === "object") {
+        nodes.push(update.node as RoleNode);
+      }
+    }
+
+    for (const coc of toArray(op.connectOrCreate) as Array<Record<string, unknown>>) {
+      const onCreate = coc?.onCreate as Record<string, unknown> | undefined;
+      if (onCreate?.node && typeof onCreate.node === "object") {
+        nodes.push(onCreate.node as RoleNode);
+      }
+      const where = coc?.where as Record<string, unknown> | undefined;
+      if (where?.node && typeof where.node === "object") {
+        connectWheres.push(where.node as WhereNode);
+      }
+    }
+
+    for (const connect of toArray(op.connect) as Array<Record<string, unknown>>) {
+      const where = connect?.where as Record<string, unknown> | undefined;
+      if (where?.node && typeof where.node === "object") {
+        connectWheres.push(where.node as WhereNode);
+      }
+    }
+  }
+}
+
+// --- Pure extraction (unit tested) ---
+
+export function extractNestedRoleWrites(input: unknown): ExtractedRoleWrites {
+  const result: ExtractedRoleWrites = {
+    serverRoleNodes: [],
+    modServerRoleNodes: [],
+    serverRoleConnectWheres: [],
+    modServerRoleConnectWheres: [],
+  };
+
+  if (!input || typeof input !== "object") {
+    return result;
+  }
+  const obj = input as Record<string, unknown>;
+
+  for (const field of SERVER_CONFIG_SERVER_ROLE_RELATIONSHIPS) {
+    collectFromRelationshipField(
+      obj[field],
+      result.serverRoleNodes,
+      result.serverRoleConnectWheres
+    );
+  }
+  for (const field of SERVER_CONFIG_MOD_ROLE_RELATIONSHIPS) {
+    collectFromRelationshipField(
+      obj[field],
+      result.modServerRoleNodes,
+      result.modServerRoleConnectWheres
+    );
+  }
+
+  return result;
+}
+
+function mergeWrites(target: ExtractedRoleWrites, source: ExtractedRoleWrites): void {
+  target.serverRoleNodes.push(...source.serverRoleNodes);
+  target.modServerRoleNodes.push(...source.modServerRoleNodes);
+  target.serverRoleConnectWheres.push(...source.serverRoleConnectWheres);
+  target.modServerRoleConnectWheres.push(...source.modServerRoleConnectWheres);
+}
+
+// Resolves the capabilities of existing roles targeted by a connect `where`, so
+// connecting a powerful role into a tier slot is caught. Throws on lookup
+// failure so the shield rule fails closed.
+async function resolveConnectedRoleNodes(
+  ctx: GraphQLContext,
+  modelName: "ServerRole" | "ModServerRole",
+  wheres: WhereNode[],
+  capabilityFields: readonly string[]
+): Promise<RoleNode[]> {
+  if (wheres.length === 0) {
+    return [];
+  }
+
+  const Model = ctx.ogm.model(modelName);
+  const selectionSet = `{ ${capabilityFields.join("\n")} }`;
+  const resolved: RoleNode[] = [];
+
+  for (const where of wheres) {
+    const roles = (await Model.find({ where, selectionSet })) as RoleNode[];
+    resolved.push(...roles);
+  }
+
+  return resolved;
+}
+
+type RoleEscalationCheck = {
+  nodes: RoleNode[];
+  connectWheres: WhereNode[];
+  modelName: "ServerRole" | "ModServerRole";
+  capabilityFields: readonly string[];
+  actorRole: EffectiveRole;
+};
+
+async function collectEscalations(
+  ctx: GraphQLContext,
+  check: RoleEscalationCheck
+): Promise<string[]> {
+  const { nodes, connectWheres, modelName, capabilityFields, actorRole } = check;
+
+  // A caller who already holds every capability (root / full admin) can never
+  // escalate, so skip the database round-trips for connect resolution.
+  if (actorRole === "all") {
+    return [];
+  }
+
+  const connectedNodes = await resolveConnectedRoleNodes(
+    ctx,
+    modelName,
+    connectWheres,
+    capabilityFields
+  );
+
+  return findEscalatedCapabilities({
+    requested: [...nodes, ...connectedNodes],
+    capabilityFields,
+    actorRole,
+  });
+}
+
+export const serverConfigInputDoesNotEscalate = rule({ cache: "contextual" })(
+  async (
+    _parent: unknown,
+    args: Record<string, unknown>,
+    ctx: GraphQLContext,
+    _info: GraphQLResolveInfo
+  ) => {
+    const inputs: unknown[] = [];
+    if (Array.isArray(args.input)) {
+      inputs.push(...(args.input as unknown[]));
+    }
+    if (args.update) {
+      inputs.push(args.update);
+    }
+
+    const writes: ExtractedRoleWrites = {
+      serverRoleNodes: [],
+      modServerRoleNodes: [],
+      serverRoleConnectWheres: [],
+      modServerRoleConnectWheres: [],
+    };
+    for (const input of inputs) {
+      mergeWrites(writes, extractNestedRoleWrites(input));
+    }
+
+    const touchesRoles =
+      writes.serverRoleNodes.length > 0 ||
+      writes.modServerRoleNodes.length > 0 ||
+      writes.serverRoleConnectWheres.length > 0 ||
+      writes.modServerRoleConnectWheres.length > 0;
+    if (!touchesRoles) {
+      return true;
+    }
+
+    const [actorServerRole, actorModRole] = await Promise.all([
+      getActorServerRoleCaps(ctx),
+      getActorModServerRoleCaps(ctx),
+    ]);
+
+    const escalated = new Set<string>();
+
+    const serverEscalations = await collectEscalations(ctx, {
+      nodes: writes.serverRoleNodes,
+      connectWheres: writes.serverRoleConnectWheres,
+      modelName: "ServerRole",
+      capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+      actorRole: actorServerRole,
+    });
+    serverEscalations.forEach((capability) => escalated.add(capability));
+
+    const modEscalations = await collectEscalations(ctx, {
+      nodes: writes.modServerRoleNodes,
+      connectWheres: writes.modServerRoleConnectWheres,
+      modelName: "ModServerRole",
+      capabilityFields: MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+      actorRole: actorModRole,
+    });
+    modEscalations.forEach((capability) => escalated.add(capability));
+
+    if (escalated.size > 0) {
+      return `You cannot grant capabilities you do not have yourself: ${[
+        ...escalated,
+      ].join(", ")}.`;
+    }
+
+    return true;
+  }
+);


### PR DESCRIPTION
## Summary

Stacked on #75 (PR-4). Closes the **apex privilege-escalation hole** PR-4 left open: nested role writes through `updateServerConfigs` / `createServerConfigs`.

The auto-generated `ServerConfigUpdateInput` allows nested `create`/`update`/`connect`/`connectOrCreate` on the tier-role relationships (`DefaultAdminRole`, `DefaultServerRole`, `DefaultModRole`, …). Those mutations are gated only by `canManageServerSettings`, so without this guard a restricted admin could run:

```graphql
updateServerConfigs(update: { DefaultAdminRole: { update: { node: { canManageAdmins: true } } } })
```

…and escalate the entire admin tier (themselves included) to the apex — bypassing PR-4's top-level role-mutation guard. The `connect` shape is equally dangerous: wiring an existing `DefaultSuperAdminRole` into the `DefaultServerRole` slot would hand every user `canManageAdmins`.

## Guard

`serverConfigInputDoesNotEscalate` walks the ServerConfig input's tier relationships and rejects any capability the actor doesn't hold:

- **Nested `create` / `update` / `connectOrCreate.onCreate`** — capability-bearing nodes are checked directly (reusing PR-4's `findEscalatedCapabilities`).
- **`connect` / `connectOrCreate.where`** — the target role(s) are resolved from the database via OGM and their capabilities checked, so connecting an existing powerful role is caught.

Root and full admins (`actorRole === "all"`) bypass — and skip the DB round-trips. Lookup failures fail closed. ServerRole nodes are checked against the actor's effective `ServerRole`; mod-role nodes against the actor's effective `ModServerRole`.

Wired into `createServerConfigs` and `updateServerConfigs` (in addition to the existing `canManageServerSettings` gate). Provisioning is unaffected — `provisionServerDefaults` uses the OGM directly and never passes through graphql-shield.

## Why channel mutations are out of scope

`Channel` only links `ChannelRole` / `ModChannelRole`, neither of which carries a server-administration capability (`canManage*`) — so channel mutations **cannot reach the apex tier**. Channel-role definition is also a legitimate channel-owner operation. Tracked as a low-risk defense-in-depth follow-up (PR-4c) in §5, not an open hole.

## Implementation

- **`rules/validation/nestedRoleEscalation.ts` (new)** — pure `extractNestedRoleWrites(...)` (handles every create/update/connect/connectOrCreate shape, to-one and array, across the seven ServerConfig tier relationships) + the shield rule (OGM connect-resolution + cap comparison).
- **`permissions.ts` / `rules.ts`** — wire the rule into the two ServerConfig mutations.
- Reuses `actorCapabilities.ts` + `roleEscalation.ts` from PR-4 unchanged.

## Testing

- `npm run tsc` clean.
- 9 new unit tests for the extractor (create/update/connect/connectOrCreate, mod routing, array inputs, junk input) + end-to-end cap-comparison reproducing the exact `DefaultAdminRole.update` apex attack (blocked for a restricted admin, allowed for root).
- Full unit suite green.

> Merge order: stacked on #75. Merge #75 first, then this retargets to `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
