### PR TITLE
docs: auth/permissions doc update + skip CI tests on docs-only changes

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -9,40 +9,102 @@ on:
       - main
 
 jobs:
-  unit-tests:
+  # Detect whether anything other than documentation changed. We do NOT use a
+  # workflow-level `paths-ignore`, because `unit-tests` is a REQUIRED status
+  # check on `main`: a path-filtered workflow never reports the check, which
+  # would leave docs-only PRs stuck "pending" and unmergeable. Instead the
+  # required job always runs (so it always reports) but skips its heavy steps
+  # when only docs changed.
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+          fi
+
+          # If the base commit isn't available (e.g. a brand-new branch reports
+          # an all-zero "before"), fail safe and run the full pipeline.
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable; running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$base" "$head")"
+          echo "Changed files:"
+          echo "$changed"
+
+          # Docs = anything under docs/ or any *.md file. If anything else
+          # changed, run the tests.
+          if echo "$changed" | grep -vE '(^docs/|\.md$)' | grep -q .; then
+            echo "Non-docs changes detected → running tests."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only change → skipping tests."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Required check on `main`. Always runs so it always reports a status; the
+  # heavy steps are gated on a non-docs change.
+  unit-tests:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'npm'
 
       - name: Clean install dependencies
+        if: needs.changes.outputs.code == 'true'
         run: npm ci
 
       # Generated type files (ogm_types.ts, src/generated/graphql.ts) are no
       # longer committed; regenerate them from typeDefs.ts (no DB needed) before
       # type checking and tests so imports resolve.
       - name: Generate GraphQL/OGM types
+        if: needs.changes.outputs.code == 'true'
         run: npm run codegen
 
       - name: Lint (enforces no console.* in runtime code)
+        if: needs.changes.outputs.code == 'true'
         run: npm run lint
 
       - name: Run TypeScript type checking
+        if: needs.changes.outputs.code == 'true'
         run: npm run tsc
 
       - name: Check for circular dependencies
+        if: needs.changes.outputs.code == 'true'
         run: npm run lint:circular
 
       - name: Run unit tests with coverage
+        if: needs.changes.outputs.code == 'true'
         run: npm run coverage
 
       - name: Upload unit coverage to Codecov
+        if: needs.changes.outputs.code == 'true'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -52,9 +114,16 @@ jobs:
           verbose: true
 
       - name: Verify build (tsc + cypher copy)
+        if: needs.changes.outputs.code == 'true'
         run: npm run build
 
+      - name: Docs-only change — tests skipped
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Only documentation changed; unit tests skipped."
+
   integration-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # The integration suite is the CI bottleneck (serial, real Neo4j). Split it
     # into parallel shards — each matrix job runs ~1/N of the files against its

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -25,6 +25,15 @@ tokens fall through the audience checks and server-side user lookups are
 rejected — users appear logged in but resolve with no username/profile. The
 value must match the frontend's `NUXT_AUTH0_AUDIENCE`.
 
+## Break-glass root (`SUPERADMIN_EMAIL`)
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `SUPERADMIN_EMAIL` | Recommended | Email of the **env break-glass root**. A caller whose verified token email equals this value holds **every** capability unconditionally, bypassing all role/tier checks (`rules/permission/isServerRoot.ts`). It is immutable from the database and cannot be locked out, so it can bootstrap the first `SuperAdmin` on a fresh install and recover if `ServerConfig.SuperAdmins` is ever emptied. It is the **only** unconditional override — and the only actor a suspension cannot restrict. Keep it to a tightly controlled account; day-to-day administration should go through the `SuperAdmins`/`Admins` tiers, not root. See [permission-system.md](./permission-system.md). |
+
+`CYPRESS_ADMIN_TEST_EMAIL` (below) is honored by the same root check, so in
+test/E2E environments the seeded admin test user also acts as root.
+
 ## Database (Neo4j)
 
 | Variable | Required | Description |

--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -1,6 +1,9 @@
 # Design: Phasing out `isAdmin` → symmetric, role-based permissions
 
-Status: **Draft for review** · Owner: TBD · Related: PR #64 (P0), PR #65 (P1)
+Status: **Implemented** (PR-1 → PR-4c; see §7 Phasing for the per-stage status).
+The remaining work is rollout/cleanup, not the core model. · Related: PR #64
+(P0), PR #65 (P1). For the resulting system, see
+[permission-system.md](./permission-system.md).
 
 ## 1. Goal & product context
 

--- a/docs/permission-system.md
+++ b/docs/permission-system.md
@@ -242,10 +242,10 @@ When a suspended user attempts a blocked action, `createSuspensionNotification` 
 - Roles are defined as nodes and wired to the `ServerConfig`/`Channel` tiers. The
   seeded defaults are the source of truth and are installed idempotently by
   `provisionServerDefaults` (`npm run provision`).
-- Custom (non-default) roles **can** be created/edited through the role-authoring
-  mutations (gated by `canManageRoles` + the no-privilege-escalation guards). A
-  UI for managing them is still planned; today they are created via
-  seed/provisioning/mutations.
+- Custom (non-default) roles are **API-only, UI pending**: they can be
+  created/edited through the role-authoring mutations (gated by `canManageRoles` +
+  the no-privilege-escalation guards) and via seed/provisioning, but there is no
+  management UI yet.
 - All permission checks are enforced through GraphQL Shield middleware combined
   with custom rule resolvers. The pure decision in each rule (given fetched roles,
   is this permission granted?) is separated from data fetching for unit testing.

--- a/docs/permission-system.md
+++ b/docs/permission-system.md
@@ -34,6 +34,14 @@ The permission system uses the following components:
 - **Channel Owners** - Have administrative control over specific channels
 - **Moderators** - Users with moderation capabilities
 - **Suspended Users** - Users with temporarily restricted permissions
+- **Server Admins** (`ServerConfig.Admins`) - Permissive server-wide tier; **restricted by default** (the seeded admin role omits `canManageAdmins`)
+- **Super Admins** (`ServerConfig.SuperAdmins`) - The operational apex; their role holds `canManageAdmins`/`canManageSuperAdmins`, so they can mint other admins. Self-managing.
+- **Root** - The env break-glass super-user (`SUPERADMIN_EMAIL`); holds every capability unconditionally. See [Server administration](#server-administration-capabilities-tiers-and-root).
+
+> **Historical note:** the backend previously had a single `isAdmin` check
+> ("you're in `Admins` ⇒ you can do anything"). It has been **removed**. Admin
+> power now flows through the capability/tier model below; the only unconditional
+> override is the env root.
 
 ## How Permissions Are Applied
 
@@ -44,6 +52,9 @@ The permission system follows a hierarchical flow:
 
 2. **Role Determination**
    - For each action, the system determines which role applies to the user
+   - **First**, a server admin (incl. SuperAdmins) or root short-circuits channel
+     and ownership checks via `passesAsServerAdminOrRoot` (unless the admin is
+     server-suspended; root is never restricted). Otherwise:
    - The system follows this priority order when determining permissions:
      - For regular user actions (e.g., creating posts):
        1. Channel Owner status (automatic permission for all channel actions)
@@ -65,9 +76,98 @@ The permission system follows a hierarchical flow:
 
 ## Special Cases
 
-- **Channel Owners** always have full permissions within their channels
+- **Server admins and root** pass any channel permission, channel-mod, or
+  ownership check across the whole server, via `passesAsServerAdminOrRoot`
+  (`rules/permission/serverAdminOverride.ts`). This is the override that replaced
+  the per-call-site `isAdmin`. It is **suspension-aware**: a server-*suspended*
+  admin loses the override and falls back to the normal (restricted) role checks;
+  **root** is the only actor a suspension cannot stop. It is deliberately **not**
+  applied to account ownership (`isAccountOwner`) — editing/deleting another
+  user's account is self-only by design.
+- **Channel Owners** resolve the channel's configurable `ElevatedChannelRole`;
+  until one is configured they retain every permission (current default). So
+  "owners have full permissions" is the default, not a hardcoded bypass.
 - **Feedback Comments** require moderator permissions (`canGiveFeedback`) rather than standard comment permissions
 - **Suspended Users** have limited permissions based on the Suspended roles
+
+## Server administration (capabilities, tiers, and root)
+
+Server-administration actions are gated by **fine-grained capabilities on
+`ServerRole`/`ModServerRole`**, not a blanket admin flag. The server scope is
+symmetric with the channel scope: a membership connection on `ServerConfig`
+selects a configurable governing role.
+
+| Capability (`ServerRole`) | Gates |
+| --- | --- |
+| `canManageServerSettings` | `create/update/deleteServerConfigs`, `deleteFilterGroups`/`Options` |
+| `canManagePlugins` | plugin install/enable/refresh/secret/delete |
+| `canManageRoles` | `create/deleteServerRoles`, `create/updateModServerRoles`, `create*ChannelRoles`, `deleteChannelRoles` |
+| `canManageMods` | `invite/cancelInviteServerMod` |
+| `canManageAdmins` (**apex**) | `invite/cancelInviteServerAdmin` |
+| `canManageSuperAdmins` (**apex**) | add/remove `ServerConfig.SuperAdmins` |
+
+Plus destructive structural caps on `ModServerRole`: `canRemoveDiscussionChannel`,
+`canRemoveEventChannel`.
+
+**Tier resolution** (`hasServerPermission.ts`, `hasServerModPermission.ts`):
+root → super-admin role → admin role → moderator role → default role, with
+**suspension taking precedence over tier**. The seeded **admin** role is
+permissive but omits `canManageAdmins` (every regular admin is "restricted" by
+default); the ability to mint admins lives in the **SuperAdmins** tier and root.
+
+**Root** (`SUPERADMIN_EMAIL`, plus `CYPRESS_ADMIN_TEST_EMAIL` in tests) is the env
+break-glass super-user: it holds every capability unconditionally, is immutable
+from the database, and is the only override a suspension cannot restrict. Its job
+is to bootstrap the first SuperAdmin and to recover if `SuperAdmins` is emptied.
+
+The seeded default roles are the single source of truth for what each tier
+grants and are installed/repaired idempotently by `provisionServerDefaults`
+(`npm run provision`).
+
+### No-privilege-escalation invariant
+
+Because role authoring and assignment are themselves capabilities, an actor must
+never grant, assign, or edit a role to exceed their **own** resolved
+capabilities — otherwise a restricted admin with `canManageRoles` could mint
+`canManageAdmins`. This is enforced at every grant path:
+
+- **Direct role authoring** — `createServerRoles`/`createModServerRoles`/
+  `updateModServerRoles` reject any capability the actor doesn't hold
+  (`rules/validation/roleEscalation.ts`, comparing against the actor's effective
+  role from `rules/permission/actorCapabilities.ts`).
+- **Nested role writes via `ServerConfig`** — `create/updateServerConfigs` can
+  carry nested role `create`/`update`/`connect` on the tier relationships;
+  `nestedRoleEscalation.ts` walks those and resolves `connect` targets from the
+  DB so a tier role can't be escalated (e.g.
+  `DefaultAdminRole.update.node.canManageAdmins = true`).
+- **Channel role authoring** — `create*ChannelRoles` may grant a capability only
+  for a channel the actor owns (or as server admin/root); channel roles carry no
+  server-administration capability (`channelRoleEscalation.ts`).
+- **Assignment** — role connections via `updateUsers` are blocked outright (the
+  generic role-connect path is never legitimate); the invite flows grant fixed
+  tier roles, so the inviter never chooses capabilities.
+
+Root bypasses these checks; when the actor's own role can't be resolved, the
+guards **fail closed**.
+
+## Account-scoped and field-level access
+
+Some access is **self-only** and does not flow through roles at all — there is no
+"manage other users" capability:
+
+- **`emails` enumeration is denied** for every caller (`Query.emails → deny`);
+  only direct database access can read the email table. Clients that need the
+  caller's own address use the self-scoped `getOwnEmail` query, which is *not*
+  gated by `isAuthenticated` so it works during onboarding (it self-scopes via the
+  token's verified email).
+- **`updateUsers` / `deleteUsers` / `deleteEmails` are self-only** (`isAccountOwner`,
+  with no admin override). Account edits/deletions are the user's own; cross-user
+  admin action happens only through the invite/suspension flows. `updateUsers`
+  additionally blocks connecting any role relationship (the
+  privilege-escalation guard from #64).
+- **Private `User` fields** (`Email`, notification settings, favorites,
+  `Notifications`, purchases, …) are gated by `isAccountOwner`; public profile
+  fields stay public.
 
 ## Suspension System
 
@@ -113,11 +213,22 @@ Channel permissions (`hasChannelPermission.ts`, `hasChannelModPermission.ts`) en
 
 ### Server-Level Suspension Enforcement
 
-Server permissions (`hasServerPermission.ts`) also check for suspensions:
+Server permissions (`hasServerPermission.ts` for creative caps,
+`hasServerModPermission.ts` for mod caps) also check for suspensions via
+`getActiveServerSuspension`:
 
-1. Query for any active suspensions (indefinite or unexpired) across all channels
-2. If any active suspension exists, use `DefaultSuspendedRole` for server-level actions
-3. This blocks suspended users from creating new channels/forums
+1. Query for any active server suspension (indefinite or unexpired)
+2. If suspended, use `DefaultSuspendedRole` / `DefaultSuspendedModRole` instead of
+   the tier role — **suspension takes precedence over tier**
+3. This blocks suspended users from creating new channels/forums and suspended
+   mods from server-level moderation
+
+**Suspending an admin.** Server suspension (`scope: 'server'`) is the lever that
+restricts a server admin. A server-suspended admin loses the admin override
+everywhere — `passesAsServerAdminOrRoot` returns false, `hasServerModPermission`
+stops short-circuiting on `isServerAdmin`, and they fall through to the suspended
+role. **Root is the only actor a suspension cannot stop.** Channel-level roles do
+not restrict an un-suspended admin — they are server staff.
 
 ### User Notifications
 
@@ -128,15 +239,28 @@ When a suspended user attempts a blocked action, `createSuspensionNotification` 
 
 ## Current Implementation Notes
 
-- The ability to create customized channel roles (changing what is allowed for standard users or moderators in a given channel) is a planned feature but is not currently available
-- Currently, the permissions are defined in the server configuration
-- All permission checks are enforced through GraphQL Shield middleware combined with custom rule resolvers
+- Roles are defined as nodes and wired to the `ServerConfig`/`Channel` tiers. The
+  seeded defaults are the source of truth and are installed idempotently by
+  `provisionServerDefaults` (`npm run provision`).
+- Custom (non-default) roles **can** be created/edited through the role-authoring
+  mutations (gated by `canManageRoles` + the no-privilege-escalation guards). A
+  UI for managing them is still planned; today they are created via
+  seed/provisioning/mutations.
+- All permission checks are enforced through GraphQL Shield middleware combined
+  with custom rule resolvers. The pure decision in each rule (given fetched roles,
+  is this permission granted?) is separated from data fetching for unit testing.
 
 ## Permission Check Implementation
 
-Permission checks are implemented in two main files:
+Permission checks span the channel and server scopes:
 
-1. `hasChannelPermission.ts` - Handles regular user permissions for channel-specific actions
-2. `hasChannelModPermission.ts` - Handles moderator permissions for moderation actions
+1. `hasChannelPermission.ts` - regular-user permissions for channel-specific actions
+2. `hasChannelModPermission.ts` - moderator permissions for channel moderation
+3. `hasServerPermission.ts` - server-wide creative/administration capabilities (tier resolution)
+4. `hasServerModPermission.ts` - server-wide moderation capabilities
 
-These files share a similar logical flow but handle different types of roles and permissions.
+Supporting modules: `serverAdminOverride.ts` (server-admin/root override),
+`actorCapabilities.ts` (resolves the actor's full effective role for the
+no-escalation guards), `getActiveSuspension.ts`/`getActiveServerSuspension.ts`,
+and the `rules/validation/*Escalation.ts` guards. Each channel/server pair shares
+a similar flow but handles different role types.


### PR DESCRIPTION
Two things: brings the backend auth/architecture/permission docs in line with everything shipped this session (PR-1 → PR-4c), and adds CI path-filtering so docs-only changes don't run the test suite.

## Docs

**`docs/permission-system.md`** (most stale — predated the whole `isAdmin` phase-out):
- Documents the server-admin capability table (`canManage*`), tier resolution (root → super-admin → admin → mod → default, suspension beats tier), restricted admins, the env break-glass **root**, and `provisionServerDefaults` as the source of truth.
- Adds the **no-privilege-escalation invariant** (direct authoring, nested `ServerConfig`, channel roles, assignment; fail-closed).
- Documents the suspension-aware `passesAsServerAdminOrRoot` override and the configurable `ElevatedChannelRole` (so "owners have full perms" is the default, not a hardcoded bypass).
- Server-level suspension now covers `hasServerModPermission` and **"suspending an admin"** (server suspension is the lever; root is unrestrictable).
- Fixes the stale "customized channel roles aren't available" note and completes the permission-check file list.
- Adds **account-scoped/field-level access** (emails `deny` + `getOwnEmail`, self-only `updateUsers`/`deleteUsers`/`deleteEmails`, private `User` fields).

**`docs/environment-variables.md`**: documents **`SUPERADMIN_EMAIL`** (the env break-glass root) — it was absent entirely — and notes `CYPRESS_ADMIN_TEST_EMAIL` is honored by the same root check.

**`docs/isadmin-phaseout-design.md`**: status flipped from "Draft for review" to "Implemented".

Checked, no change needed: `docs/architecture.md` (accurate; its `tests/integration` claim holds) and `README.md` (high-level, delegates to the permission doc).

## CI: skip tests on docs-only changes

`unit-tests` is a **required** status check on `main`, so a workflow-level `paths-ignore` would leave it forever "pending" on docs-only PRs and block the merge. Instead:
- A `changes` job detects whether anything other than docs (under `docs/` or any `*.md`) changed.
- `unit-tests` always runs (so it always reports the required status) but **skips its heavy steps** on docs-only changes.
- `integration-tests` (not required) is **skipped entirely** on docs-only changes.
- Fails safe: if the base commit can't be resolved, the full pipeline runs.

(This PR touches the workflow file — a non-docs change — so CI runs in full here; the skip path applies to future docs-only PRs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)