### PR TITLE
feat(permissions): PR-4c channel-role guard + re-land orphaned #74/#76

### DIFF
--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -229,10 +229,21 @@ production):
    - 🔲 Adopt `provisionServerDefaults` in integration-test setup (incremental).
    - 🔲 Wire env root (`SUPERADMIN_EMAIL`) in deploy config; run provisioning per
      environment in a maintenance window.
-3. **PR-3** — convert Category-A call sites to capability checks; drop `isAdmin`
-   from Category-B ORs; tier-based mod resolution for admins in
-   `hasServerModPermission`; remove the `isAdmin` rule. Integration coverage for a
-   restricted admin.
+3. **PR-3 — ✅ DONE.** PR-3a (#72) converted Category-A call sites to capability
+   checks; PR-3b (#73) dropped `isAdmin` from the Category-B ORs and removed the
+   `isAdmin` rule, replacing it with a server-admin + root override
+   (`passesAsServerAdminOrRoot`) inside the channel/ownership rules. `updateUsers`/
+   `deleteUsers`/`deleteEmails` are self-only; the dangerous Cypress seams use the
+   env-root-only `isRoot`; `reportProfilePicture` uses `canReportServerContent`.
+3.5. **PR-3.5 — suspended-admin path. ✅ DONE.** The override is **server-
+   suspension-aware**: a server-suspended admin loses the blanket override and
+   falls through to the normal (restricted) role checks everywhere (channel,
+   ownership, and server-mod). `hasServerModPermission` no longer lets a suspended
+   admin bypass the suspended role. **Root is the only actor a suspension cannot
+   stop.** Server suspension (`scope: 'server'`) is the lever to restrict an admin;
+   channel-level roles intentionally do *not* restrict an un-suspended admin (they
+   are server staff). Unit tests: `serverAdminOverride.test.ts` (pure
+   `evaluateAdminOverride`) + a suspended-admin case in `hasServerModPermission.test.ts`.
 4. **PR-4 — no-privilege-escalation invariant. ✅ DONE (server roles).** Role
    authoring is now gated by a capability-superset check in addition to
    `canManageRoles`: `createServerRoles` / `createModServerRoles` /
@@ -244,12 +255,17 @@ production):
    `findEscalatedCapabilities` in `rules/validation/roleEscalation.ts`. Assignment
    is already covered: `updateUsers` role-connect is blocked (#64), and the invite
    flows grant fixed tier roles (the inviter never chooses capabilities).
-   - 🔲 **Follow-up (PR-4b):** extend the guard to channel-scoped role authoring
-     (`createChannelRoles` / `createModChannelRoles`) and to **nested** role
-     create/update reachable through other mutations (e.g. a role `create`/`update`
-     embedded in `updateServerConfigs`). Channel-role capabilities carry no
-     server-administration power, so this is lower-risk than the server-role paths
-     closed here.
+   - ✅ **PR-4b — nested ServerConfig escalation closed.** `serverConfigInputDoesNotEscalate`
+     (`rules/validation/nestedRoleEscalation.ts`) rejects nested role
+     `create`/`update`/`connectOrCreate` (and resolves `connect` targets from the
+     DB) on the `ServerConfig` tier relationships in
+     `createServerConfigs`/`updateServerConfigs`, so a `canManageServerSettings`
+     holder cannot escalate a tier role (e.g.
+     `DefaultAdminRole.update.node.canManageAdmins = true`).
+   - ✅ **PR-4c — channel-role authoring.** `createChannelRoles`/`createModChannelRoles`
+     may only author a capability-bearing channel role for a channel the actor
+     owns (or as server admin / root); channel roles carry no server-administration
+     capability, so this is defense-in-depth.
 5. **PR-5 (later)** — role-management UI; SuperAdmins section in
    `ServerMembershipEditor`.
 

--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -255,17 +255,25 @@ production):
    `findEscalatedCapabilities` in `rules/validation/roleEscalation.ts`. Assignment
    is already covered: `updateUsers` role-connect is blocked (#64), and the invite
    flows grant fixed tier roles (the inviter never chooses capabilities).
-   - ✅ **PR-4b — nested ServerConfig escalation closed.** `serverConfigInputDoesNotEscalate`
-     (`rules/validation/nestedRoleEscalation.ts`) rejects nested role
-     `create`/`update`/`connectOrCreate` (and resolves `connect` targets from the
-     DB) on the `ServerConfig` tier relationships in
-     `createServerConfigs`/`updateServerConfigs`, so a `canManageServerSettings`
-     holder cannot escalate a tier role (e.g.
-     `DefaultAdminRole.update.node.canManageAdmins = true`).
-   - ✅ **PR-4c — channel-role authoring.** `createChannelRoles`/`createModChannelRoles`
-     may only author a capability-bearing channel role for a channel the actor
-     owns (or as server admin / root); channel roles carry no server-administration
-     capability, so this is defense-in-depth.
+   - ✅ **PR-4b — nested ServerConfig escalation closed.** The generated
+     `ServerConfig` create/update input allows nested role writes on the tier
+     relationships (`DefaultAdminRole`, `DefaultServerRole`, …), reachable via
+     `updateServerConfigs`/`createServerConfigs` (gated only by
+     `canManageServerSettings`) — e.g.
+     `updateServerConfigs(update: { DefaultAdminRole: { update: { node: { canManageAdmins: true } } } })`.
+     `serverConfigInputDoesNotEscalate` (`rules/validation/nestedRoleEscalation.ts`)
+     now walks those relationships and rejects any nested `create`/`update`/
+     `connectOrCreate` node — and resolves `connect`/`connectOrCreate` targets from
+     the DB — that grants a capability the actor lacks (so connecting an existing
+     `DefaultSuperAdminRole` into a lower tier slot is caught too). Root / full
+     admin bypass; lookup failures fail closed.
+   - ✅ **PR-4c — channel-role authoring (defense-in-depth).**
+     `createChannelRoles`/`createModChannelRoles` may author a capability-bearing
+     channel role only for a channel the actor owns (or as server admin / root).
+     Channel roles carry **no** server-administration capability and cannot reach
+     the apex tier; wiring a channel role is already channel-owner-gated. Nested
+     role writes in `createChannels`/`updateChannels` need no guard — the actor is
+     creating/owns the channel and legitimately defines its roles.
 5. **PR-5 (later)** — role-management UI; SuperAdmins section in
    `ServerMembershipEditor`.
 

--- a/permissions.ts
+++ b/permissions.ts
@@ -41,6 +41,7 @@ const {
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
+  serverConfigInputDoesNotEscalate,
   canReport,
   canSuspendAndUnsuspendUser,
   canArchiveAndUnarchiveComment,
@@ -137,10 +138,12 @@ const permissionList = shield({
 
       createModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       createServerRoles: and(isAuthenticated, canManageRoles, serverRoleInputDoesNotEscalate),
-      createServerConfigs: and(isAuthenticated, canManageServerSettings),
+      createServerConfigs: and(isAuthenticated, canManageServerSettings, serverConfigInputDoesNotEscalate),
       deleteServerConfigs: and(isAuthenticated, canManageServerSettings),
 
-      updateServerConfigs: and(isAuthenticated, canManageServerSettings),
+      // canManageServerSettings additionally must not be used to escalate a tier
+      // role via a nested role create/update/connect (see §5 / PR-4b).
+      updateServerConfigs: and(isAuthenticated, canManageServerSettings, serverConfigInputDoesNotEscalate),
       updateModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       deleteChannelRoles: and(isAuthenticated, or(canManageRoles, isChannelOwner)),
       deleteServerRoles: and(isAuthenticated, canManageRoles),

--- a/permissions.ts
+++ b/permissions.ts
@@ -42,6 +42,8 @@ const {
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
   serverConfigInputDoesNotEscalate,
+  channelRoleInputDoesNotEscalate,
+  modChannelRoleInputDoesNotEscalate,
   canReport,
   canSuspendAndUnsuspendUser,
   canArchiveAndUnarchiveComment,
@@ -127,14 +129,15 @@ const permissionList = shield({
       createTags: and(isAuthenticated, allow),
       
       // Role management requires canManageRoles (the updateUsers role-connect
-      // block still prevents self-escalation via assignment). The server-role
-      // create/update paths additionally enforce the no-privilege-escalation
-      // invariant: you cannot author a role granting a capability you lack
-      // (e.g. a restricted admin cannot mint canManageAdmins). Channel-role
-      // creation carries no server-administration capability, so it is not
-      // guarded here — see docs/isadmin-phaseout-design.md §5.
-      createChannelRoles: and(isAuthenticated, canManageRoles),
-      createModChannelRoles: and(isAuthenticated, canManageRoles),
+      // block still prevents self-escalation via assignment). The role-authoring
+      // paths additionally enforce the no-privilege-escalation invariant: you
+      // cannot author a role granting a capability you lack (e.g. a restricted
+      // admin cannot mint canManageAdmins). For channel roles — which carry no
+      // server-administration capability — the invariant is ownership: you may
+      // author a capability-bearing channel role only for a channel you own (or
+      // as server admin / root). See docs/isadmin-phaseout-design.md §5.
+      createChannelRoles: and(isAuthenticated, canManageRoles, channelRoleInputDoesNotEscalate),
+      createModChannelRoles: and(isAuthenticated, canManageRoles, modChannelRoleInputDoesNotEscalate),
 
       createModServerRoles: and(isAuthenticated, canManageRoles, modServerRoleInputDoesNotEscalate),
       createServerRoles: and(isAuthenticated, canManageRoles, serverRoleInputDoesNotEscalate),

--- a/rules/permission/actorCapabilities.ts
+++ b/rules/permission/actorCapabilities.ts
@@ -62,6 +62,34 @@ export const MOD_SERVER_ROLE_CAPABILITY_FIELDS = [
   "canRemoveEventChannel",
 ] as const;
 
+// Channel-scoped role capabilities (no server-administration power). Used by the
+// PR-4c channel-role-authoring guard. Display-only showModTag is excluded.
+export const CHANNEL_ROLE_CAPABILITY_FIELDS = [
+  "canCreateDiscussion",
+  "canCreateEvent",
+  "canCreateComment",
+  "canUpvoteDiscussion",
+  "canUpvoteComment",
+  "canUploadFile",
+  "canUpdateChannel",
+] as const;
+
+export const MOD_CHANNEL_ROLE_CAPABILITY_FIELDS = [
+  "canHideComment",
+  "canHideEvent",
+  "canHideDiscussion",
+  "canEditComments",
+  "canEditDiscussions",
+  "canEditEvents",
+  "canGiveFeedback",
+  "canOpenSupportTickets",
+  "canCloseSupportTickets",
+  "canReport",
+  "canSuspendUser",
+  "canArchiveImage",
+  "canDeleteWiki",
+] as const;
+
 // --- Pure tier selection (extracted for unit testing) ---
 
 export function resolveEffectiveServerRole(input: {

--- a/rules/permission/hasServerModPermission.test.ts
+++ b/rules/permission/hasServerModPermission.test.ts
@@ -174,10 +174,69 @@ async function testServerAdminBypassesServerModRoleChecks() {
   assert.equal(result, true);
 }
 
+async function testSuspendedServerAdminFallsThroughToSuspendedRole() {
+  // A server admin who is also server-suspended must NOT bypass the role checks
+  // — they fall through to the DefaultSuspendedModRole (suspension beats tier).
+  const result = await hasServerModPermission("canSuspendUser", asContext({
+    driver: buildDriver({
+      modSuspensions: [
+        {
+          id: "server-admin-suspension-1",
+          modProfileName: "Mod Alice",
+          suspendedIndefinitely: true,
+          suspendedUntil: null,
+        },
+      ],
+    }),
+    user: {
+      username: "alice",
+      email: "alice@example.com",
+      data: {
+        ModerationProfile: {
+          displayName: "Mod Alice",
+        },
+      },
+    },
+    req: { headers: {} },
+    ogm: {
+      model(name: string) {
+        if (name === "ServerConfig") {
+          return {
+            find: async () => [
+              {
+                DefaultModRole: { canSuspendUser: true },
+                DefaultElevatedModRole: { canSuspendUser: true },
+                DefaultSuspendedModRole: { canSuspendUser: false },
+                Admins: [{ username: "alice" }],
+                Moderators: [],
+                SuspendedUsers: [],
+                SuspendedMods: [],
+              },
+            ],
+          };
+        }
+
+        if (name === "User") {
+          return {
+            find: async () => [],
+            update: async () => ({}),
+          };
+        }
+
+        throw new Error(`Unexpected model lookup: ${name}`);
+      },
+    },
+  }));
+
+  assert.ok(result instanceof Error);
+  assert.equal(result.message, "You do not have permission to do that.");
+}
+
 async function run() {
   await testServerModeratorUsesElevatedRoleForSuspendPermission();
   await testSuspendedServerModUsesSuspendedRole();
   await testServerAdminBypassesServerModRoleChecks();
+  await testSuspendedServerAdminFallsThroughToSuspendedRole();
   console.log("hasServerModPermission tests passed");
 }
 

--- a/rules/permission/hasServerModPermission.ts
+++ b/rules/permission/hasServerModPermission.ts
@@ -59,7 +59,11 @@ export const hasServerModPermission: (
 
   const membership = await getServerScopedMembership(context);
 
-  if (membership.isServerAdmin) {
+  // A server admin holds every mod capability — UNLESS they are server-
+  // suspended, in which case they fall through to the DefaultSuspendedModRole
+  // below (root already short-circuited above and is never suspended). This
+  // keeps admin suspension effective and consistent with hasServerPermission.
+  if (membership.isServerAdmin && !suspensionInfo.isSuspended) {
     return true;
   }
 

--- a/rules/permission/serverAdminOverride.test.ts
+++ b/rules/permission/serverAdminOverride.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateAdminOverride } from "./serverAdminOverride.js";
+
+// The server-admin/root override that owner & channel rules use. Root always
+// passes; a server admin passes unless server-suspended; everyone else fails.
+// See docs/isadmin-phaseout-design.md.
+
+test("evaluateAdminOverride: root always passes, even when suspended", () => {
+  assert.equal(
+    evaluateAdminOverride({ isRoot: true, isServerAdmin: false, isServerSuspended: true }),
+    true
+  );
+  assert.equal(
+    evaluateAdminOverride({ isRoot: true, isServerAdmin: true, isServerSuspended: true }),
+    true
+  );
+});
+
+test("evaluateAdminOverride: an un-suspended server admin passes", () => {
+  assert.equal(
+    evaluateAdminOverride({ isRoot: false, isServerAdmin: true, isServerSuspended: false }),
+    true
+  );
+});
+
+test("evaluateAdminOverride: a server-suspended admin loses the override", () => {
+  assert.equal(
+    evaluateAdminOverride({ isRoot: false, isServerAdmin: true, isServerSuspended: true }),
+    false
+  );
+});
+
+test("evaluateAdminOverride: a non-admin never passes via the override", () => {
+  assert.equal(
+    evaluateAdminOverride({ isRoot: false, isServerAdmin: false, isServerSuspended: false }),
+    false
+  );
+});

--- a/rules/permission/serverAdminOverride.ts
+++ b/rules/permission/serverAdminOverride.ts
@@ -1,12 +1,41 @@
 import type { GraphQLContext } from "../../types/context.js";
 import { isServerRoot } from "./isServerRoot.js";
 import { getServerScopedMembership } from "./getServerScopedMembership.js";
+import { getActiveServerSuspension } from "./getActiveServerSuspension.js";
+
+// --- Pure decision (extracted for unit testing) ---
 
 /**
- * True when the caller is a server admin (incl. SuperAdmins) or the env
- * break-glass root. This is the override that replaces the per-call-site
- * `isAdmin` in ownership-gated content/channel mutations, so server admins keep
- * their cross-server powers and root can do everything.
+ * Decides whether the caller passes an owner/channel check purely on the
+ * strength of being server staff.
+ *
+ * - The env break-glass root always passes (suspension can never stop root).
+ * - A server admin (incl. SuperAdmins) passes UNLESS they are server-suspended,
+ *   in which case they lose the blanket override and fall through to the normal
+ *   (restricted) role checks. This mirrors hasServerPermission, where "suspension
+ *   takes precedence over tier". Server suspension is the lever that restricts an
+ *   admin; root is the only actor it cannot stop.
+ */
+export function evaluateAdminOverride(input: {
+  isRoot: boolean;
+  isServerAdmin: boolean;
+  isServerSuspended: boolean;
+}): boolean {
+  const { isRoot, isServerAdmin, isServerSuspended } = input;
+  if (isRoot) {
+    return true;
+  }
+  if (!isServerAdmin) {
+    return false;
+  }
+  return !isServerSuspended;
+}
+
+/**
+ * True when the caller is the env break-glass root, or a server admin (incl.
+ * SuperAdmins) who is not server-suspended. This is the override that replaces
+ * the per-call-site `isAdmin` in ownership-gated content/channel mutations, so
+ * server admins keep their cross-server powers and root can do everything.
  *
  * Deliberately NOT applied to account ownership (isAccountOwner): editing or
  * deleting another user's account is self-only by design (only the invite
@@ -15,14 +44,32 @@ import { getServerScopedMembership } from "./getServerScopedMembership.js";
 export const passesAsServerAdminOrRoot = async (
   ctx: GraphQLContext
 ): Promise<boolean> => {
-  // Resolve membership first: getServerScopedMembership populates ctx.user from
-  // the request (email/username) when it isn't set yet. The ownership rules call
-  // this BEFORE their own setUserDataOnContext, and isServerRoot reads
-  // ctx.user.email — so the root check must run only once identity is resolved,
-  // otherwise an env-only root (not in the Admins list) would be missed.
-  const { isServerAdmin } = await getServerScopedMembership(ctx);
+  // Root passes unconditionally; resolve it first so it never pays for the
+  // membership/suspension lookups.
   if (isServerRoot(ctx)) {
     return true;
   }
-  return isServerAdmin;
+
+  // getServerScopedMembership populates ctx.user from the request (email/
+  // username) when it isn't set yet. The ownership rules call this BEFORE their
+  // own setUserDataOnContext, so identity must be resolved here.
+  const { isServerAdmin } = await getServerScopedMembership(ctx);
+  if (!isServerAdmin) {
+    return false;
+  }
+
+  // Only an admin reaches the (more expensive) server-suspension lookup. A
+  // server-suspended admin loses the override and falls through to the normal
+  // role checks at the call site.
+  const username = ctx.user?.username ?? undefined;
+  if (!username) {
+    return false;
+  }
+  const suspension = await getActiveServerSuspension({ context: ctx, username });
+
+  return evaluateAdminOverride({
+    isRoot: false,
+    isServerAdmin,
+    isServerSuspended: suspension.isSuspended,
+  });
 };

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -60,6 +60,10 @@ import {
 } from "./validation/roleEscalation.js";
 import { serverConfigInputDoesNotEscalate } from "./validation/nestedRoleEscalation.js";
 import {
+  channelRoleInputDoesNotEscalate,
+  modChannelRoleInputDoesNotEscalate,
+} from "./validation/channelRoleEscalation.js";
+import {
   canCreateChannel,
   canCreateComment,
   canCreateDiscussion,
@@ -132,6 +136,8 @@ const ruleList = {
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
   serverConfigInputDoesNotEscalate,
+  channelRoleInputDoesNotEscalate,
+  modChannelRoleInputDoesNotEscalate,
   hasChannelPermission,
   isRoot,
   canManageServerSettings,

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -58,6 +58,7 @@ import {
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
 } from "./validation/roleEscalation.js";
+import { serverConfigInputDoesNotEscalate } from "./validation/nestedRoleEscalation.js";
 import {
   canCreateChannel,
   canCreateComment,
@@ -130,6 +131,7 @@ const ruleList = {
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
+  serverConfigInputDoesNotEscalate,
   hasChannelPermission,
   isRoot,
   canManageServerSettings,

--- a/rules/validation/channelRoleEscalation.test.ts
+++ b/rules/validation/channelRoleEscalation.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { roleItemsGrantingCapabilities } from "./channelRoleEscalation.js";
+import {
+  CHANNEL_ROLE_CAPABILITY_FIELDS,
+  MOD_CHANNEL_ROLE_CAPABILITY_FIELDS,
+} from "../permission/actorCapabilities.js";
+
+// PR-4c: channel-role authoring guard. roleItemsGrantingCapabilities selects the
+// input items that actually grant a capability — only those require the caller
+// to own the target channel (or be a server admin / root).
+
+test("selects only items that set a channel capability to true", () => {
+  const items = [
+    { channelUniqueName: "cats", name: "Reader" }, // no caps -> harmless
+    { channelUniqueName: "cats", canUpdateChannel: true }, // grants a cap
+    { channelUniqueName: "dogs", canUploadFile: false }, // explicitly false
+  ];
+  const granting = roleItemsGrantingCapabilities(items, CHANNEL_ROLE_CAPABILITY_FIELDS);
+  assert.deepEqual(granting, [{ channelUniqueName: "cats", canUpdateChannel: true }]);
+});
+
+test("an all-false / capability-free role grants nothing", () => {
+  const items = [
+    { channelUniqueName: "cats", name: "Reader", description: "x", showModTag: true },
+  ];
+  assert.deepEqual(
+    roleItemsGrantingCapabilities(items, CHANNEL_ROLE_CAPABILITY_FIELDS),
+    []
+  );
+});
+
+test("works for mod-channel capabilities", () => {
+  const items = [
+    { channelUniqueName: "cats", canSuspendUser: true },
+    { channelUniqueName: "cats", name: "Helper" },
+  ];
+  const granting = roleItemsGrantingCapabilities(
+    items,
+    MOD_CHANNEL_ROLE_CAPABILITY_FIELDS
+  );
+  assert.deepEqual(granting, [{ channelUniqueName: "cats", canSuspendUser: true }]);
+});
+
+test("ignores a server-administration field that is not a channel capability", () => {
+  // canManageAdmins is not a ChannelRole capability, so it must not count as a
+  // granted channel capability (channel roles can't carry it anyway).
+  const items = [{ channelUniqueName: "cats", canManageAdmins: true }];
+  assert.deepEqual(
+    roleItemsGrantingCapabilities(items, CHANNEL_ROLE_CAPABILITY_FIELDS),
+    []
+  );
+});
+
+test("handles non-array / empty / junk input", () => {
+  assert.deepEqual(roleItemsGrantingCapabilities(undefined, CHANNEL_ROLE_CAPABILITY_FIELDS), []);
+  assert.deepEqual(roleItemsGrantingCapabilities([], CHANNEL_ROLE_CAPABILITY_FIELDS), []);
+  assert.deepEqual(
+    roleItemsGrantingCapabilities([null, "x", 3], CHANNEL_ROLE_CAPABILITY_FIELDS),
+    []
+  );
+});

--- a/rules/validation/channelRoleEscalation.ts
+++ b/rules/validation/channelRoleEscalation.ts
@@ -1,0 +1,111 @@
+// No-privilege-escalation guard for CHANNEL role authoring (PR-4c; extends PR-4
+// to the channel scope — docs/isadmin-phaseout-design.md §5).
+//
+// `createChannelRoles` / `createModChannelRoles` are gated by the server-level
+// `canManageRoles`, but a channel role is fundamentally the channel owner's to
+// define. Channel roles carry NO server-administration capability, so they can
+// never reach the apex tier — this is defense-in-depth. The invariant: you may
+// author a capability-bearing channel role only for a channel you own (or as a
+// server admin / root, who hold every channel capability everywhere). A non-owner
+// with `canManageRoles` can still create empty/no-capability roles.
+//
+// (Wiring a channel role into a channel is separately channel-owner-gated via
+// updateChannels, and createChannels makes the caller the owner — so nested
+// channel-role writes there need no guard.)
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  CHANNEL_ROLE_CAPABILITY_FIELDS,
+  MOD_CHANNEL_ROLE_CAPABILITY_FIELDS,
+} from "../permission/actorCapabilities.js";
+import { passesAsServerAdminOrRoot } from "../permission/serverAdminOverride.js";
+import { isChannelAdmin } from "../permission/hasChannelPermission.js";
+import { setUserDataOnContext } from "../permission/userDataHelperFunctions.js";
+
+type RoleItem = Record<string, unknown>;
+
+// --- Pure: which input items actually grant a capability (extracted for tests) ---
+
+export function roleItemsGrantingCapabilities(
+  items: unknown,
+  capabilityFields: readonly string[]
+): RoleItem[] {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return (items as RoleItem[]).filter(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      capabilityFields.some((field) => item[field] === true)
+  );
+}
+
+// True when the caller is listed among the channel's owners (Admins).
+async function ownsChannel(
+  ctx: GraphQLContext,
+  channelUniqueName: unknown
+): Promise<boolean> {
+  if (typeof channelUniqueName !== "string" || !channelUniqueName) {
+    return false;
+  }
+  const username = ctx.user?.username;
+  if (!username) {
+    return false;
+  }
+  const Channel = ctx.ogm.model("Channel");
+  const channels = (await Channel.find({
+    where: { uniqueName: channelUniqueName },
+    selectionSet: `{ Admins { username } }`,
+  })) as Array<{ Admins?: Array<{ username?: string | null }> | null }>;
+
+  return isChannelAdmin(channels?.[0]?.Admins, username);
+}
+
+const channelRoleEscalationRule = (capabilityFields: readonly string[]) =>
+  rule({ cache: "contextual" })(
+    async (
+      _parent: unknown,
+      args: Record<string, unknown>,
+      ctx: GraphQLContext,
+      _info: GraphQLResolveInfo
+    ) => {
+      const capabilityItems = roleItemsGrantingCapabilities(
+        args.input,
+        capabilityFields
+      );
+      // Roles that grant nothing are harmless to author.
+      if (capabilityItems.length === 0) {
+        return true;
+      }
+
+      // Server admins and root hold every channel capability everywhere, so they
+      // may author any channel role. (This also populates ctx.user.)
+      if (await passesAsServerAdminOrRoot(ctx)) {
+        return true;
+      }
+      if (!ctx.user?.username) {
+        ctx.user = await setUserDataOnContext({ context: ctx });
+      }
+
+      // Otherwise every capability-bearing role must target a channel the caller
+      // owns. A channel owner inherently holds all of their channel's
+      // capabilities, so ownership is the capability check for the channel scope.
+      for (const item of capabilityItems) {
+        if (!(await ownsChannel(ctx, item.channelUniqueName))) {
+          return "You can only author channel roles that grant capabilities for a channel you own.";
+        }
+      }
+
+      return true;
+    }
+  );
+
+export const channelRoleInputDoesNotEscalate = channelRoleEscalationRule(
+  CHANNEL_ROLE_CAPABILITY_FIELDS
+);
+
+export const modChannelRoleInputDoesNotEscalate = channelRoleEscalationRule(
+  MOD_CHANNEL_ROLE_CAPABILITY_FIELDS
+);

--- a/rules/validation/nestedRoleEscalation.test.ts
+++ b/rules/validation/nestedRoleEscalation.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractNestedRoleWrites } from "./nestedRoleEscalation.js";
+import { findEscalatedCapabilities } from "./roleEscalation.js";
+import {
+  SERVER_ROLE_CAPABILITY_FIELDS,
+  type EffectiveRole,
+} from "../permission/actorCapabilities.js";
+
+// PR-4b: the nested role-escalation guard for ServerConfig mutations.
+// extractNestedRoleWrites pulls capability-bearing role nodes and connect
+// `where`s out of the (auto-generated) ServerConfig create/update input, across
+// all create/update/connect/connectOrCreate shapes.
+
+test("extracts a nested update node on a ServerRole tier relationship", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true } } },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canManageAdmins: true }]);
+  assert.deepEqual(writes.modServerRoleNodes, []);
+});
+
+test("extracts a nested create node on a ServerRole tier relationship", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultServerRole: { create: { node: { canCreateChannel: true } } },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canCreateChannel: true }]);
+});
+
+test("extracts connectOrCreate onCreate nodes and connect wheres", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: {
+      connectOrCreate: {
+        where: { node: { name: "Super Administrator" } },
+        onCreate: { node: { canManageSuperAdmins: true } },
+      },
+    },
+  });
+  assert.deepEqual(writes.serverRoleNodes, [{ canManageSuperAdmins: true }]);
+  assert.deepEqual(writes.serverRoleConnectWheres, [{ name: "Super Administrator" }]);
+});
+
+test("extracts a connect where (connecting an existing role into a tier slot)", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultServerRole: { connect: { where: { node: { name: "Super Administrator" } } } },
+  });
+  assert.deepEqual(writes.serverRoleConnectWheres, [{ name: "Super Administrator" }]);
+  assert.deepEqual(writes.serverRoleNodes, []);
+});
+
+test("routes mod-role relationships to the mod buckets", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultModRole: { update: { node: { canRemoveDiscussionChannel: true } } },
+    DefaultElevatedModRole: { connect: { where: { node: { name: "Full Mod" } } } },
+  });
+  assert.deepEqual(writes.modServerRoleNodes, [{ canRemoveDiscussionChannel: true }]);
+  assert.deepEqual(writes.modServerRoleConnectWheres, [{ name: "Full Mod" }]);
+  assert.deepEqual(writes.serverRoleNodes, []);
+});
+
+test("handles array-shaped relationship inputs defensively", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: [
+      { update: { node: { canManageAdmins: true } } },
+      { create: { node: { canManageRoles: true } } },
+    ],
+  });
+  assert.deepEqual(writes.serverRoleNodes, [
+    { canManageAdmins: true },
+    { canManageRoles: true },
+  ]);
+});
+
+test("ignores non-role fields and empty/invalid input", () => {
+  assert.deepEqual(extractNestedRoleWrites({ name: "My Server", description: "x" }), {
+    serverRoleNodes: [],
+    modServerRoleNodes: [],
+    serverRoleConnectWheres: [],
+    modServerRoleConnectWheres: [],
+  });
+  assert.deepEqual(extractNestedRoleWrites(null).serverRoleNodes, []);
+  assert.deepEqual(extractNestedRoleWrites("nope").serverRoleNodes, []);
+});
+
+test("end to end: a nested DefaultAdminRole.update escalates for a restricted admin", () => {
+  // The exact apex-escalation attack: a restricted admin (canManageRoles but not
+  // canManageAdmins) edits the shared admin tier role to grant canManageAdmins.
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true, canManageRoles: true } } },
+  });
+  const restrictedAdmin: EffectiveRole = {
+    canManageRoles: true,
+    canManageAdmins: false,
+  };
+  const escalated = findEscalatedCapabilities({
+    requested: writes.serverRoleNodes,
+    capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+    actorRole: restrictedAdmin,
+  });
+  assert.deepEqual(escalated, ["canManageAdmins"]);
+});
+
+test("end to end: the same nested edit is allowed for root ('all')", () => {
+  const writes = extractNestedRoleWrites({
+    DefaultAdminRole: { update: { node: { canManageAdmins: true } } },
+  });
+  const escalated = findEscalatedCapabilities({
+    requested: writes.serverRoleNodes,
+    capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+    actorRole: "all",
+  });
+  assert.deepEqual(escalated, []);
+});

--- a/rules/validation/nestedRoleEscalation.ts
+++ b/rules/validation/nestedRoleEscalation.ts
@@ -1,0 +1,277 @@
+// No-privilege-escalation guard for NESTED role writes (PR-4b; extends PR-4 /
+// docs/isadmin-phaseout-design.md §5).
+//
+// PR-4 guards the top-level role-authoring mutations, but the auto-generated
+// `ServerConfigUpdateInput` / `ServerConfigCreateInput` also allow nested
+// role writes on the tier relationships:
+//
+//   updateServerConfigs(update: {
+//     DefaultAdminRole: { update: { node: { canManageAdmins: true } } }
+//   })
+//
+// That path is gated only by `canManageServerSettings`, so without this guard a
+// restricted admin could edit the shared `DefaultAdminRole` (or connect an
+// existing powerful role into a tier slot) and escalate the whole admin tier.
+//
+// This guard walks the ServerConfig input's role relationships and rejects any
+// nested create/update/connectOrCreate role node — and any connect target
+// resolved from the database — that grants a capability the actor lacks. Root /
+// full admin bypass; resolution failures fail closed.
+//
+// Channel mutations are intentionally out of scope: Channel only links
+// ChannelRole / ModChannelRole, which carry no server-administration capability,
+// so they cannot reach the apex tier (see §5 follow-up notes).
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  SERVER_ROLE_CAPABILITY_FIELDS,
+  MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+  getActorServerRoleCaps,
+  getActorModServerRoleCaps,
+  type EffectiveRole,
+} from "../permission/actorCapabilities.js";
+import { findEscalatedCapabilities } from "./roleEscalation.js";
+
+// ServerConfig tier relationships, by the role type they connect.
+export const SERVER_CONFIG_SERVER_ROLE_RELATIONSHIPS = [
+  "DefaultServerRole",
+  "DefaultAdminRole",
+  "DefaultSuperAdminRole",
+  "DefaultSuspendedRole",
+] as const;
+
+export const SERVER_CONFIG_MOD_ROLE_RELATIONSHIPS = [
+  "DefaultModRole",
+  "DefaultElevatedModRole",
+  "DefaultSuspendedModRole",
+] as const;
+
+type RoleNode = Record<string, unknown>;
+type WhereNode = Record<string, unknown>;
+
+export type ExtractedRoleWrites = {
+  // Capability-bearing nodes (create / update / connectOrCreate.onCreate).
+  serverRoleNodes: RoleNode[];
+  modServerRoleNodes: RoleNode[];
+  // `where` clauses that connect an EXISTING role (connect / connectOrCreate),
+  // whose capabilities must be resolved from the database.
+  serverRoleConnectWheres: WhereNode[];
+  modServerRoleConnectWheres: WhereNode[];
+};
+
+const toArray = <T>(value: T | T[] | null | undefined): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+
+// Pulls the capability-bearing nodes and connect `where`s out of a single
+// relationship field input (create | update | connect | connectOrCreate), for
+// both the create-input and update-input shapes.
+function collectFromRelationshipField(
+  fieldInput: unknown,
+  nodes: RoleNode[],
+  connectWheres: WhereNode[]
+): void {
+  for (const op of toArray(fieldInput) as Array<Record<string, unknown>>) {
+    if (!op || typeof op !== "object") {
+      continue;
+    }
+
+    for (const create of toArray(op.create) as Array<Record<string, unknown>>) {
+      if (create?.node && typeof create.node === "object") {
+        nodes.push(create.node as RoleNode);
+      }
+    }
+
+    for (const update of toArray(op.update) as Array<Record<string, unknown>>) {
+      if (update?.node && typeof update.node === "object") {
+        nodes.push(update.node as RoleNode);
+      }
+    }
+
+    for (const coc of toArray(op.connectOrCreate) as Array<Record<string, unknown>>) {
+      const onCreate = coc?.onCreate as Record<string, unknown> | undefined;
+      if (onCreate?.node && typeof onCreate.node === "object") {
+        nodes.push(onCreate.node as RoleNode);
+      }
+      const where = coc?.where as Record<string, unknown> | undefined;
+      if (where?.node && typeof where.node === "object") {
+        connectWheres.push(where.node as WhereNode);
+      }
+    }
+
+    for (const connect of toArray(op.connect) as Array<Record<string, unknown>>) {
+      const where = connect?.where as Record<string, unknown> | undefined;
+      if (where?.node && typeof where.node === "object") {
+        connectWheres.push(where.node as WhereNode);
+      }
+    }
+  }
+}
+
+// --- Pure extraction (unit tested) ---
+
+export function extractNestedRoleWrites(input: unknown): ExtractedRoleWrites {
+  const result: ExtractedRoleWrites = {
+    serverRoleNodes: [],
+    modServerRoleNodes: [],
+    serverRoleConnectWheres: [],
+    modServerRoleConnectWheres: [],
+  };
+
+  if (!input || typeof input !== "object") {
+    return result;
+  }
+  const obj = input as Record<string, unknown>;
+
+  for (const field of SERVER_CONFIG_SERVER_ROLE_RELATIONSHIPS) {
+    collectFromRelationshipField(
+      obj[field],
+      result.serverRoleNodes,
+      result.serverRoleConnectWheres
+    );
+  }
+  for (const field of SERVER_CONFIG_MOD_ROLE_RELATIONSHIPS) {
+    collectFromRelationshipField(
+      obj[field],
+      result.modServerRoleNodes,
+      result.modServerRoleConnectWheres
+    );
+  }
+
+  return result;
+}
+
+function mergeWrites(target: ExtractedRoleWrites, source: ExtractedRoleWrites): void {
+  target.serverRoleNodes.push(...source.serverRoleNodes);
+  target.modServerRoleNodes.push(...source.modServerRoleNodes);
+  target.serverRoleConnectWheres.push(...source.serverRoleConnectWheres);
+  target.modServerRoleConnectWheres.push(...source.modServerRoleConnectWheres);
+}
+
+// Resolves the capabilities of existing roles targeted by a connect `where`, so
+// connecting a powerful role into a tier slot is caught. Throws on lookup
+// failure so the shield rule fails closed.
+async function resolveConnectedRoleNodes(
+  ctx: GraphQLContext,
+  modelName: "ServerRole" | "ModServerRole",
+  wheres: WhereNode[],
+  capabilityFields: readonly string[]
+): Promise<RoleNode[]> {
+  if (wheres.length === 0) {
+    return [];
+  }
+
+  const Model = ctx.ogm.model(modelName);
+  const selectionSet = `{ ${capabilityFields.join("\n")} }`;
+  const resolved: RoleNode[] = [];
+
+  for (const where of wheres) {
+    const roles = (await Model.find({ where, selectionSet })) as RoleNode[];
+    resolved.push(...roles);
+  }
+
+  return resolved;
+}
+
+type RoleEscalationCheck = {
+  nodes: RoleNode[];
+  connectWheres: WhereNode[];
+  modelName: "ServerRole" | "ModServerRole";
+  capabilityFields: readonly string[];
+  actorRole: EffectiveRole;
+};
+
+async function collectEscalations(
+  ctx: GraphQLContext,
+  check: RoleEscalationCheck
+): Promise<string[]> {
+  const { nodes, connectWheres, modelName, capabilityFields, actorRole } = check;
+
+  // A caller who already holds every capability (root / full admin) can never
+  // escalate, so skip the database round-trips for connect resolution.
+  if (actorRole === "all") {
+    return [];
+  }
+
+  const connectedNodes = await resolveConnectedRoleNodes(
+    ctx,
+    modelName,
+    connectWheres,
+    capabilityFields
+  );
+
+  return findEscalatedCapabilities({
+    requested: [...nodes, ...connectedNodes],
+    capabilityFields,
+    actorRole,
+  });
+}
+
+export const serverConfigInputDoesNotEscalate = rule({ cache: "contextual" })(
+  async (
+    _parent: unknown,
+    args: Record<string, unknown>,
+    ctx: GraphQLContext,
+    _info: GraphQLResolveInfo
+  ) => {
+    const inputs: unknown[] = [];
+    if (Array.isArray(args.input)) {
+      inputs.push(...(args.input as unknown[]));
+    }
+    if (args.update) {
+      inputs.push(args.update);
+    }
+
+    const writes: ExtractedRoleWrites = {
+      serverRoleNodes: [],
+      modServerRoleNodes: [],
+      serverRoleConnectWheres: [],
+      modServerRoleConnectWheres: [],
+    };
+    for (const input of inputs) {
+      mergeWrites(writes, extractNestedRoleWrites(input));
+    }
+
+    const touchesRoles =
+      writes.serverRoleNodes.length > 0 ||
+      writes.modServerRoleNodes.length > 0 ||
+      writes.serverRoleConnectWheres.length > 0 ||
+      writes.modServerRoleConnectWheres.length > 0;
+    if (!touchesRoles) {
+      return true;
+    }
+
+    const [actorServerRole, actorModRole] = await Promise.all([
+      getActorServerRoleCaps(ctx),
+      getActorModServerRoleCaps(ctx),
+    ]);
+
+    const escalated = new Set<string>();
+
+    const serverEscalations = await collectEscalations(ctx, {
+      nodes: writes.serverRoleNodes,
+      connectWheres: writes.serverRoleConnectWheres,
+      modelName: "ServerRole",
+      capabilityFields: SERVER_ROLE_CAPABILITY_FIELDS,
+      actorRole: actorServerRole,
+    });
+    serverEscalations.forEach((capability) => escalated.add(capability));
+
+    const modEscalations = await collectEscalations(ctx, {
+      nodes: writes.modServerRoleNodes,
+      connectWheres: writes.modServerRoleConnectWheres,
+      modelName: "ModServerRole",
+      capabilityFields: MOD_SERVER_ROLE_CAPABILITY_FIELDS,
+      actorRole: actorModRole,
+    });
+    modEscalations.forEach((capability) => escalated.add(capability));
+
+    if (escalated.size > 0) {
+      return `You cannot grant capabilities you do not have yourself: ${[
+        ...escalated,
+      ].join(", ")}.`;
+    }
+
+    return true;
+  }
+);


### PR DESCRIPTION
## Summary

Two things, both off `main` (non-stacked, to avoid another orphaned merge):

### 1. Re-lands two orphaned PRs that never reached `main`

#74 (suspension-aware override) and #76 (nested-ServerConfig escalation guard) were **stacked** PRs — GitHub merged each into its *base branch* rather than `main`, so their commits never landed. Notably, **the nested apex-escalation hole was live on `main`** (no `serverConfigInputDoesNotEscalate`). This branch cherry-picks both back onto `main`:

- `dcd2838` — make the server-admin override **suspension-aware** (a server-suspended admin loses the override; root stays absolute). Was #74.
- `07e6dc4` — close **nested role-escalation via `updateServerConfigs`/`createServerConfigs`** (`serverConfigInputDoesNotEscalate`). Was #76.

(Both were already reviewed/approved; re-landed verbatim, only the design-doc Phasing section was merged.)

### 2. PR-4c — channel-role authoring guard (new)

Extends the no-privilege-escalation guard to `createChannelRoles` / `createModChannelRoles`. Channel roles carry **no** server-administration capability, so this is **defense-in-depth** — but it closes the last channel-scoped gap:

**Invariant:** you may author a *capability-bearing* channel role only for a channel you **own** (or as server admin / root, who hold every channel capability everywhere). A channel owner inherently holds all of their channel's capabilities, so ownership *is* the capability check for the channel scope. A non-owner with `canManageRoles` can still create empty/no-capability roles.

- `rules/validation/channelRoleEscalation.ts` (new) — pure `roleItemsGrantingCapabilities` (selects the input items that actually grant a capability) + the two shield rules (server-admin/root bypass, else per-item channel-ownership check via `Channel.Admins`).
- Channel capability field lists added to `actorCapabilities.ts`.

**Why `createChannels`/`updateChannels` need no guard:** nested channel-role writes there are already safe — `updateChannels` is channel-owner-gated, and `createChannels` makes the caller the owner; either way the actor legitimately defines their own channel's roles.

## Testing

- `npm run tsc` clean.
- New unit tests for the pure selector (`channelRoleEscalation.test.ts`); the re-landed PRs bring their own tests.
- Full unit suite green.

## After this merges

The privilege-escalation surface is closed end to end: direct role authoring (#75), nested/connect role wiring via ServerConfig (#76, re-landed here), channel-role authoring (PR-4c), role self-assignment via `updateUsers` (#64), and invites that only grant fixed tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
