### PR TITLE
feat(super-upvotes): karma, atomicity, suspension, comment deep-links + tests

### DIFF
--- a/customResolvers/mutations/createScratchpadEntry.ts
+++ b/customResolvers/mutations/createScratchpadEntry.ts
@@ -28,7 +28,9 @@ type Args = {
 const MAX_TEXT_LENGTH = 500;
 
 const createScratchpadEntryResolver = (input: Input) => {
-  const { ScratchpadEntry, Comment, DiscussionChannel, User, driver } = input;
+  // ScratchpadEntry intentionally unused: the entry is created via Cypher inside
+  // the transaction (below) so it is atomic with the super-upvote/notification.
+  const { Comment, DiscussionChannel, User, driver } = input;
 
   return async (parent: unknown, args: Args, context: GraphQLContext, resolveInfo: GraphQLResolveInfo) => {
     const { recipientUsername, text, sourceType, sourceId, sourceChannelUniqueName } = args;
@@ -74,12 +76,15 @@ const createScratchpadEntryResolver = (input: Input) => {
       }
 
       // 2. Verify the logged-in user has already upvoted the source content.
-      //    Also capture where the content lives so the notification can link
-      //    directly to the upvoted post/comment.
+      //    Also capture where the content lives (to link the notification to the
+      //    upvoted post/comment) and who authored it (to award karma).
       let hasUpvoted = false;
       let hasSuperUpvoted = false;
       let postDiscussionId: string | null = null;
       let postChannelUniqueName: string | null = sourceChannelUniqueName || null;
+      // The content author, if it is a User (ModerationProfile authors get no
+      // karma, matching the normal upvote resolvers).
+      let postAuthorUsername: string | null = null;
 
       if (sourceType === 'comment') {
         const commentResult = await Comment.find({
@@ -89,6 +94,9 @@ const createScratchpadEntryResolver = (input: Input) => {
             UpvotedByUsers { username }
             SuperUpvotedByUsers { username }
             DiscussionChannel { discussionId channelUniqueName }
+            CommentAuthor {
+              ... on User { username }
+            }
           }`,
         });
 
@@ -102,6 +110,9 @@ const createScratchpadEntryResolver = (input: Input) => {
         postDiscussionId = comment.DiscussionChannel?.discussionId || null;
         postChannelUniqueName =
           comment.DiscussionChannel?.channelUniqueName || postChannelUniqueName;
+        const commentAuthor = comment.CommentAuthor;
+        postAuthorUsername =
+          commentAuthor && 'username' in commentAuthor ? commentAuthor.username : null;
       } else {
         // sourceType === 'discussion'
         const dcResult = await DiscussionChannel.find({
@@ -112,6 +123,7 @@ const createScratchpadEntryResolver = (input: Input) => {
             channelUniqueName
             UpvotedByUsers { username }
             SuperUpvotedByUsers { username }
+            Discussion { Author { username } }
           }`,
         });
 
@@ -124,6 +136,7 @@ const createScratchpadEntryResolver = (input: Input) => {
         hasSuperUpvoted = dc.SuperUpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
         postDiscussionId = dc.discussionId || null;
         postChannelUniqueName = dc.channelUniqueName || postChannelUniqueName;
+        postAuthorUsername = dc.Discussion?.Author?.username || null;
       }
 
       if (!hasUpvoted) {
@@ -134,64 +147,88 @@ const createScratchpadEntryResolver = (input: Input) => {
         throw new Error('You have already super upvoted this content');
       }
 
-      // 3. Create the ScratchpadEntry
-      const createEntryResult = await ScratchpadEntry.create({
-        input: [
-          {
-            text: text.trim(),
-            isPublic: false,
-            sourceType,
-            sourceId,
-            sourceChannelUniqueName:
-              sourceChannelUniqueName || postChannelUniqueName || null,
-            discussionId: postDiscussionId || null,
-            Author: {
-              connect: {
-                where: { node: { username: loggedInUsername } },
-              },
-            },
-            Recipient: {
-              connect: {
-                where: { node: { username: recipientUsername } },
-              },
-            },
-          },
-        ],
-      });
+      // 3. Create the ScratchpadEntry node + Author/Recipient relationships in
+      //    the transaction (not via OGM) so it is atomic with everything below.
+      const createEntryResult = await tx.run(
+        `MATCH (author:User { username: $loggedInUsername })
+         MATCH (recipient:User { username: $recipientUsername })
+         CREATE (author)-[:WROTE_SCRATCHPAD_ENTRY]->(e:ScratchpadEntry {
+           id: randomUUID(),
+           createdAt: datetime(),
+           text: $text,
+           isPublic: false,
+           sourceType: $sourceType,
+           sourceId: $sourceId,
+           sourceChannelUniqueName: $sourceChannelUniqueName,
+           discussionId: $discussionId
+         })
+         CREATE (recipient)-[:HAS_SCRATCHPAD_ENTRY]->(e)
+         RETURN e.id AS id, toString(e.createdAt) AS createdAt, e.text AS text,
+                e.isPublic AS isPublic, e.sourceType AS sourceType,
+                e.sourceId AS sourceId,
+                e.sourceChannelUniqueName AS sourceChannelUniqueName,
+                e.discussionId AS discussionId`,
+        {
+          loggedInUsername,
+          recipientUsername,
+          text: text.trim(),
+          sourceType,
+          sourceId,
+          sourceChannelUniqueName: sourceChannelUniqueName || postChannelUniqueName || null,
+          discussionId: postDiscussionId || null,
+        }
+      );
 
-      const createdEntry = createEntryResult.scratchpadEntries[0];
+      const entryRecord = createEntryResult.records[0];
+      if (!entryRecord) {
+        throw new Error('Failed to create scratchpad entry');
+      }
+      const entryId = entryRecord.get('id');
 
-      // 4. Create the SUPER_UPVOTED relationship
+      // 4. Create the SUPER_UPVOTED relationship and bump weightedVotesCount.
+      //    A super upvote is a second vote, so it adds the same +1 weight as a
+      //    normal upvote (the recipient already has the normal upvote's weight).
       if (sourceType === 'comment') {
-        const superUpvoteQuery = `
-          MATCH (c:Comment { id: $sourceId }), (u:User { username: $username })
-          CREATE (u)-[:SUPER_UPVOTED_COMMENT]->(c)
-          SET c.weightedVotesCount = coalesce(c.weightedVotesCount, 0) + 1
-          RETURN c
-        `;
-        await tx.run(superUpvoteQuery, { sourceId, username: loggedInUsername });
+        await tx.run(
+          `MATCH (c:Comment { id: $sourceId }), (u:User { username: $username })
+           CREATE (u)-[:SUPER_UPVOTED_COMMENT]->(c)
+           SET c.weightedVotesCount = coalesce(c.weightedVotesCount, 0) + 1`,
+          { sourceId, username: loggedInUsername }
+        );
       } else {
-        const superUpvoteQuery = `
-          MATCH (dc:DiscussionChannel { id: $sourceId }), (u:User { username: $username })
-          CREATE (u)-[:SUPER_UPVOTED_DISCUSSION]->(dc)
-          SET dc.weightedVotesCount = coalesce(dc.weightedVotesCount, 0) + 1
-          RETURN dc
-        `;
-        await tx.run(superUpvoteQuery, { sourceId, username: loggedInUsername });
+        await tx.run(
+          `MATCH (dc:DiscussionChannel { id: $sourceId }), (u:User { username: $username })
+           CREATE (u)-[:SUPER_UPVOTED_DISCUSSION]->(dc)
+           SET dc.weightedVotesCount = coalesce(dc.weightedVotesCount, 0) + 1`,
+          { sourceId, username: loggedInUsername }
+        );
       }
 
-      // 5. Notify the recipient. Build a working link to the upvoted content
-      //    plus a link to their Kudos page, and connect the notification to the
-      //    scratchpad entry so the recipient can show-on-profile / ignore it
-      //    straight from the notification. Created inside the transaction so the
-      //    notification is atomic with the super upvote.
+      // 5. Award karma to the content author, like a normal upvote does (a super
+      //    upvote is a second vote, so it grants a second karma point).
+      if (postAuthorUsername) {
+        const karmaField = sourceType === 'comment' ? 'commentKarma' : 'discussionKarma';
+        await tx.run(
+          `MATCH (a:User { username: $postAuthorUsername })
+           SET a.${karmaField} = coalesce(a.${karmaField}, 0) + 1`,
+          { postAuthorUsername }
+        );
+      }
+
+      // 6. Notify the recipient. Link to the upvoted content (the specific
+      //    comment if a comment was super upvoted, otherwise the discussion) and
+      //    to their Kudos page, and connect the notification to the scratchpad
+      //    entry so they can show-on-profile / ignore it from the bell.
       const truncatedText = text.length > 50 ? text.substring(0, 50) + '...' : text;
       const subject = sourceType === 'comment' ? 'comment' : 'post';
       const kudosUrl = `/u/${recipientUsername}/scratchpad`;
-      const postUrl =
-        postDiscussionId && postChannelUniqueName
-          ? `/forums/${postChannelUniqueName}/discussions/${postDiscussionId}`
-          : kudosUrl;
+      let postUrl = kudosUrl;
+      if (postDiscussionId && postChannelUniqueName) {
+        postUrl =
+          sourceType === 'comment'
+            ? `/forums/${postChannelUniqueName}/discussions/${postDiscussionId}/comments/${sourceId}`
+            : `/forums/${postChannelUniqueName}/discussions/${postDiscussionId}`;
+      }
       const notificationText =
         `[@${loggedInUsername}](/u/${loggedInUsername}) super upvoted your ` +
         `[${subject}](${postUrl}) with a thank-you note: "${truncatedText}" — ` +
@@ -211,16 +248,16 @@ const createScratchpadEntryResolver = (input: Input) => {
          RETURN n`,
         {
           recipientUsername,
-          entryId: createdEntry.id,
+          entryId,
           notificationText,
         }
       );
 
-      // Read the updated super-upvoter list inside the same transaction so it
-      // always reflects the relationship we just created. A post-commit read on
-      // a fresh OGM session can lag behind the write on a clustered database,
-      // returning a stale list that omits the actor — which left the frontend
-      // super-upvote button looking inactive (and un-undoable).
+      // 7. Read the updated super-upvoter list inside the same transaction so it
+      //    always reflects the relationship we just created. A post-commit read
+      //    on a fresh OGM session can lag behind the write on a clustered
+      //    database, returning a stale list that omits the actor — which left the
+      //    frontend super-upvote button looking inactive (and un-undoable).
       const readSuperUpvotersQuery =
         sourceType === 'comment'
           ? `MATCH (u:User)-[:SUPER_UPVOTED_COMMENT]->(:Comment { id: $sourceId })
@@ -235,14 +272,14 @@ const createScratchpadEntryResolver = (input: Input) => {
 
       // Return the created entry with author info and updated super upvoted users
       return {
-        id: createdEntry.id,
-        createdAt: createdEntry.createdAt,
-        text: createdEntry.text,
-        isPublic: createdEntry.isPublic,
-        sourceType: createdEntry.sourceType,
-        sourceId: createdEntry.sourceId,
-        sourceChannelUniqueName: createdEntry.sourceChannelUniqueName,
-        discussionId: createdEntry.discussionId,
+        id: entryId,
+        createdAt: entryRecord.get('createdAt'),
+        text: entryRecord.get('text'),
+        isPublic: entryRecord.get('isPublic'),
+        sourceType: entryRecord.get('sourceType'),
+        sourceId: entryRecord.get('sourceId'),
+        sourceChannelUniqueName: entryRecord.get('sourceChannelUniqueName'),
+        discussionId: entryRecord.get('discussionId'),
         Author: {
           username: loggedInUsername,
         },

--- a/customResolvers/mutations/undoSuperUpvote.ts
+++ b/customResolvers/mutations/undoSuperUpvote.ts
@@ -21,7 +21,9 @@ type Args = {
 };
 
 const undoSuperUpvoteResolver = (input: Input) => {
-  const { Comment, DiscussionChannel, ScratchpadEntry, driver } = input;
+  // ScratchpadEntry intentionally unused: the entry is deleted via Cypher inside
+  // the transaction (below) so it is atomic with the relationship/weight/karma.
+  const { Comment, DiscussionChannel, driver } = input;
 
   return async (parent: unknown, args: Args, context: GraphQLContext, resolveInfo: GraphQLResolveInfo) => {
     const { sourceType, sourceId } = args;
@@ -44,8 +46,10 @@ const undoSuperUpvoteResolver = (input: Input) => {
     const tx = session.beginTransaction();
 
     try {
-      // 1. Verify the user has super upvoted this content
+      // 1. Verify the user has super upvoted this content, and capture the
+      //    content author (a User) so we can reverse the karma we awarded.
       let hasSuperUpvoted = false;
+      let postAuthorUsername: string | null = null;
 
       if (sourceType === 'comment') {
         const commentResult = await Comment.find({
@@ -53,6 +57,9 @@ const undoSuperUpvoteResolver = (input: Input) => {
           selectionSet: `{
             id
             SuperUpvotedByUsers { username }
+            CommentAuthor {
+              ... on User { username }
+            }
           }`,
         });
 
@@ -62,6 +69,9 @@ const undoSuperUpvoteResolver = (input: Input) => {
 
         const comment = commentResult[0];
         hasSuperUpvoted = comment.SuperUpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
+        const commentAuthor = comment.CommentAuthor;
+        postAuthorUsername =
+          commentAuthor && 'username' in commentAuthor ? commentAuthor.username : null;
       } else {
         // sourceType === 'discussion'
         const dcResult = await DiscussionChannel.find({
@@ -69,6 +79,7 @@ const undoSuperUpvoteResolver = (input: Input) => {
           selectionSet: `{
             id
             SuperUpvotedByUsers { username }
+            Discussion { Author { username } }
           }`,
         });
 
@@ -78,43 +89,51 @@ const undoSuperUpvoteResolver = (input: Input) => {
 
         const dc = dcResult[0];
         hasSuperUpvoted = dc.SuperUpvotedByUsers?.some((u: { username: string }) => u.username === loggedInUsername) || false;
+        postAuthorUsername = dc.Discussion?.Author?.username || null;
       }
 
       if (!hasSuperUpvoted) {
         throw new Error('You have not super upvoted this content');
       }
 
-      // 2. Remove the SUPER_UPVOTED relationship
+      // 2. Remove the SUPER_UPVOTED relationship and reverse the weight.
       if (sourceType === 'comment') {
-        const undoSuperUpvoteQuery = `
-          MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_COMMENT]->(c:Comment { id: $sourceId })
-          DELETE r
-          SET c.weightedVotesCount = coalesce(c.weightedVotesCount, 1) - 1
-          RETURN c
-        `;
-        await tx.run(undoSuperUpvoteQuery, { sourceId, username: loggedInUsername });
+        await tx.run(
+          `MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_COMMENT]->(c:Comment { id: $sourceId })
+           DELETE r
+           SET c.weightedVotesCount = coalesce(c.weightedVotesCount, 1) - 1`,
+          { sourceId, username: loggedInUsername }
+        );
       } else {
-        const undoSuperUpvoteQuery = `
-          MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_DISCUSSION]->(dc:DiscussionChannel { id: $sourceId })
-          DELETE r
-          SET dc.weightedVotesCount = coalesce(dc.weightedVotesCount, 1) - 1
-          RETURN dc
-        `;
-        await tx.run(undoSuperUpvoteQuery, { sourceId, username: loggedInUsername });
+        await tx.run(
+          `MATCH (u:User { username: $username })-[r:SUPER_UPVOTED_DISCUSSION]->(dc:DiscussionChannel { id: $sourceId })
+           DELETE r
+           SET dc.weightedVotesCount = coalesce(dc.weightedVotesCount, 1) - 1`,
+          { sourceId, username: loggedInUsername }
+        );
       }
 
-      // 3. Delete the associated scratchpad entry
-      await ScratchpadEntry.delete({
-        where: {
-          sourceType,
-          sourceId,
-          Author: { username: loggedInUsername },
-        },
-      });
+      // 3. Reverse the karma the super upvote awarded to the content author.
+      if (postAuthorUsername) {
+        const karmaField = sourceType === 'comment' ? 'commentKarma' : 'discussionKarma';
+        await tx.run(
+          `MATCH (a:User { username: $postAuthorUsername })
+           SET a.${karmaField} = coalesce(a.${karmaField}, 0) - 1`,
+          { postAuthorUsername }
+        );
+      }
 
-      // Read the updated super-upvoter list inside the same transaction so it
-      // reflects the relationship we just deleted. A post-commit read on a fresh
-      // OGM session can lag behind the write on a clustered database.
+      // 4. Delete the associated scratchpad entry (in the transaction, so it is
+      //    atomic with the relationship/weight/karma changes above).
+      await tx.run(
+        `MATCH (:User { username: $username })-[:WROTE_SCRATCHPAD_ENTRY]->(e:ScratchpadEntry { sourceType: $sourceType, sourceId: $sourceId })
+         DETACH DELETE e`,
+        { username: loggedInUsername, sourceType, sourceId }
+      );
+
+      // 5. Read the updated super-upvoter list inside the same transaction so it
+      //    reflects the relationship we just deleted. A post-commit read on a
+      //    fresh OGM session can lag behind the write on a clustered database.
       const readSuperUpvotersQuery =
         sourceType === 'comment'
           ? `MATCH (u:User)-[:SUPER_UPVOTED_COMMENT]->(:Comment { id: $sourceId })

--- a/permissions.ts
+++ b/permissions.ts
@@ -27,6 +27,7 @@ const {
   canUploadFile,
   canUpvoteComment,
   canUpvoteDiscussion,
+  canSuperUpvote,
   issueIsValid,
   createChannelInputIsValid,
   updateChannelInputIsValid,
@@ -213,8 +214,8 @@ const permissionList = shield({
       // Any user who can upvote a discussion can undo their upvote. The undo upvote resolver
       // checks if the user has upvoted the discussion and if so, removes the upvote.
 
-      createScratchpadEntry: and(isAuthenticated, allow), // Super upvote - any authenticated user can send a thank-you note
-      undoSuperUpvote: and(isAuthenticated, allow), // Undo super upvote - any authenticated user can undo their super upvote
+      createScratchpadEntry: and(isAuthenticated, canSuperUpvote), // Super upvote requires the same channel permission as a normal upvote (blocks suspended users)
+      undoSuperUpvote: and(isAuthenticated, canSuperUpvote), // Reuse the same rule for undoing a super upvote
       
       createIssue: and(isAuthenticated, issueIsValid),
       createIssues: and(isAuthenticated, issueIsValid),

--- a/rules/definitions/votingRules.ts
+++ b/rules/definitions/votingRules.ts
@@ -67,6 +67,78 @@ export const canUpvoteComment = rule({ cache: "contextual" })(
   }
 );
 
+type CanSuperUpvoteArgs = {
+  sourceType: "comment" | "discussion";
+  sourceId: string;
+  sourceChannelUniqueName?: string;
+};
+
+// Super upvoting is a second vote, so it requires the same channel permission as
+// a normal upvote (this blocks suspended users from super upvoting). The mutation
+// handles both comments and discussions, so resolve the channel + permission from
+// the source type. Reused for undoSuperUpvote, which sends the same args.
+export const canSuperUpvote = rule({ cache: "contextual" })(
+  async (parent: unknown, args: CanSuperUpvoteArgs, ctx: GraphQLContext, info: GraphQLResolveInfo) => {
+    const { sourceType, sourceId, sourceChannelUniqueName } = args;
+
+    if (!sourceType || !sourceId) {
+      throw new Error("sourceType and sourceId are required");
+    }
+
+    let channelName = sourceChannelUniqueName;
+    let permission: "canUpvoteComment" | "canUpvoteDiscussion";
+
+    if (sourceType === "comment") {
+      permission = "canUpvoteComment";
+      if (!channelName) {
+        const CommentModel = ctx.ogm.model("Comment");
+        const commentData = await CommentModel.find({
+          where: { id: sourceId },
+          selectionSet: `{
+            DiscussionChannel { channelUniqueName }
+            Channel { uniqueName }
+          }`,
+        });
+        channelName =
+          commentData?.[0]?.DiscussionChannel?.channelUniqueName ||
+          commentData?.[0]?.Channel?.uniqueName;
+      }
+    } else if (sourceType === "discussion") {
+      permission = "canUpvoteDiscussion";
+      if (!channelName) {
+        const DiscussionChannelModel = ctx.ogm.model("DiscussionChannel");
+        const dcData = await DiscussionChannelModel.find({
+          where: { id: sourceId },
+          selectionSet: `{ channelUniqueName }`,
+        });
+        channelName = dcData?.[0]?.channelUniqueName;
+      }
+    } else {
+      throw new Error('sourceType must be "comment" or "discussion"');
+    }
+
+    if (!channelName) {
+      throw new Error("No channel found.");
+    }
+
+    const permissionResult = await hasChannelPermission({
+      permission,
+      channelName,
+      context: ctx,
+    });
+
+    if (!permissionResult) {
+      throw new Error(ERROR_MESSAGES.channel.noChannelPermission);
+    }
+
+    if (permissionResult instanceof Error) {
+      return permissionResult;
+    }
+
+    return true;
+  }
+);
+
 type CanUpvoteDiscussionChannelArgs = {
   discussionChannelId: string;
   username: string;

--- a/rules/permission/hasChannelPermission.test.ts
+++ b/rules/permission/hasChannelPermission.test.ts
@@ -64,6 +64,36 @@ test("a suspended user is governed by the suspended role", () => {
   assert.deepEqual(r.role, { [PERM]: false });
 });
 
+// Super upvoting requires the same channel permission as normal voting
+// (createScratchpadEntry/undoSuperUpvote are gated by canSuperUpvote, which calls
+// hasChannelPermission with these keys). So a suspended user — governed by the
+// suspended role, which denies voting — cannot super upvote, while a normal user
+// can. Guards against the super-upvote permission silently diverging from voting.
+for (const votePermission of ["canUpvoteComment", "canUpvoteDiscussion"] as const) {
+  test(`super upvoting is blocked for a suspended user (${votePermission})`, () => {
+    const suspended = evaluateChannelRolePermission({
+      permission: votePermission,
+      channelData: {
+        DefaultChannelRole: { [votePermission]: true },
+        SuspendedRole: { [votePermission]: false },
+      },
+      serverDefaults: undefined,
+      isSuspended: true,
+    });
+    assert.equal(suspended.allowed, false);
+  });
+
+  test(`super upvoting is allowed for a non-suspended user (${votePermission})`, () => {
+    const normal = evaluateChannelRolePermission({
+      permission: votePermission,
+      channelData: { DefaultChannelRole: { [votePermission]: true } },
+      serverDefaults: undefined,
+      isSuspended: false,
+    });
+    assert.equal(normal.allowed, true);
+  });
+}
+
 test("falls back to the server default role when the channel defines none", () => {
   const normal = evalPerm({
     channelData: {},

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -74,7 +74,7 @@ import {
   canDeleteWikiPages,
   canEditWikiHomePage,
 } from "./definitions/wikiRules.js";
-import { canUpvoteComment, canUpvoteDiscussion } from "./definitions/votingRules.js";
+import { canUpvoteComment, canUpvoteDiscussion, canSuperUpvote } from "./definitions/votingRules.js";
 import {
   isRoot,
   canUploadFile,
@@ -152,6 +152,7 @@ const ruleList = {
   canUploadFile,
   canUpvoteComment,
   canUpvoteDiscussion,
+  canSuperUpvote,
   canGiveFeedback,
   canReportContent,
   canReportServerContent,

--- a/tests/integration/superUpvote.test.ts
+++ b/tests/integration/superUpvote.test.ts
@@ -24,12 +24,21 @@ after(async () => {
 
 beforeEach(async () => {
   await resetDb();
-  // alice (actor) has upvoted comment-1; bob is the comment author / recipient.
+  // bob authored both comment-1 (inside dc-1) and discussion-1; alice (the actor)
+  // has already upvoted both, so she may super upvote them. Weights/karma start
+  // at 0 so the +1 / -1 effects are unambiguous.
   await run(
     `CREATE (alice:User { username: 'alice' })
-     CREATE (bob:User { username: 'bob' })
+     CREATE (bob:User { username: 'bob', commentKarma: 0, discussionKarma: 0 })
+     CREATE (d:Discussion { id: 'discussion-1', title: 'Great idea', createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', weightedVotesCount: 0, createdAt: datetime() })
      CREATE (c:Comment { id: 'comment-1', text: 'great point', isRootComment: true, weightedVotesCount: 0, createdAt: datetime() })
-     CREATE (alice)-[:UPVOTED_COMMENT]->(c)`
+     CREATE (bob)-[:POSTED_DISCUSSION]->(d)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(d)
+     CREATE (bob)-[:AUTHORED_COMMENT]->(c)
+     CREATE (dc)-[:CONTAINS_COMMENT]->(c)
+     CREATE (alice)-[:UPVOTED_COMMENT]->(c)
+     CREATE (alice)-[:UPVOTED_DISCUSSION]->(dc)`
   );
 });
 
@@ -51,16 +60,6 @@ const updateScratchpadEntryVisibility = (
 ) =>
   env.resolvers.Mutation.updateScratchpadEntryVisibility(null, args, asUser(username));
 
-// Seed a discussion that alice has already upvoted, so she can super upvote it.
-// bob is the discussion author / recipient.
-const seedUpvotedDiscussion = () =>
-  run(
-    `MATCH (alice:User { username: 'alice' })
-     CREATE (d:Discussion { id: 'discussion-1', title: 'Great idea', createdAt: datetime() })
-     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', weightedVotesCount: 0, createdAt: datetime() })
-     CREATE (alice)-[:UPVOTED_DISCUSSION]->(dc)`
-  );
-
 // Read the current weightedVotesCount (the visibility/ranking signal) for a
 // Comment or DiscussionChannel.
 const weightOf = async (label: "Comment" | "DiscussionChannel", id: string) => {
@@ -71,11 +70,28 @@ const weightOf = async (label: "Comment" | "DiscussionChannel", id: string) => {
   return Number(rows[0]?.weight);
 };
 
+// Read a user's karma for the relevant content type.
+const karmaOf = async (username: string, field: "commentKarma" | "discussionKarma") => {
+  const rows = await run(
+    `MATCH (u:User { username: $username }) RETURN u.${field} AS karma`,
+    { username }
+  );
+  return Number(rows[0]?.karma);
+};
+
 const baseArgs = {
   recipientUsername: "bob",
   text: "Thanks for the thoughtful comment!",
   sourceType: "comment",
   sourceId: "comment-1",
+};
+
+const discussionArgs = {
+  recipientUsername: "bob",
+  text: "Loved this discussion!",
+  sourceType: "discussion",
+  sourceId: "dc-1",
+  sourceChannelUniqueName: "cats",
 };
 
 test("createScratchpadEntry writes an entry, super-upvotes, and notifies", async () => {
@@ -154,15 +170,7 @@ test("undoSuperUpvote removes the super-upvote and deletes the scratchpad entry"
 });
 
 test("super upvoting a discussion creates the relationship and makes it more visible", async () => {
-  await seedUpvotedDiscussion();
-
-  await createScratchpadEntry({
-    recipientUsername: "bob",
-    text: "Loved this discussion!",
-    sourceType: "discussion",
-    sourceId: "dc-1",
-    sourceChannelUniqueName: "cats",
-  });
+  await createScratchpadEntry({ ...discussionArgs });
 
   const superUpvote = await run(
     `MATCH (:User { username: 'alice' })-[:SUPER_UPVOTED_DISCUSSION]->(:DiscussionChannel { id: 'dc-1' })
@@ -175,14 +183,7 @@ test("super upvoting a discussion creates the relationship and makes it more vis
 });
 
 test("undoSuperUpvote on a discussion removes the relationship, deletes the entry, and reverses the weight", async () => {
-  await seedUpvotedDiscussion();
-  await createScratchpadEntry({
-    recipientUsername: "bob",
-    text: "Loved this discussion!",
-    sourceType: "discussion",
-    sourceId: "dc-1",
-    sourceChannelUniqueName: "cats",
-  });
+  await createScratchpadEntry({ ...discussionArgs });
 
   await undoSuperUpvote({ sourceType: "discussion", sourceId: "dc-1" });
 
@@ -222,15 +223,7 @@ test("the scratchpad notification is linked to the entry so the recipient can ac
 });
 
 test("the scratchpad notification for a discussion links to the post", async () => {
-  await seedUpvotedDiscussion();
-
-  await createScratchpadEntry({
-    recipientUsername: "bob",
-    text: "Loved this discussion!",
-    sourceType: "discussion",
-    sourceId: "dc-1",
-    sourceChannelUniqueName: "cats",
-  });
+  await createScratchpadEntry({ ...discussionArgs });
 
   const notifications = await run(
     `MATCH (:User { username: 'bob' })-[:HAS_NOTIFICATION]->(n:Notification)
@@ -246,15 +239,7 @@ test("the scratchpad notification for a discussion links to the post", async () 
 });
 
 test("createScratchpadEntry records the discussionId so the Kudos card can link to the post", async () => {
-  await seedUpvotedDiscussion();
-
-  await createScratchpadEntry({
-    recipientUsername: "bob",
-    text: "Loved this discussion!",
-    sourceType: "discussion",
-    sourceId: "dc-1",
-    sourceChannelUniqueName: "cats",
-  });
+  await createScratchpadEntry({ ...discussionArgs });
 
   const entries = await run(
     `MATCH (e:ScratchpadEntry { sourceId: 'dc-1' })
@@ -302,4 +287,66 @@ test("updateScratchpadEntryVisibility rejects anyone other than the recipient", 
     ),
     /only the recipient/i
   );
+});
+
+// --- karma (a super upvote is a second vote, so it grants a second karma point) ---
+
+test("super upvoting a comment awards the author commentKarma", async () => {
+  await createScratchpadEntry({ ...baseArgs });
+  assert.equal(await karmaOf("bob", "commentKarma"), 1, "comment author karma 0 -> 1");
+});
+
+test("undoing a super upvote on a comment reverses the author's commentKarma", async () => {
+  await createScratchpadEntry({ ...baseArgs });
+  await undoSuperUpvote({ sourceType: "comment", sourceId: "comment-1" });
+  assert.equal(await karmaOf("bob", "commentKarma"), 0, "comment author karma back to 0");
+});
+
+test("super upvoting a discussion awards the author discussionKarma", async () => {
+  await createScratchpadEntry({ ...discussionArgs });
+  assert.equal(await karmaOf("bob", "discussionKarma"), 1, "discussion author karma 0 -> 1");
+});
+
+test("undoing a super upvote on a discussion reverses the author's discussionKarma", async () => {
+  await createScratchpadEntry({ ...discussionArgs });
+  await undoSuperUpvote({ sourceType: "discussion", sourceId: "dc-1" });
+  assert.equal(await karmaOf("bob", "discussionKarma"), 0, "discussion author karma back to 0");
+});
+
+// --- notification deep-links to the upvoted content ---
+
+test("the scratchpad notification for a comment links to the comment", async () => {
+  await createScratchpadEntry({ ...baseArgs });
+
+  const notifications = await run(
+    `MATCH (:User { username: 'bob' })-[:HAS_NOTIFICATION]->(n:Notification)
+     RETURN n.text AS text`
+  );
+
+  assert.equal(notifications.length, 1);
+  assert.match(
+    notifications[0].text,
+    /\/forums\/cats\/discussions\/discussion-1\/comments\/comment-1/,
+    "comment notification should link to the comment permalink"
+  );
+});
+
+// --- ranking: a super upvote makes content rank higher by weightedVotesCount ---
+
+test("a super upvoted discussion ranks above one with fewer votes", async () => {
+  // dc-2 lives in the same channel but is not super upvoted.
+  await run(
+    `CREATE (d2:Discussion { id: 'discussion-2', title: 'Other', createdAt: datetime() })
+     CREATE (dc2:DiscussionChannel { id: 'dc-2', discussionId: 'discussion-2', channelUniqueName: 'cats', weightedVotesCount: 0, createdAt: datetime() })`
+  );
+
+  await createScratchpadEntry({ ...discussionArgs });
+
+  const ranked = await run(
+    `MATCH (dc:DiscussionChannel { channelUniqueName: 'cats' })
+     RETURN dc.id AS id
+     ORDER BY dc.weightedVotesCount DESC`
+  );
+
+  assert.equal(ranked[0].id, "dc-1", "the super upvoted discussion ranks first");
 });


### PR DESCRIPTION
Follow-ups to the merged super-upvote feature (backend half). Pairs with **gennit-project/multiforum-nuxt#feat/super-upvote-followups** — deploy together.

## Changes
- **Karma**: a super upvote now awards the content author karma (`commentKarma` / `discussionKarma`), and undo reverses it — a super upvote is a second vote, so it grants a second karma point (ModerationProfile authors get none, matching normal upvotes). Weight stays **+1** (the second vote already doubles weight).
- **Comment notifications** deep-link to the comment permalink (`/forums/<ch>/discussions/<discussionId>/comments/<commentId>`); discussions still link to the discussion.
- **Suspension**: `createScratchpadEntry` / `undoSuperUpvote` now require `canSuperUpvote`, which resolves the channel from `sourceType`/`sourceId` and checks the same `hasChannelPermission` (`canUpvoteComment` / `canUpvoteDiscussion`) used for normal voting — so a user suspended in the channel can no longer super upvote.
- **Atomicity**: both resolvers do all writes (entry create/delete, super-upvote relationship, weight, karma, notification) in a single transaction; the entry is created/deleted via Cypher instead of a separate auto-committed OGM session.

## Tests
- `tests/integration/superUpvote.test.ts` (20): karma both content types (+ undo), comment-notification deep-link, ranking (a super-upvoted discussion sorts above one with fewer weighted votes), plus existing lifecycle coverage.
- `rules/permission/hasChannelPermission.test.ts`: suspended users are denied the upvote permissions super upvote requires; non-suspended users allowed.
- Verified locally on Node 22 (testcontainers + Docker): integration + unit green; `tsc` + ESLint clean.

> Generated files (`ogm_types.ts`, `src/generated/graphql.ts`) are gitignored — run `npm run codegen` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)