### PR TITLE
feat(schema): remove legacy showAdminTag/showModTag (tag-refactor contract)

### DIFF
--- a/customResolvers/cypher/getCommentRepliesQuery.cypher
+++ b/customResolvers/cypher/getCommentRepliesQuery.cypher
@@ -53,14 +53,11 @@ WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, Su
      GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
      10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
-     serverRoles, channelRoles
-
-WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
-     [role IN serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRoles
-
-WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, serverRoles, isFavoritedByUser,
-     [role IN channelRoles | {showModTag: role.showModTag}] AS channelRoles
+// Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
+// @cypher field + server-admin membership), so the author's roles are no longer
+// projected onto the reply. (serverRoles/channelRoles were collapsed above and are
+// now dropped.)
+WITH parentComment, child, author, UpvotedByUsers, SuperUpvotedByUsers, weightedVotesCount, hotRank, GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser
 
 // Structure the return data
 RETURN {
@@ -80,9 +77,7 @@ RETURN {
         profilePicURL: author.profilePicURL,
         discussionKarma: author.discussionKarma,
         commentKarma: author.commentKarma,
-        createdAt: author.createdAt,
-        ServerRoles: serverRoles,
-        ChannelRoles: channelRoles
+        createdAt: author.createdAt
     },
     isFavoritedByUser: isFavoritedByUser,
     UpvotedByUsers: [user IN UpvotedByUsers | user{.*, createdAt: toString(user.createdAt)}],

--- a/customResolvers/cypher/getCommentsQuery.cypher
+++ b/customResolvers/cypher/getCommentsQuery.cypher
@@ -48,19 +48,11 @@ WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByU
 WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, isFavoritedByUser,
     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-// Collect distinct server roles which should be attached to the comment author.
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
-     COLLECT(DISTINCT serverRole) AS serverRoles, channelRole
-
-// Each serverRole should include: {showAdminTag: role.showAdminTag}
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser,
-        [role IN serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRole
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
-     COLLECT(DISTINCT channelRole) AS channelRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, serverRoles, isFavoritedByUser,
-        [role IN channelRoles | {showModTag: role.showModTag}] AS channelRoles
+// Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
+// @cypher field + server-admin membership), so the author's roles are no longer
+// projected onto the comment. Collapse the serverRole/channelRole fan-out from the
+// OPTIONAL MATCHes above so each comment yields a single row.
+WITH DISTINCT c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, hotRank, isFavoritedByUser
 
 RETURN {
     id: c.id,
@@ -77,9 +69,7 @@ RETURN {
         profilePicURL: author.profilePicURL,
         discussionKarma: author.discussionKarma,
         commentKarma: author.commentKarma,
-        createdAt: author.createdAt,
-        ServerRoles: serverRoles,
-        ChannelRoles: channelRoles
+        createdAt: author.createdAt
     } END,
     isFavoritedByUser: isFavoritedByUser,
     ParentComment: CASE WHEN SIZE(parentIds) > 0 THEN {id: parentIds[0]} ELSE null END,

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -139,14 +139,10 @@ WITH dc, d, author, serverRole, channelRole, COLLECT(c) AS comments, tagsText, l
 WITH dc, d, author, serverRole, channelRole, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, totalCount,
      10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
-     COLLECT(DISTINCT serverRole) AS serverRoles, channelRole
-
-WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRole, totalCount
-
-WITH dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount,
-     [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles,
-     [role in COLLECT(DISTINCT channelRole) | {showModTag: role.showModTag}] AS channelRoles
+// Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
+// @cypher field + server-admin membership), so the author's roles are no longer
+// projected onto the result. Collapse the serverRole/channelRole fan-out.
+WITH DISTINCT dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, totalCount
 
 // Sort based on individual elements, not the collection
 ORDER BY
@@ -156,7 +152,7 @@ ORDER BY
     dc.createdAt DESC
 
 // Apply pagination
-WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank, serverRoles, channelRoles
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, hotRank
 SKIP toInteger($offset)
 LIMIT toInteger($limit)
 
@@ -167,7 +163,7 @@ WHERE image.id IS NOT NULL
   AND (image.permanentlyRemoved IS NULL OR image.permanentlyRemoved = false)
 
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
-     weightedVotesCount, comments, hotRank, serverRoles, channelRoles,
+     weightedVotesCount, comments, hotRank,
      album,
      [img IN COLLECT(DISTINCT CASE WHEN image IS NOT NULL THEN {
          id: image.id,
@@ -181,7 +177,7 @@ WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperU
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
-     weightedVotesCount, comments, hotRank, serverRoles, channelRoles, album, albumImages,
+     weightedVotesCount, comments, hotRank, album, albumImages,
      CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null WHEN favUser IS NOT NULL THEN true ELSE false END AS isFavorited
 
 // Return the results with modified UpvotedByUsers
@@ -218,9 +214,7 @@ RETURN {
                       profilePicURL: author.profilePicURL,
                       createdAt: author.createdAt,
                       discussionKarma: author.discussionKarma,
-                      commentKarma: author.commentKarma,
-                      ServerRoles: serverRoles,
-                      ChannelRoles: channelRoles
+                      commentKarma: author.commentKarma
                   }
                 END,
         Album: CASE 

--- a/customResolvers/cypher/getEventCommentsQuery.cypher
+++ b/customResolvers/cypher/getEventCommentsQuery.cypher
@@ -38,17 +38,10 @@ WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildCom
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
 
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
-    serverRole, COLLECT(DISTINCT channelRole) AS channelRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
-    channelRoles, COLLECT(DISTINCT serverRole) AS serverRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
-    [role in serverRoles | {showAdminTag: role.showAdminTag}] AS serverRoles, channelRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser,
-    serverRoles, [role in channelRoles | {showModTag: role.showModTag}] AS channelRoles
+// Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
+// @cypher field + server-admin membership), so the author's roles are no longer
+// projected onto the comment. Collapse the serverRole/channelRole fan-out.
+WITH DISTINCT c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, hotRank, FilteredPastVersions, isFavoritedByUser
 
 RETURN {
     id: c.id,
@@ -64,9 +57,7 @@ RETURN {
         profilePicURL: author.profilePicURL,
         discussionKarma: author.discussionKarma,
         commentKarma: author.commentKarma,
-        createdAt: author.createdAt,
-        ServerRoles: serverRoles,
-        ChannelRoles: channelRoles
+        createdAt: author.createdAt
     },
     isFavoritedByUser: isFavoritedByUser,
     ParentComment: CASE WHEN SIZE(parentIds) > 0 THEN {id: parentIds[0]} ELSE null END,

--- a/customResolvers/cypher/getNewCommentsQuery.cypher
+++ b/customResolvers/cypher/getNewCommentsQuery.cypher
@@ -41,21 +41,11 @@ WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByU
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
     FeedbackComments
 
-WITH c, author, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
-    ChildComments, FilteredPastVersions, FeedbackComments,
-    COLLECT(DISTINCT serverRole) AS serverRoles
-
-WITH c, author, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
-    ChildComments, FilteredPastVersions, FeedbackComments,
-    [role IN serverRoles | {showAdminTag: role.showAdminTag}] as serverRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
-    ChildComments, FilteredPastVersions, FeedbackComments, serverRoles,
-    COLLECT(DISTINCT channelRole) AS channelRoles
-
-WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
-    ChildComments, FilteredPastVersions, FeedbackComments, serverRoles,
-    [role IN channelRoles | {showModTag: role.showModTag}] as channelRoles
+// Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
+// @cypher field + server-admin membership), so the author's roles are no longer
+// projected onto the comment. Collapse the serverRole/channelRole fan-out.
+WITH DISTINCT c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, isFavoritedByUser,
+    ChildComments, FilteredPastVersions, FeedbackComments
 
 RETURN {
     id: c.id,
@@ -70,9 +60,7 @@ RETURN {
         profilePicURL: author.profilePicURL,
         discussionKarma: author.discussionKarma,
         commentKarma: author.commentKarma,
-        createdAt: author.createdAt,
-        ServerRoles: serverRoles,
-        ChannelRoles: channelRoles
+        createdAt: author.createdAt
     } END,
     isFavoritedByUser: isFavoritedByUser,
     ParentComment: CASE WHEN SIZE(parentIds) > 0 THEN {id: parentIds[0]} ELSE null END,

--- a/customResolvers/queries/getCommentSection.ts
+++ b/customResolvers/queries/getCommentSection.ts
@@ -40,14 +40,6 @@ const discussionChannelSelectionSet = `
             commentKarma
             createdAt
             discussionKarma
-            ... on User {
-                ServerRoles {
-                  showAdminTag
-                }
-                ChannelRoles {
-                  showModTag
-                }
-            }
         }
     }
     CommentsAggregate(where: { isFeedbackComment: false }) {

--- a/customResolvers/queries/publicCollectionsContaining.ts
+++ b/customResolvers/queries/publicCollectionsContaining.ts
@@ -69,9 +69,6 @@ const selectionSet = `
       commentKarma
       discussionKarma
       createdAt
-      ServerRoles {
-        showAdminTag
-      }
     }
   }
 }

--- a/rules/permission/actorCapabilities.ts
+++ b/rules/permission/actorCapabilities.ts
@@ -23,8 +23,8 @@ type RoleLike = Record<string, boolean | null | undefined> | null | undefined;
 // i.e. fail closed).
 export type EffectiveRole = RoleLike | "all";
 
-// Real capabilities only — display-only flags (showAdminTag / showModTag) are
-// intentionally excluded: granting a tag is not a privilege escalation.
+// Real capabilities only. (The legacy display-only tag flags have been removed;
+// ADMIN/MOD badges are membership-derived, not role flags.)
 export const SERVER_ROLE_CAPABILITY_FIELDS = [
   "canCreateChannel",
   "canCreateDiscussion",
@@ -63,7 +63,7 @@ export const MOD_SERVER_ROLE_CAPABILITY_FIELDS = [
 ] as const;
 
 // Channel-scoped role capabilities (no server-administration power). Used by the
-// PR-4c channel-role-authoring guard. Display-only showModTag is excluded.
+// PR-4c channel-role-authoring guard.
 export const CHANNEL_ROLE_CAPABILITY_FIELDS = [
   "canCreateDiscussion",
   "canCreateEvent",

--- a/rules/permission/getServerConfigForPermissions.ts
+++ b/rules/permission/getServerConfigForPermissions.ts
@@ -12,7 +12,6 @@ const SERVER_ROLE_CAPS = `
   canUpvoteDiscussion
   canUploadFile
   canGiveFeedback
-  showAdminTag
   canManageServerSettings
   canManagePlugins
   canManageRoles

--- a/rules/validation/channelRoleEscalation.test.ts
+++ b/rules/validation/channelRoleEscalation.test.ts
@@ -22,7 +22,7 @@ test("selects only items that set a channel capability to true", () => {
 
 test("an all-false / capability-free role grants nothing", () => {
   const items = [
-    { channelUniqueName: "cats", name: "Reader", description: "x", showModTag: true },
+    { channelUniqueName: "cats", name: "Reader", description: "x" },
   ];
   assert.deepEqual(
     roleItemsGrantingCapabilities(items, CHANNEL_ROLE_CAPABILITY_FIELDS),

--- a/seedData/defaultRoles.ts
+++ b/seedData/defaultRoles.ts
@@ -49,11 +49,12 @@ const ALL_CONTENT_CAPS = {
   canGiveFeedback: true,
 };
 
-// Note: roles are permissions-only. The ADMIN/MOD display tag is NOT set here —
-// it should derive from the user's membership relationship to ServerConfig /
-// Channel (e.g. in ServerConfig.Admins/SuperAdmins), not from a role flag. The
-// legacy `showAdminTag` / `showModTag` schema fields are slated for removal once
-// the tag is membership-derived. See docs/isadmin-phaseout-design.md.
+// Note: roles are permissions-only. The ADMIN/MOD display tag is NOT a role
+// flag — it derives from the user's membership relationship to ServerConfig /
+// Channel (server-admin membership for the ADMIN badge; the
+// `authorIsChannelModerator` @cypher field for the channel MOD badge). The
+// legacy `showAdminTag` / `showModTag` schema fields have been removed.
+// See docs/isadmin-phaseout-design.md.
 export const DEFAULT_SERVER_ROLES = [
   {
     // Standard signed-in user: can create/participate, no administration.

--- a/tests/integration/getDiscussionsInChannel.test.ts
+++ b/tests/integration/getDiscussionsInChannel.test.ts
@@ -1,0 +1,61 @@
+// Integration test for the getDiscussionsInChannel resolver against live Neo4j.
+// It runs the getDiscussionChannelsQuery.cypher (a heavy custom query). This test
+// exercises the query end to end against a real database so the Cypher's syntax
+// and variable threading are validated — it is the only coverage for that query.
+// (Added alongside the tag-refactor contract, which simplified the query's
+// serverRole/channelRole handling.)
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+const anon = () => ({
+  driver: env.driver,
+  ogm: env.ogm,
+  req: { headers: {}, body: {} },
+});
+
+const callForSort = (sort: string) =>
+  env.resolvers.Query.getDiscussionsInChannel(
+    null,
+    {
+      channelUniqueName: "does-not-exist",
+      options: { offset: "0", limit: "10", sort },
+      selectedTags: [],
+      searchInput: "",
+      showArchived: false,
+      labelFilters: [],
+    },
+    anon(),
+    {} as never
+  );
+
+// Running the query against an empty DB validates that the Cypher parses and
+// executes (the real risk in the contract change); a non-existent channel simply
+// yields an empty result.
+for (const sort of ["new", "top", "hot"]) {
+  test(`getDiscussionsInChannel (${sort}) executes and returns an empty result for an unknown channel`, async () => {
+    const result = await callForSort(sort);
+    assert.deepEqual(result.discussionChannels, []);
+    assert.equal(Number(result.aggregateDiscussionChannelsCount), 0);
+  });
+}

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1497,7 +1497,6 @@ const typeDefinitions = gql`
     canUpvoteComment: Boolean
     canUploadFile: Boolean
     canGiveFeedback: Boolean
-    showAdminTag: Boolean
     # Server-administration capabilities ("creative" — configure/grant). Default
     # off; held by the admin/super-admin tier roles. See
     # docs/isadmin-phaseout-design.md.
@@ -1520,7 +1519,6 @@ const typeDefinitions = gql`
     canUpvoteComment: Boolean
     canUploadFile: Boolean
     canUpdateChannel: Boolean
-    showModTag: Boolean
   }
 
   type ModChannelRole {


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE / DEPLOY until the frontend switch (multiforum-nuxt#169) is merged AND deployed.** This removes `ChannelRole.showModTag` from the schema; deploying it while a frontend that still selects `showModTag` is live would break those queries. `showAdminTag` is already safe (the frontend never selected it). Opened as a draft for that reason.

## Summary

The contract phase of the membership-derived tag refactor. Now that ADMIN/MOD badges are membership-derived (server-admin membership for ADMIN; the `authorIsChannelModerator` @cypher field for the channel MOD badge, consumed by frontend #169), the legacy role display flags are removed:

- **`ServerRole.showAdminTag`** — already fully dead (never queried by the frontend; no backend logic).
- **`ChannelRole.showModTag`** — unconsumed once #169 ships.

## Changes

- **`typeDefs.ts`** — remove both fields.
- **OGM selections** — `getServerConfigForPermissions`, `getCommentSection`, `publicCollectionsContaining` no longer select the removed fields.
- **Cypher (5 queries)** — `getCommentsQuery`, `getNewCommentsQuery`, `getEventCommentsQuery`, `getCommentRepliesQuery`, `getDiscussionChannelsQuery`: the `serverRole`/`channelRole` fan-out (which existed only to carry the badge flags onto the comment/discussion author) is collapsed with `WITH DISTINCT` and the `ServerRoles`/`ChannelRoles` author attachments are dropped.
- **`seedData` / `actorCapabilities` comments** updated; the channel-role-escalation test mock no longer uses `showModTag`.

## Testing

- `npm run build` (regenerates types from `typeDefs`) + `npm run tsc` — clean.
- Full unit suite — green.
- **Cypher validated against live Neo4j (Testcontainers):** the existing comment/event/reply integration tests cover 4 of the 5 queries (`getCommentSection` runs both `getCommentsQuery` and `getNewCommentsQuery`); I added **`getDiscussionsInChannel.test.ts`** to cover the 5th (`getDiscussionChannelsQuery`) across the new/top/hot sort branches — the query had no prior integration coverage.

## Deploy ordering (expand-contract)

backend expand (`authorIsChannelModerator`, already shipped) → **frontend switch (#169) merged + deployed** → **this contract**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
