### PR TITLE
feat(super-upvotes): correct returned lists, link notifications, add post links

### DIFF
--- a/customResolvers/mutations/createScratchpadEntry.ts
+++ b/customResolvers/mutations/createScratchpadEntry.ts
@@ -1,6 +1,5 @@
 import type { Driver } from 'neo4j-driver';
 import type { GraphQLResolveInfo } from 'graphql';
-import { createInAppNotification } from '../../hooks/notificationHelpers.js';
 import type { GraphQLContext } from '../../types/context.js';
 import { logger } from "../../logger.js";
 import type {
@@ -74,9 +73,13 @@ const createScratchpadEntryResolver = (input: Input) => {
         throw new Error('Recipient user not found');
       }
 
-      // 2. Verify the logged-in user has already upvoted the source content
+      // 2. Verify the logged-in user has already upvoted the source content.
+      //    Also capture where the content lives so the notification can link
+      //    directly to the upvoted post/comment.
       let hasUpvoted = false;
       let hasSuperUpvoted = false;
+      let postDiscussionId: string | null = null;
+      let postChannelUniqueName: string | null = sourceChannelUniqueName || null;
 
       if (sourceType === 'comment') {
         const commentResult = await Comment.find({
@@ -85,6 +88,7 @@ const createScratchpadEntryResolver = (input: Input) => {
             id
             UpvotedByUsers { username }
             SuperUpvotedByUsers { username }
+            DiscussionChannel { discussionId channelUniqueName }
           }`,
         });
 
@@ -95,12 +99,17 @@ const createScratchpadEntryResolver = (input: Input) => {
         const comment = commentResult[0];
         hasUpvoted = comment.UpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
         hasSuperUpvoted = comment.SuperUpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
+        postDiscussionId = comment.DiscussionChannel?.discussionId || null;
+        postChannelUniqueName =
+          comment.DiscussionChannel?.channelUniqueName || postChannelUniqueName;
       } else {
         // sourceType === 'discussion'
         const dcResult = await DiscussionChannel.find({
           where: { id: sourceId },
           selectionSet: `{
             id
+            discussionId
+            channelUniqueName
             UpvotedByUsers { username }
             SuperUpvotedByUsers { username }
           }`,
@@ -113,6 +122,8 @@ const createScratchpadEntryResolver = (input: Input) => {
         const dc = dcResult[0];
         hasUpvoted = dc.UpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
         hasSuperUpvoted = dc.SuperUpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
+        postDiscussionId = dc.discussionId || null;
+        postChannelUniqueName = dc.channelUniqueName || postChannelUniqueName;
       }
 
       if (!hasUpvoted) {
@@ -131,7 +142,9 @@ const createScratchpadEntryResolver = (input: Input) => {
             isPublic: false,
             sourceType,
             sourceId,
-            sourceChannelUniqueName: sourceChannelUniqueName || null,
+            sourceChannelUniqueName:
+              sourceChannelUniqueName || postChannelUniqueName || null,
+            discussionId: postDiscussionId || null,
             Author: {
               connect: {
                 where: { node: { username: loggedInUsername } },
@@ -167,34 +180,58 @@ const createScratchpadEntryResolver = (input: Input) => {
         await tx.run(superUpvoteQuery, { sourceId, username: loggedInUsername });
       }
 
-      // 5. Send notification to the recipient
+      // 5. Notify the recipient. Build a working link to the upvoted content
+      //    plus a link to their Kudos page, and connect the notification to the
+      //    scratchpad entry so the recipient can show-on-profile / ignore it
+      //    straight from the notification. Created inside the transaction so the
+      //    notification is atomic with the super upvote.
       const truncatedText = text.length > 50 ? text.substring(0, 50) + '...' : text;
-      const notificationText = `[@${loggedInUsername}](/u/${loggedInUsername}) wrote on your scratchpad: "${truncatedText}" [View scratchpad](/u/${recipientUsername}/scratchpad)`;
+      const subject = sourceType === 'comment' ? 'comment' : 'post';
+      const kudosUrl = `/u/${recipientUsername}/scratchpad`;
+      const postUrl =
+        postDiscussionId && postChannelUniqueName
+          ? `/forums/${postChannelUniqueName}/discussions/${postDiscussionId}`
+          : kudosUrl;
+      const notificationText =
+        `[@${loggedInUsername}](/u/${loggedInUsername}) super upvoted your ` +
+        `[${subject}](${postUrl}) with a thank-you note: "${truncatedText}" — ` +
+        `[View on your Kudos page](${kudosUrl})`;
 
-      await createInAppNotification({
-        UserModel: User,
-        username: recipientUsername,
-        text: notificationText,
-        notificationType: 'scratchpad',
-      });
+      await tx.run(
+        `MATCH (recipient:User { username: $recipientUsername })
+         MATCH (entry:ScratchpadEntry { id: $entryId })
+         CREATE (recipient)-[:HAS_NOTIFICATION]->(n:Notification {
+           id: randomUUID(),
+           createdAt: datetime(),
+           read: false,
+           text: $notificationText,
+           notificationType: 'scratchpad'
+         })
+         CREATE (n)-[:NOTIFICATION_FOR_SCRATCHPAD_ENTRY]->(entry)
+         RETURN n`,
+        {
+          recipientUsername,
+          entryId: createdEntry.id,
+          notificationText,
+        }
+      );
+
+      // Read the updated super-upvoter list inside the same transaction so it
+      // always reflects the relationship we just created. A post-commit read on
+      // a fresh OGM session can lag behind the write on a clustered database,
+      // returning a stale list that omits the actor — which left the frontend
+      // super-upvote button looking inactive (and un-undoable).
+      const readSuperUpvotersQuery =
+        sourceType === 'comment'
+          ? `MATCH (u:User)-[:SUPER_UPVOTED_COMMENT]->(:Comment { id: $sourceId })
+             RETURN collect({ username: u.username }) AS users`
+          : `MATCH (u:User)-[:SUPER_UPVOTED_DISCUSSION]->(:DiscussionChannel { id: $sourceId })
+             RETURN collect({ username: u.username }) AS users`;
+      const superUpvotersResult = await tx.run(readSuperUpvotersQuery, { sourceId });
+      const superUpvotedByUsers: Array<{ username: string }> =
+        superUpvotersResult.records[0]?.get('users') || [];
 
       await tx.commit();
-
-      // Fetch the updated SuperUpvotedByUsers for cache update
-      let superUpvotedByUsers: Array<{ username: string }> = [];
-      if (sourceType === 'comment') {
-        const result = await Comment.find({
-          where: { id: sourceId },
-          selectionSet: `{ SuperUpvotedByUsers { username } }`,
-        });
-        superUpvotedByUsers = result[0]?.SuperUpvotedByUsers || [];
-      } else {
-        const result = await DiscussionChannel.find({
-          where: { id: sourceId },
-          selectionSet: `{ SuperUpvotedByUsers { username } }`,
-        });
-        superUpvotedByUsers = result[0]?.SuperUpvotedByUsers || [];
-      }
 
       // Return the created entry with author info and updated super upvoted users
       return {
@@ -205,6 +242,7 @@ const createScratchpadEntryResolver = (input: Input) => {
         sourceType: createdEntry.sourceType,
         sourceId: createdEntry.sourceId,
         sourceChannelUniqueName: createdEntry.sourceChannelUniqueName,
+        discussionId: createdEntry.discussionId,
         Author: {
           username: loggedInUsername,
         },

--- a/customResolvers/mutations/undoSuperUpvote.ts
+++ b/customResolvers/mutations/undoSuperUpvote.ts
@@ -112,36 +112,27 @@ const undoSuperUpvoteResolver = (input: Input) => {
         },
       });
 
-      await tx.commit();
+      // Read the updated super-upvoter list inside the same transaction so it
+      // reflects the relationship we just deleted. A post-commit read on a fresh
+      // OGM session can lag behind the write on a clustered database.
+      const readSuperUpvotersQuery =
+        sourceType === 'comment'
+          ? `MATCH (u:User)-[:SUPER_UPVOTED_COMMENT]->(:Comment { id: $sourceId })
+             RETURN collect({ username: u.username }) AS users`
+          : `MATCH (u:User)-[:SUPER_UPVOTED_DISCUSSION]->(:DiscussionChannel { id: $sourceId })
+             RETURN collect({ username: u.username }) AS users`;
+      const superUpvotersResult = await tx.run(readSuperUpvotersQuery, { sourceId });
+      const superUpvotedByUsers: Array<{ username: string }> =
+        superUpvotersResult.records[0]?.get('users') || [];
 
-      // Fetch and return the updated source with SuperUpvotedByUsers for cache update
-      let updatedSource = null;
-      if (sourceType === 'comment') {
-        const result = await Comment.find({
-          where: { id: sourceId },
-          selectionSet: `{
-            id
-            SuperUpvotedByUsers { username }
-          }`,
-        });
-        updatedSource = result[0];
-      } else {
-        const result = await DiscussionChannel.find({
-          where: { id: sourceId },
-          selectionSet: `{
-            id
-            SuperUpvotedByUsers { username }
-          }`,
-        });
-        updatedSource = result[0];
-      }
+      await tx.commit();
 
       return {
         success: true,
         message: 'Super upvote removed successfully',
         sourceId,
         sourceType,
-        superUpvotedByUsers: updatedSource?.SuperUpvotedByUsers || [],
+        superUpvotedByUsers,
       };
     } catch (e) {
       if (tx) {

--- a/customResolvers/mutations/updateScratchpadEntryVisibility.ts
+++ b/customResolvers/mutations/updateScratchpadEntryVisibility.ts
@@ -46,6 +46,7 @@ const updateScratchpadEntryVisibilityResolver = (input: Input) => {
         sourceType
         sourceId
         sourceChannelUniqueName
+        discussionId
         createdAt
         Recipient {
           username

--- a/tests/integration/superUpvote.test.ts
+++ b/tests/integration/superUpvote.test.ts
@@ -45,6 +45,22 @@ const createScratchpadEntry = (args: Record<string, unknown>, username = "alice"
 const undoSuperUpvote = (args: Record<string, unknown>, username = "alice") =>
   env.resolvers.Mutation.undoSuperUpvote(null, args, asUser(username));
 
+const updateScratchpadEntryVisibility = (
+  args: Record<string, unknown>,
+  username = "bob"
+) =>
+  env.resolvers.Mutation.updateScratchpadEntryVisibility(null, args, asUser(username));
+
+// Seed a discussion that alice has already upvoted, so she can super upvote it.
+// bob is the discussion author / recipient.
+const seedUpvotedDiscussion = () =>
+  run(
+    `MATCH (alice:User { username: 'alice' })
+     CREATE (d:Discussion { id: 'discussion-1', title: 'Great idea', createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (alice)-[:UPVOTED_DISCUSSION]->(dc)`
+  );
+
 const baseArgs = {
   recipientUsername: "bob",
   text: "Thanks for the thoughtful comment!",
@@ -125,5 +141,102 @@ test("undoSuperUpvote throws when the user has not super-upvoted", async () => {
   await assert.rejects(
     undoSuperUpvote({ sourceType: "comment", sourceId: "comment-1" }),
     /not super upvoted/i
+  );
+});
+
+test("the scratchpad notification is linked to the entry so the recipient can act on it", async () => {
+  await createScratchpadEntry({ ...baseArgs });
+
+  const linked = await run(
+    `MATCH (:User { username: 'bob' })-[:HAS_NOTIFICATION]->(n:Notification)-[:NOTIFICATION_FOR_SCRATCHPAD_ENTRY]->(e:ScratchpadEntry)
+     RETURN n.notificationType AS type, n.read AS read, e.sourceId AS sourceId`
+  );
+
+  assert.equal(linked.length, 1, "notification should link to exactly one scratchpad entry");
+  assert.equal(linked[0].type, "scratchpad");
+  assert.equal(linked[0].read, false, "new notification should be unread");
+  assert.equal(linked[0].sourceId, "comment-1");
+});
+
+test("the scratchpad notification for a discussion links to the post", async () => {
+  await seedUpvotedDiscussion();
+
+  await createScratchpadEntry({
+    recipientUsername: "bob",
+    text: "Loved this discussion!",
+    sourceType: "discussion",
+    sourceId: "dc-1",
+    sourceChannelUniqueName: "cats",
+  });
+
+  const notifications = await run(
+    `MATCH (:User { username: 'bob' })-[:HAS_NOTIFICATION]->(n:Notification)
+     RETURN n.text AS text`
+  );
+
+  assert.equal(notifications.length, 1);
+  assert.match(
+    notifications[0].text,
+    /\/forums\/cats\/discussions\/discussion-1/,
+    "notification should contain a working link to the post"
+  );
+});
+
+test("createScratchpadEntry records the discussionId so the Kudos card can link to the post", async () => {
+  await seedUpvotedDiscussion();
+
+  await createScratchpadEntry({
+    recipientUsername: "bob",
+    text: "Loved this discussion!",
+    sourceType: "discussion",
+    sourceId: "dc-1",
+    sourceChannelUniqueName: "cats",
+  });
+
+  const entries = await run(
+    `MATCH (e:ScratchpadEntry { sourceId: 'dc-1' })
+     RETURN e.discussionId AS discussionId, e.sourceChannelUniqueName AS channel`
+  );
+
+  assert.equal(entries.length, 1);
+  // sourceId is the DiscussionChannel id; discussionId is the Discussion id used
+  // to build the route, so they must differ and discussionId must be resolved.
+  assert.equal(entries[0].discussionId, "discussion-1");
+  assert.equal(entries[0].channel, "cats");
+});
+
+test("updateScratchpadEntryVisibility lets the recipient show a note on their profile", async () => {
+  const created = await createScratchpadEntry({ ...baseArgs });
+
+  // Entry starts private (pending).
+  const before = await run(
+    `MATCH (e:ScratchpadEntry { id: $id }) RETURN e.isPublic AS isPublic`,
+    { id: created.id }
+  );
+  assert.equal(before[0].isPublic, false);
+
+  // The recipient (bob) makes it public ("show on profile").
+  await updateScratchpadEntryVisibility(
+    { scratchpadEntryId: created.id, isPublic: true },
+    "bob"
+  );
+
+  const after = await run(
+    `MATCH (e:ScratchpadEntry { id: $id }) RETURN e.isPublic AS isPublic`,
+    { id: created.id }
+  );
+  assert.equal(after[0].isPublic, true, "entry should be public after show-on-profile");
+});
+
+test("updateScratchpadEntryVisibility rejects anyone other than the recipient", async () => {
+  const created = await createScratchpadEntry({ ...baseArgs });
+
+  // alice is the author, not the recipient, so she cannot publish it.
+  await assert.rejects(
+    updateScratchpadEntryVisibility(
+      { scratchpadEntryId: created.id, isPublic: true },
+      "alice"
+    ),
+    /only the recipient/i
   );
 });

--- a/tests/integration/superUpvote.test.ts
+++ b/tests/integration/superUpvote.test.ts
@@ -28,7 +28,7 @@ beforeEach(async () => {
   await run(
     `CREATE (alice:User { username: 'alice' })
      CREATE (bob:User { username: 'bob' })
-     CREATE (c:Comment { id: 'comment-1', text: 'great point', isRootComment: true, createdAt: datetime() })
+     CREATE (c:Comment { id: 'comment-1', text: 'great point', isRootComment: true, weightedVotesCount: 0, createdAt: datetime() })
      CREATE (alice)-[:UPVOTED_COMMENT]->(c)`
   );
 });
@@ -57,9 +57,19 @@ const seedUpvotedDiscussion = () =>
   run(
     `MATCH (alice:User { username: 'alice' })
      CREATE (d:Discussion { id: 'discussion-1', title: 'Great idea', createdAt: datetime() })
-     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', weightedVotesCount: 0, createdAt: datetime() })
      CREATE (alice)-[:UPVOTED_DISCUSSION]->(dc)`
   );
+
+// Read the current weightedVotesCount (the visibility/ranking signal) for a
+// Comment or DiscussionChannel.
+const weightOf = async (label: "Comment" | "DiscussionChannel", id: string) => {
+  const rows = await run(
+    `MATCH (n:${label} { id: $id }) RETURN n.weightedVotesCount AS weight`,
+    { id }
+  );
+  return Number(rows[0]?.weight);
+};
 
 const baseArgs = {
   recipientUsername: "bob",
@@ -83,6 +93,9 @@ test("createScratchpadEntry writes an entry, super-upvotes, and notifies", async
      RETURN count(*) AS n`
   );
   assert.equal(Number(superUpvote[0].n), 1);
+
+  // The super upvote makes the comment more visible: weightedVotesCount 0 -> 1.
+  assert.equal(await weightOf("Comment", "comment-1"), 1, "comment weight 0 -> 1");
 
   const notifications = await run(
     `MATCH (b:User { username: 'bob' })-[:HAS_NOTIFICATION]->(n:Notification)
@@ -135,6 +148,56 @@ test("undoSuperUpvote removes the super-upvote and deletes the scratchpad entry"
     `MATCH (e:ScratchpadEntry { sourceId: 'comment-1' }) RETURN count(e) AS n`
   );
   assert.equal(Number(entries[0].n), 0, "scratchpad entry should be deleted");
+
+  // Undoing the super upvote reverses the visibility bump: weight 1 -> 0.
+  assert.equal(await weightOf("Comment", "comment-1"), 0, "comment weight back to 0");
+});
+
+test("super upvoting a discussion creates the relationship and makes it more visible", async () => {
+  await seedUpvotedDiscussion();
+
+  await createScratchpadEntry({
+    recipientUsername: "bob",
+    text: "Loved this discussion!",
+    sourceType: "discussion",
+    sourceId: "dc-1",
+    sourceChannelUniqueName: "cats",
+  });
+
+  const superUpvote = await run(
+    `MATCH (:User { username: 'alice' })-[:SUPER_UPVOTED_DISCUSSION]->(:DiscussionChannel { id: 'dc-1' })
+     RETURN count(*) AS n`
+  );
+  assert.equal(Number(superUpvote[0].n), 1, "SUPER_UPVOTED_DISCUSSION relationship created");
+
+  // The super upvote makes the discussion more visible: weightedVotesCount 0 -> 1.
+  assert.equal(await weightOf("DiscussionChannel", "dc-1"), 1, "discussion weight 0 -> 1");
+});
+
+test("undoSuperUpvote on a discussion removes the relationship, deletes the entry, and reverses the weight", async () => {
+  await seedUpvotedDiscussion();
+  await createScratchpadEntry({
+    recipientUsername: "bob",
+    text: "Loved this discussion!",
+    sourceType: "discussion",
+    sourceId: "dc-1",
+    sourceChannelUniqueName: "cats",
+  });
+
+  await undoSuperUpvote({ sourceType: "discussion", sourceId: "dc-1" });
+
+  const superUpvote = await run(
+    `MATCH (:User { username: 'alice' })-[:SUPER_UPVOTED_DISCUSSION]->(:DiscussionChannel { id: 'dc-1' })
+     RETURN count(*) AS n`
+  );
+  assert.equal(Number(superUpvote[0].n), 0, "super-upvote relationship should be removed");
+
+  const entries = await run(
+    `MATCH (e:ScratchpadEntry { sourceId: 'dc-1' }) RETURN count(e) AS n`
+  );
+  assert.equal(Number(entries[0].n), 0, "scratchpad entry should be deleted");
+
+  assert.equal(await weightOf("DiscussionChannel", "dc-1"), 0, "discussion weight back to 0");
 });
 
 test("undoSuperUpvote throws when the user has not super-upvoted", async () => {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -182,6 +182,10 @@ const typeDefinitions = gql`
     read: Boolean
     text: String
     notificationType: String # "feedback", "mention", "reply", "moderation", "scratchpad", etc.
+    # Set for "scratchpad" (super upvote) notifications so the recipient can act
+    # on the thank-you note (show on profile / ignore) straight from the bell.
+    ScratchpadEntry: ScratchpadEntry
+      @relationship(type: "NOTIFICATION_FOR_SCRATCHPAD_ENTRY", direction: OUT)
   }
 
   type Message {
@@ -311,8 +315,12 @@ const typeDefinitions = gql`
     text: String!
     isPublic: Boolean! @default(value: false)
     sourceType: String! # "comment" or "discussion"
-    sourceId: String!
+    sourceId: String! # DiscussionChannel id (discussion) or Comment id (comment)
     sourceChannelUniqueName: String
+    # The Discussion id the upvoted content belongs to, used to build a working
+    # link back to the post/comment from the recipient's Kudos page. (sourceId is
+    # the DiscussionChannel/Comment id, which the discussion route cannot use.)
+    discussionId: String
 
     # Relationships
     Author: User! @relationship(type: "WROTE_SCRATCHPAD_ENTRY", direction: IN)


### PR DESCRIPTION
## Summary
Backend half of the super-upvote feature/bugfix. Pairs with **gennit-project/multiforum-nuxt#172** — deploy together (frontend queries the new schema fields).

### Changes
- **In-transaction reads**: `createScratchpadEntry` / `undoSuperUpvote` now read the updated `SuperUpvotedByUsers` list **inside the same transaction** instead of a post-commit read on a fresh OGM session, which could lag behind the write and return a stale list (the cause of the frontend "button looks inactive" bug).
- **Notification ↔ entry link**: `Notification` gains a `NOTIFICATION_FOR_SCRATCHPAD_ENTRY` relationship; the notification is created in-transaction so the recipient can show-on-profile / ignore it straight from the bell. Notification text links to the upvoted **post** and the **Kudos page**.
- **`discussionId` on `ScratchpadEntry`**: stored so the recipient's Kudos card can link back to the post/comment (`sourceId` is the DiscussionChannel/Comment id, which the discussion route can't use). `updateScratchpadEntryVisibility` returns it too.

### Tests
- `tests/integration/superUpvote.test.ts` (testcontainers + Neo4j): notification↔entry link, post link, `discussionId` persistence, recipient-only show-on-profile. **12/12 pass** (Node 22).

> Note: generated files (`ogm_types.ts`, `src/generated/graphql.ts`) are gitignored — run `npm run codegen` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)