### PR TITLE
fix(discussions): restore the Mod badge on channel-scoped list items

### DIFF
--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -225,7 +225,18 @@ RETURN {
                     Images: albumImages
                 }
               END,
-        Tags: [t IN tagsText | {text: t}]
+        Tags: [t IN tagsText | {text: t}],
+        // Membership-derived MOD badge: is the author channel staff (owner or
+        // moderator) of this channel? Computed inline because the @cypher field
+        // of the same name only auto-resolves on the generated `discussions`
+        // query, not inside this custom resolver. Mirrors typeDefs.ts.
+        authorIsChannelModerator: CASE
+            WHEN author IS NULL THEN false
+            WHEN EXISTS { (author)-[:ADMIN_OF_CHANNEL]->(:Channel {uniqueName: dc.channelUniqueName}) }
+              OR EXISTS { (author)-[:MODERATION_PROFILE]->(:ModerationProfile)-[:MODERATOR_OF_CHANNEL]->(:Channel {uniqueName: dc.channelUniqueName}) }
+            THEN true
+            ELSE false
+        END
     },
     Channel: {
         uniqueName: dc.channelUniqueName

--- a/tests/integration/authorIsChannelModerator.test.ts
+++ b/tests/integration/authorIsChannelModerator.test.ts
@@ -57,6 +57,21 @@ before(async () => {
       `CREATE (u:User { username: 'regular' })
        CREATE (u)-[:POSTED_DISCUSSION]->(:Discussion { id: 'd-regular', title: 'r' })`
     );
+
+    // Link each discussion to the channel via a DiscussionChannel so the custom
+    // getDiscussionsInChannel resolver (which matches DiscussionChannel, not the
+    // auto `discussions` query) returns them. The resolver needs createdAt for
+    // hot-rank scoring.
+    await session.run(
+      `MATCH (ch:Channel { uniqueName: $ch })
+       MATCH (d:Discussion) WHERE d.id IN ['d-owner', 'd-mod', 'd-regular']
+       SET d.createdAt = datetime()
+       CREATE (dc:DiscussionChannel {
+         id: 'dc-' + d.id, channelUniqueName: $ch, createdAt: datetime(),
+         archived: false, answered: false, locked: false
+       })-[:POSTED_IN_CHANNEL]->(d)`,
+      { ch: CHANNEL }
+    );
   } finally {
     await session.close();
   }
@@ -106,4 +121,46 @@ test("a different channel does not grant the badge", async () => {
 
 test("null channelUniqueName -> false", async () => {
   assert.equal(await run("d-owner", null), false);
+});
+
+// The channel list uses the custom getDiscussionsInChannel resolver, where the
+// @cypher field does NOT auto-resolve — the resolver's Cypher must populate
+// authorIsChannelModerator itself. This guards that path (the badge regression).
+const LIST_QUERY = /* GraphQL */ `
+  query ($ch: String!) {
+    getDiscussionsInChannel(
+      channelUniqueName: $ch
+      searchInput: ""
+      selectedTags: []
+      showArchived: false
+      showUnanswered: false
+      hasDownload: false
+      options: { limit: 10, offset: 0 }
+    ) {
+      discussionChannels {
+        Discussion {
+          id
+          authorIsChannelModerator(channelUniqueName: $ch)
+        }
+      }
+    }
+  }
+`;
+
+test("getDiscussionsInChannel (custom resolver) populates authorIsChannelModerator", async () => {
+  const result = await graphql({
+    schema,
+    source: LIST_QUERY,
+    contextValue: { driver, ogm, req: { headers: {} } },
+    variableValues: { ch: CHANNEL },
+  });
+  assert.equal(result.errors, undefined, JSON.stringify(result.errors));
+  const channels =
+    (result.data as any)?.getDiscussionsInChannel?.discussionChannels ?? [];
+  const byId = Object.fromEntries(
+    channels.map((c: any) => [c.Discussion.id, c.Discussion.authorIsChannelModerator])
+  );
+  assert.equal(byId["d-owner"], true, "channel owner should be a mod in the list");
+  assert.equal(byId["d-mod"], true, "channel moderator should be a mod in the list");
+  assert.equal(byId["d-regular"], false, "regular user should not be a mod in the list");
 });


### PR DESCRIPTION
## Problem

After the membership-tag refactor, channel-scoped **list** items (channel discussion list, channel downloads) stopped showing the **Mod** badge that the discussion *detail* view still showed — for the same author/channel.

## Root cause

`authorIsChannelModerator` is an `@cypher` field. It auto-resolves on the generated `discussions` query (which the **detail** view uses), but the channel **list** uses the custom `getDiscussionsInChannel` resolver — and an `@cypher` field is **not** auto-computed inside a hand-written Cypher resolver. The #79 contract removed the old `showModTag` projection that resolver used to return, and nothing replaced it, so the field came back null → no badge.

## Fix

Compute `authorIsChannelModerator` inline in `getDiscussionChannelsQuery.cypher`, mirroring the `typeDefs.ts` `@cypher` logic (author is `ADMIN_OF_CHANNEL`, or `MODERATION_PROFILE` → `MODERATOR_OF_CHANNEL`, of the channel). I verified a custom resolver's value for an `@cypher` field is **not** overridden by the field resolver (tested with a hardcoded value, then the real logic), so the map value flows through to the client.

This fixes **both** the channel discussion list and the channel downloads list (same query). **Events are unaffected** — they use the auto-generated `events` query, where the `@cypher` field already resolves.

## Test

Adds the missing regression guard to `tests/integration/authorIsChannelModerator.test.ts` (this gap is exactly why it shipped): seeds `DiscussionChannel`s and asserts `getDiscussionsInChannel` returns `authorIsChannelModerator` **true** for a channel owner/moderator and **false** for a regular user. Verified against real Neo4j (cats: `cluse`→true; vue_devs: `eleanor`→false, `alice`→true). All 6 tests pass; full unit suite green.

> Pairs with frontend PR gennit-project/multiforum-nuxt#170 (show both Admin + Mod badges). This backend change alone restores the missing Mod badge; the frontend PR adds the both-badges enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)