### PR TITLE
feat: server health dashboard + notification type fix

### DIFF
--- a/customResolvers/mutations/lockChannel.ts
+++ b/customResolvers/mutations/lockChannel.ts
@@ -267,7 +267,8 @@ const getResolver = (input: Input) => {
               id: randomUUID(),
               createdAt: datetime(),
               read: false,
-              text: $notificationText
+              text: $notificationText,
+              notificationType: 'moderation'
             })
             CREATE (user)-[:HAS_NOTIFICATION]->(notification)
             RETURN count(notification) as notificationsCreated

--- a/customResolvers/mutations/unlockChannel.ts
+++ b/customResolvers/mutations/unlockChannel.ts
@@ -217,7 +217,8 @@ const getResolver = (input: Input) => {
               id: randomUUID(),
               createdAt: datetime(),
               read: false,
-              text: $notificationText
+              text: $notificationText,
+              notificationType: 'moderation'
             })
             CREATE (user)-[:HAS_NOTIFICATION]->(notification)
             RETURN count(notification) as notificationsCreated

--- a/customResolvers/mutations/updateEventInSeries.ts
+++ b/customResolvers/mutations/updateEventInSeries.ts
@@ -369,7 +369,8 @@ const getResolver = (input: Input) => {
                 id: randomUUID(),
                 createdAt: datetime(),
                 read: false,
-                text: $notificationText
+                text: $notificationText,
+                notificationType: 'event'
               })
               CREATE (user)-[:HAS_NOTIFICATION]->(notification)
               `,

--- a/customResolvers/mutations/updateEventWithChannelConnections.ts
+++ b/customResolvers/mutations/updateEventWithChannelConnections.ts
@@ -208,7 +208,8 @@ const getResolver = (input: Input) => {
               id: randomUUID(),
               createdAt: datetime(),
               read: false,
-              text: $notificationText
+              text: $notificationText,
+              notificationType: 'event'
             })
             CREATE (user)-[:HAS_NOTIFICATION]->(notification)
             `,

--- a/customResolvers/queries/getServerHealthDashboard.ts
+++ b/customResolvers/queries/getServerHealthDashboard.ts
@@ -47,6 +47,8 @@ type AttentionItem = {
 
 const DEFAULT_RANGE_DAYS = 30;
 const DEFAULT_CHANNEL_LIMIT = 25;
+const SERVER_SCOPED_ISSUE_WHERE =
+  "(coalesce(issue.flaggedServerRuleViolation, false) = true OR issue.channelUniqueName IS NULL)";
 
 const toNumber = (value: unknown): number => {
   if (neo4j.isInt(value)) return value.toNumber();
@@ -274,6 +276,7 @@ const channelHealthQuery = `
   CALL {
     WITH c, startDate, endDate
     MATCH (c)-[:HAS_ISSUE]->(issue:Issue)
+    WHERE ${SERVER_SCOPED_ISSUE_WHERE}
     RETURN count(DISTINCT CASE WHEN coalesce(issue.isOpen, false) THEN issue END) AS openIssueCount,
            count(DISTINCT CASE WHEN date(datetime(issue.createdAt)) >= startDate AND date(datetime(issue.createdAt)) <= endDate THEN issue END) AS issueOpenedCount,
            max(CASE WHEN coalesce(issue.isOpen, false) THEN duration.between(date(datetime(issue.createdAt)), date()).days ELSE null END) AS oldestOpenIssueAgeDays
@@ -281,8 +284,9 @@ const channelHealthQuery = `
 
   CALL {
     WITH c, startDate, endDate
-    MATCH (c)-[:HAS_ISSUE]->(:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
+    MATCH (c)-[:HAS_ISSUE]->(issue:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
     WHERE date(datetime(action.createdAt)) >= startDate AND date(datetime(action.createdAt)) <= endDate
+      AND ${SERVER_SCOPED_ISSUE_WHERE}
     RETURN count(DISTINCT action) AS moderationActionCount
   }
 
@@ -385,6 +389,7 @@ const timeSeriesQuery = `
       MATCH (issue:Issue)
       WHERE date(datetime(issue.createdAt)) = day
         AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+        AND ${SERVER_SCOPED_ISSUE_WHERE}
       RETURN count(DISTINCT issue) AS issuesOpened
     }
     CALL {
@@ -392,6 +397,7 @@ const timeSeriesQuery = `
       MATCH (issue:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
       WHERE date(datetime(action.createdAt)) = day
         AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+        AND ${SERVER_SCOPED_ISSUE_WHERE}
       RETURN count(DISTINCT action) AS moderationActions
     }
 
@@ -416,6 +422,7 @@ const issueSummaryQuery = `
   WHERE date(datetime(issue.createdAt)) >= startDate
     AND date(datetime(issue.createdAt)) <= endDate
     AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+    AND ${SERVER_SCOPED_ISSUE_WHERE}
   OPTIONAL MATCH (issue)-[:ACTIVITY_ON_ISSUE]->(closeAction:ModerationAction)
   WHERE toLower(coalesce(closeAction.actionType, "")) CONTAINS "close"
   WITH issue, count(closeAction) AS closeActions
@@ -428,6 +435,7 @@ const openIssueSummaryQuery = `
   MATCH (issue:Issue)
   WHERE coalesce(issue.isOpen, false) = true
     AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+    AND ${SERVER_SCOPED_ISSUE_WHERE}
   RETURN count(DISTINCT issue) AS totalOpenIssueCount,
          collect(duration.between(date(datetime(issue.createdAt)), date()).days) AS openIssueAges
 `;
@@ -440,6 +448,7 @@ const moderationActionTotalQuery = `
   WHERE date(datetime(action.createdAt)) >= startDate
     AND date(datetime(action.createdAt)) <= endDate
     AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+    AND ${SERVER_SCOPED_ISSUE_WHERE}
   RETURN count(DISTINCT action) AS totalModerationActionCount
 `;
 

--- a/customResolvers/queries/getServerHealthDashboard.ts
+++ b/customResolvers/queries/getServerHealthDashboard.ts
@@ -279,7 +279,7 @@ const channelHealthQuery = `
     WHERE ${SERVER_SCOPED_ISSUE_WHERE}
     RETURN count(DISTINCT CASE WHEN coalesce(issue.isOpen, false) THEN issue END) AS openIssueCount,
            count(DISTINCT CASE WHEN date(datetime(issue.createdAt)) >= startDate AND date(datetime(issue.createdAt)) <= endDate THEN issue END) AS issueOpenedCount,
-           max(CASE WHEN coalesce(issue.isOpen, false) THEN duration.between(date(datetime(issue.createdAt)), date()).days ELSE null END) AS oldestOpenIssueAgeDays
+           max(CASE WHEN coalesce(issue.isOpen, false) THEN duration.inDays(date(datetime(issue.createdAt)), date()).days ELSE null END) AS oldestOpenIssueAgeDays
   }
 
   CALL {
@@ -333,7 +333,7 @@ const timeSeriesQuery = `
        $channelUniqueNames AS channelUniqueNames
   CALL {
     WITH startDate, endDate, channelUniqueNames
-    UNWIND range(0, duration.between(startDate, endDate).days) AS offset
+    UNWIND range(0, duration.inDays(startDate, endDate).days) AS offset
     WITH startDate + duration({days: offset}) AS day, channelUniqueNames
 
     CALL {
@@ -437,7 +437,7 @@ const openIssueSummaryQuery = `
     AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
     AND ${SERVER_SCOPED_ISSUE_WHERE}
   RETURN count(DISTINCT issue) AS totalOpenIssueCount,
-         collect(duration.between(date(datetime(issue.createdAt)), date()).days) AS openIssueAges
+         collect(duration.inDays(date(datetime(issue.createdAt)), date()).days) AS openIssueAges
 `;
 
 const moderationActionTotalQuery = `

--- a/customResolvers/queries/getServerHealthDashboard.ts
+++ b/customResolvers/queries/getServerHealthDashboard.ts
@@ -1,0 +1,567 @@
+import { DateTime } from "luxon";
+import neo4j, { type Driver } from "neo4j-driver";
+import { logger } from "../../logger.js";
+import type { QueryResult, Session } from "neo4j-driver";
+
+type Input = {
+  driver: Driver;
+};
+
+type Args = {
+  startDate?: string | null;
+  endDate?: string | null;
+  channelUniqueNames?: string[] | null;
+  limit?: number | null;
+};
+
+type ChannelHealthRow = {
+  channelUniqueName: string;
+  displayName: string | null;
+  channelIconURL: string | null;
+  discussionCount: number;
+  commentCount: number;
+  eventCount: number;
+  downloadCount: number;
+  voteCount: number;
+  uniqueContributorCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  moderationActionCount: number;
+  archivedContentCount: number;
+  lockedContentCount: number;
+  oldestOpenIssueAgeDays: number | null;
+  issuesPerHundredContributions: number;
+  activityScore: number;
+  healthLabel: string;
+};
+
+type AttentionItem = {
+  severity: "INFO" | "WARNING" | "CRITICAL";
+  title: string;
+  description: string;
+  channelUniqueName?: string | null;
+  issueNumber?: number | null;
+  metric?: string | null;
+  value?: number | null;
+};
+
+const DEFAULT_RANGE_DAYS = 30;
+const DEFAULT_CHANNEL_LIMIT = 25;
+
+const toNumber = (value: unknown): number => {
+  if (neo4j.isInt(value)) return value.toNumber();
+  if (typeof value === "number") return value;
+  if (value == null) return 0;
+  return Number(value);
+};
+
+const toNullableNumber = (value: unknown): number | null => {
+  if (value == null) return null;
+  return toNumber(value);
+};
+
+const sanitize = (value: unknown): unknown => {
+  if (neo4j.isInt(value)) return value.toNumber();
+  if (Array.isArray(value)) return value.map(sanitize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitize(entry)])
+    );
+  }
+  return value;
+};
+
+const parseDateArg = (value: string | null | undefined, fallback: DateTime) => {
+  if (!value) return fallback;
+  const parsed = DateTime.fromISO(value, { zone: "utc" });
+  return parsed.isValid ? parsed : fallback;
+};
+
+const getHealthLabel = (row: Omit<ChannelHealthRow, "healthLabel">): string => {
+  if ((row.oldestOpenIssueAgeDays || 0) >= 14 || row.openIssueCount >= 10) {
+    return "Needs review";
+  }
+  if (row.issuesPerHundredContributions >= 20 && row.issueOpenedCount >= 3) {
+    return "High moderation load";
+  }
+  if (row.activityScore === 0) {
+    return "Quiet";
+  }
+  if (row.activityScore >= 20 && row.issuesPerHundredContributions < 5) {
+    return "Healthy activity";
+  }
+  return "Active";
+};
+
+const buildAttentionItems = (rows: ChannelHealthRow[]): AttentionItem[] => {
+  const staleIssueItems = rows
+    .filter((row) => (row.oldestOpenIssueAgeDays || 0) >= 7)
+    .sort((a, b) => (b.oldestOpenIssueAgeDays || 0) - (a.oldestOpenIssueAgeDays || 0))
+    .slice(0, 5)
+    .map((row) => ({
+      severity: (row.oldestOpenIssueAgeDays || 0) >= 30 ? "CRITICAL" as const : "WARNING" as const,
+      title: "Stale open issues",
+      description: `${row.channelUniqueName} has ${row.openIssueCount} open issue${row.openIssueCount === 1 ? "" : "s"}; oldest is ${row.oldestOpenIssueAgeDays} day${row.oldestOpenIssueAgeDays === 1 ? "" : "s"} old.`,
+      channelUniqueName: row.channelUniqueName,
+      metric: "oldestOpenIssueAgeDays",
+      value: row.oldestOpenIssueAgeDays,
+    }));
+
+  const highPressureItems = rows
+    .filter((row) => row.issueOpenedCount >= 3 && row.issuesPerHundredContributions >= 20)
+    .sort((a, b) => b.issuesPerHundredContributions - a.issuesPerHundredContributions)
+    .slice(0, 5)
+    .map((row) => ({
+      severity: "WARNING" as const,
+      title: "High issue pressure",
+      description: `${row.channelUniqueName} opened ${row.issuesPerHundredContributions.toFixed(1)} issues per 100 contributions in this period.`,
+      channelUniqueName: row.channelUniqueName,
+      metric: "issuesPerHundredContributions",
+      value: row.issuesPerHundredContributions,
+    }));
+
+  const underRespondedItems = rows
+    .filter((row) => row.openIssueCount >= 3 && row.moderationActionCount === 0)
+    .sort((a, b) => b.openIssueCount - a.openIssueCount)
+    .slice(0, 5)
+    .map((row) => ({
+      severity: "WARNING" as const,
+      title: "Open issues without recent mod activity",
+      description: `${row.channelUniqueName} has ${row.openIssueCount} open issues and no moderation actions in this period.`,
+      channelUniqueName: row.channelUniqueName,
+      metric: "openIssueCount",
+      value: row.openIssueCount,
+    }));
+
+  return [...staleIssueItems, ...highPressureItems, ...underRespondedItems].slice(0, 10);
+};
+
+const buildIssueAging = (ages: number[]) => [
+  { label: "<1 day", minDays: 0, maxDays: 0, count: ages.filter((age) => age < 1).length },
+  { label: "1-3 days", minDays: 1, maxDays: 3, count: ages.filter((age) => age >= 1 && age <= 3).length },
+  { label: "4-7 days", minDays: 4, maxDays: 7, count: ages.filter((age) => age >= 4 && age <= 7).length },
+  { label: "8-30 days", minDays: 8, maxDays: 30, count: ages.filter((age) => age >= 8 && age <= 30).length },
+  { label: "30+ days", minDays: 31, maxDays: null, count: ages.filter((age) => age > 30).length },
+];
+
+const getMedian = (values: number[]): number | null => {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return ((sorted[mid - 1] || 0) + (sorted[mid] || 0)) / 2;
+  }
+  return sorted[mid] ?? null;
+};
+
+const channelHealthQuery = `
+  WITH date($startDate) AS startDate,
+       date($endDate) AS endDate,
+       $channelUniqueNames AS channelUniqueNames
+  MATCH (c:Channel)
+  WHERE coalesce(c.deleted, false) = false
+    AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+
+  CALL {
+    WITH c, startDate, endDate
+    MATCH (c)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)-[:POSTED_IN_CHANNEL]->(d:Discussion)
+    WHERE date(datetime(dc.createdAt)) >= startDate
+      AND date(datetime(dc.createdAt)) <= endDate
+      AND coalesce(d.deleted, false) = false
+    RETURN count(DISTINCT dc) AS discussionCount,
+           count(DISTINCT CASE WHEN coalesce(d.hasDownload, false) THEN dc END) AS downloadCount,
+           count(DISTINCT CASE WHEN coalesce(dc.archived, false) THEN dc END) AS archivedDiscussions,
+           count(DISTINCT CASE WHEN coalesce(dc.locked, false) THEN dc END) AS lockedDiscussions
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    MATCH (c)<-[:POSTED_IN_CHANNEL]-(ec:EventChannel)-[:POSTED_IN_CHANNEL]->(e:Event)
+    WHERE date(datetime(ec.createdAt)) >= startDate
+      AND date(datetime(ec.createdAt)) <= endDate
+      AND coalesce(e.deleted, false) = false
+    RETURN count(DISTINCT ec) AS eventCount,
+           count(DISTINCT CASE WHEN coalesce(ec.archived, false) THEN ec END) AS archivedEvents,
+           count(DISTINCT CASE WHEN coalesce(ec.locked, false) THEN ec END) AS lockedEvents
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    CALL {
+      WITH c, startDate, endDate
+      MATCH (c)-[:HAS_COMMENT]->(comment:Comment)
+      WHERE date(datetime(comment.createdAt)) >= startDate
+        AND date(datetime(comment.createdAt)) <= endDate
+        AND coalesce(comment.deleted, false) = false
+      RETURN comment
+      UNION
+      WITH c, startDate, endDate
+      MATCH (c)<-[:POSTED_IN_CHANNEL]-(:DiscussionChannel)-[:CONTAINS_COMMENT]->(comment:Comment)
+      WHERE date(datetime(comment.createdAt)) >= startDate
+        AND date(datetime(comment.createdAt)) <= endDate
+        AND coalesce(comment.deleted, false) = false
+      RETURN comment
+      UNION
+      WITH c, startDate, endDate
+      MATCH (c)<-[:POSTED_IN_CHANNEL]-(:EventChannel)-[:CONTAINS_COMMENT]->(comment:Comment)
+      WHERE date(datetime(comment.createdAt)) >= startDate
+        AND date(datetime(comment.createdAt)) <= endDate
+        AND coalesce(comment.deleted, false) = false
+      RETURN comment
+    }
+    RETURN count(DISTINCT comment) AS commentCount,
+           count(DISTINCT CASE WHEN coalesce(comment.archived, false) THEN comment END) AS archivedComments,
+           count(DISTINCT CASE WHEN coalesce(comment.locked, false) THEN comment END) AS lockedComments
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    CALL {
+      WITH c, startDate, endDate
+      MATCH (c)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)<-[vote:UPVOTED_DISCUSSION|SUPER_UPVOTED_DISCUSSION]-(:User)
+      WHERE date(datetime(dc.createdAt)) >= startDate AND date(datetime(dc.createdAt)) <= endDate
+      RETURN vote
+      UNION
+      WITH c, startDate, endDate
+      MATCH (c)-[:HAS_COMMENT]->(comment:Comment)<-[vote:UPVOTED_COMMENT|SUPER_UPVOTED_COMMENT]-(:User)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN vote
+      UNION
+      WITH c, startDate, endDate
+      MATCH (c)<-[:POSTED_IN_CHANNEL]-(:DiscussionChannel)-[:CONTAINS_COMMENT]->(comment:Comment)<-[vote:UPVOTED_COMMENT|SUPER_UPVOTED_COMMENT]-(:User)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN vote
+      UNION
+      WITH c, startDate, endDate
+      MATCH (c)<-[:POSTED_IN_CHANNEL]-(:EventChannel)-[:CONTAINS_COMMENT]->(comment:Comment)<-[vote:UPVOTED_COMMENT|SUPER_UPVOTED_COMMENT]-(:User)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN vote
+    }
+    RETURN count(DISTINCT vote) AS voteCount
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    CALL {
+      WITH c, startDate, endDate
+      MATCH (contributor)-[:POSTED_DISCUSSION]->(:Discussion)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)-[:POSTED_IN_CHANNEL]->(c)
+      WHERE date(datetime(dc.createdAt)) >= startDate AND date(datetime(dc.createdAt)) <= endDate
+      RETURN contributor
+      UNION
+      WITH c, startDate, endDate
+      MATCH (contributor)-[:POSTED_BY]->(:Event)<-[:POSTED_IN_CHANNEL]-(ec:EventChannel)-[:POSTED_IN_CHANNEL]->(c)
+      WHERE date(datetime(ec.createdAt)) >= startDate AND date(datetime(ec.createdAt)) <= endDate
+      RETURN contributor
+      UNION
+      WITH c, startDate, endDate
+      MATCH (contributor)-[:AUTHORED_COMMENT]->(comment:Comment)<-[:HAS_COMMENT]-(c)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN contributor
+      UNION
+      WITH c, startDate, endDate
+      MATCH (contributor)-[:AUTHORED_COMMENT]->(comment:Comment)<-[:CONTAINS_COMMENT]-(:DiscussionChannel)-[:POSTED_IN_CHANNEL]->(c)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN contributor
+      UNION
+      WITH c, startDate, endDate
+      MATCH (contributor)-[:AUTHORED_COMMENT]->(comment:Comment)<-[:CONTAINS_COMMENT]-(:EventChannel)-[:POSTED_IN_CHANNEL]->(c)
+      WHERE date(datetime(comment.createdAt)) >= startDate AND date(datetime(comment.createdAt)) <= endDate
+      RETURN contributor
+    }
+    RETURN count(DISTINCT contributor) AS uniqueContributorCount
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    MATCH (c)-[:HAS_ISSUE]->(issue:Issue)
+    RETURN count(DISTINCT CASE WHEN coalesce(issue.isOpen, false) THEN issue END) AS openIssueCount,
+           count(DISTINCT CASE WHEN date(datetime(issue.createdAt)) >= startDate AND date(datetime(issue.createdAt)) <= endDate THEN issue END) AS issueOpenedCount,
+           max(CASE WHEN coalesce(issue.isOpen, false) THEN duration.between(date(datetime(issue.createdAt)), date()).days ELSE null END) AS oldestOpenIssueAgeDays
+  }
+
+  CALL {
+    WITH c, startDate, endDate
+    MATCH (c)-[:HAS_ISSUE]->(:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
+    WHERE date(datetime(action.createdAt)) >= startDate AND date(datetime(action.createdAt)) <= endDate
+    RETURN count(DISTINCT action) AS moderationActionCount
+  }
+
+  WITH c,
+       discussionCount,
+       commentCount,
+       eventCount,
+       downloadCount,
+       voteCount,
+       uniqueContributorCount,
+       openIssueCount,
+       issueOpenedCount,
+       moderationActionCount,
+       archivedDiscussions + archivedEvents + archivedComments AS archivedContentCount,
+       lockedDiscussions + lockedEvents + lockedComments + CASE WHEN coalesce(c.locked, false) THEN 1 ELSE 0 END AS lockedContentCount,
+       oldestOpenIssueAgeDays,
+       discussionCount + commentCount + eventCount AS contributionCount
+  WITH {
+    channelUniqueName: c.uniqueName,
+    displayName: c.displayName,
+    channelIconURL: c.channelIconURL,
+    discussionCount: discussionCount,
+    commentCount: commentCount,
+    eventCount: eventCount,
+    downloadCount: downloadCount,
+    voteCount: voteCount,
+    uniqueContributorCount: uniqueContributorCount,
+    openIssueCount: openIssueCount,
+    issueOpenedCount: issueOpenedCount,
+    moderationActionCount: moderationActionCount,
+    archivedContentCount: archivedContentCount,
+    lockedContentCount: lockedContentCount,
+    oldestOpenIssueAgeDays: oldestOpenIssueAgeDays,
+    issuesPerHundredContributions: CASE WHEN contributionCount = 0 THEN 0.0 ELSE toFloat(issueOpenedCount) / toFloat(contributionCount) * 100.0 END,
+    activityScore: contributionCount
+  } AS row
+  ORDER BY row.activityScore DESC, row.openIssueCount DESC, row.channelUniqueName ASC
+  RETURN collect(row) AS allChannelHealth
+`;
+
+const timeSeriesQuery = `
+  WITH date($startDate) AS startDate,
+       date($endDate) AS endDate,
+       $channelUniqueNames AS channelUniqueNames
+  CALL {
+    WITH startDate, endDate, channelUniqueNames
+    UNWIND range(0, duration.between(startDate, endDate).days) AS offset
+    WITH startDate + duration({days: offset}) AS day, channelUniqueNames
+
+    CALL {
+      WITH day, channelUniqueNames
+      MATCH (c:Channel)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)-[:POSTED_IN_CHANNEL]->(d:Discussion)
+      WHERE date(datetime(dc.createdAt)) = day
+        AND coalesce(c.deleted, false) = false
+        AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+        AND coalesce(d.deleted, false) = false
+      RETURN count(DISTINCT dc) AS discussions,
+             count(DISTINCT CASE WHEN coalesce(d.hasDownload, false) THEN dc END) AS downloads
+    }
+    CALL {
+      WITH day, channelUniqueNames
+      MATCH (c:Channel)<-[:POSTED_IN_CHANNEL]-(ec:EventChannel)-[:POSTED_IN_CHANNEL]->(e:Event)
+      WHERE date(datetime(ec.createdAt)) = day
+        AND coalesce(c.deleted, false) = false
+        AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+        AND coalesce(e.deleted, false) = false
+      RETURN count(DISTINCT ec) AS events
+    }
+    CALL {
+      WITH day, channelUniqueNames
+      CALL {
+        WITH day, channelUniqueNames
+        MATCH (c:Channel)-[:HAS_COMMENT]->(comment:Comment)
+        WHERE date(datetime(comment.createdAt)) = day
+          AND coalesce(c.deleted, false) = false
+          AND coalesce(comment.deleted, false) = false
+          AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+        RETURN comment
+        UNION
+        WITH day, channelUniqueNames
+        MATCH (c:Channel)<-[:POSTED_IN_CHANNEL]-(:DiscussionChannel)-[:CONTAINS_COMMENT]->(comment:Comment)
+        WHERE date(datetime(comment.createdAt)) = day
+          AND coalesce(c.deleted, false) = false
+          AND coalesce(comment.deleted, false) = false
+          AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+        RETURN comment
+        UNION
+        WITH day, channelUniqueNames
+        MATCH (c:Channel)<-[:POSTED_IN_CHANNEL]-(:EventChannel)-[:CONTAINS_COMMENT]->(comment:Comment)
+        WHERE date(datetime(comment.createdAt)) = day
+          AND coalesce(c.deleted, false) = false
+          AND coalesce(comment.deleted, false) = false
+          AND (size(channelUniqueNames) = 0 OR c.uniqueName IN channelUniqueNames)
+        RETURN comment
+      }
+      RETURN count(DISTINCT comment) AS comments
+    }
+    CALL {
+      WITH day, channelUniqueNames
+      MATCH (issue:Issue)
+      WHERE date(datetime(issue.createdAt)) = day
+        AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+      RETURN count(DISTINCT issue) AS issuesOpened
+    }
+    CALL {
+      WITH day, channelUniqueNames
+      MATCH (issue:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
+      WHERE date(datetime(action.createdAt)) = day
+        AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+      RETURN count(DISTINCT action) AS moderationActions
+    }
+
+    RETURN collect({
+      date: toString(day),
+      discussions: discussions,
+      comments: comments,
+      events: events,
+      downloads: downloads,
+      issuesOpened: issuesOpened,
+      moderationActions: moderationActions
+    }) AS timeSeries
+  }
+  RETURN timeSeries
+`;
+
+const issueSummaryQuery = `
+  WITH date($startDate) AS startDate,
+       date($endDate) AS endDate,
+       $channelUniqueNames AS channelUniqueNames
+  MATCH (issue:Issue)
+  WHERE date(datetime(issue.createdAt)) >= startDate
+    AND date(datetime(issue.createdAt)) <= endDate
+    AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+  OPTIONAL MATCH (issue)-[:ACTIVITY_ON_ISSUE]->(closeAction:ModerationAction)
+  WHERE toLower(coalesce(closeAction.actionType, "")) CONTAINS "close"
+  WITH issue, count(closeAction) AS closeActions
+  RETURN count(DISTINCT issue) AS issueOpenedCount,
+         count(DISTINCT CASE WHEN closeActions > 0 OR coalesce(issue.isOpen, false) = false THEN issue END) AS issueClosedCount
+`;
+
+const openIssueSummaryQuery = `
+  WITH $channelUniqueNames AS channelUniqueNames
+  MATCH (issue:Issue)
+  WHERE coalesce(issue.isOpen, false) = true
+    AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+  RETURN count(DISTINCT issue) AS totalOpenIssueCount,
+         collect(duration.between(date(datetime(issue.createdAt)), date()).days) AS openIssueAges
+`;
+
+const moderationActionTotalQuery = `
+  WITH date($startDate) AS startDate,
+       date($endDate) AS endDate,
+       $channelUniqueNames AS channelUniqueNames
+  MATCH (issue:Issue)-[:ACTIVITY_ON_ISSUE]->(action:ModerationAction)
+  WHERE date(datetime(action.createdAt)) >= startDate
+    AND date(datetime(action.createdAt)) <= endDate
+    AND (size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames)
+  RETURN count(DISTINCT action) AS totalModerationActionCount
+`;
+
+const suspensionTotalQuery = `
+  WITH date($startDate) AS startDate,
+       date($endDate) AS endDate,
+       $channelUniqueNames AS channelUniqueNames
+  MATCH (s:Suspension)
+  WHERE date(datetime(s.createdAt)) >= startDate
+    AND date(datetime(s.createdAt)) <= endDate
+  OPTIONAL MATCH (s)-[:HAS_CONTEXT]->(issue:Issue)
+  WITH s, issue, channelUniqueNames
+  WHERE size(channelUniqueNames) = 0 OR issue.channelUniqueName IN channelUniqueNames
+  RETURN count(DISTINCT s) AS suspensionCount
+`;
+
+const runDashboardQuery = async (
+  session: Session,
+  name: string,
+  query: string,
+  params: Record<string, unknown>
+): Promise<QueryResult> => {
+  try {
+    return await session.run(query, params);
+  } catch (error) {
+    logger.error(`Error fetching server health dashboard subquery: ${name}`, error);
+    throw error;
+  }
+};
+
+const getServerHealthDashboardResolver = ({ driver }: Input) => {
+  return async (_parent: unknown, args: Args = {}) => {
+    const now = DateTime.utc();
+    const requestedEnd = parseDateArg(args.endDate, now);
+    const requestedStart = parseDateArg(
+      args.startDate,
+      requestedEnd.minus({ days: DEFAULT_RANGE_DAYS })
+    );
+    const [start, end] = requestedStart > requestedEnd
+      ? [requestedEnd, requestedStart]
+      : [requestedStart, requestedEnd];
+    const startDate = start.toISODate() || now.toISODate();
+    const endDate = end.toISODate() || now.toISODate();
+    const limit = args.limit || DEFAULT_CHANNEL_LIMIT;
+    const channelUniqueNames = args.channelUniqueNames || [];
+    const session = driver.session({ defaultAccessMode: "READ" });
+
+    try {
+      const params = {
+        startDate,
+        endDate,
+        channelUniqueNames,
+        limit,
+      };
+      const channelResult = await runDashboardQuery(session, "channelHealth", channelHealthQuery, params);
+      const timeSeriesResult = await runDashboardQuery(session, "timeSeries", timeSeriesQuery, params);
+      const issueSummaryResult = await runDashboardQuery(session, "issueSummary", issueSummaryQuery, params);
+      const openIssueSummaryResult = await runDashboardQuery(session, "openIssueSummary", openIssueSummaryQuery, params);
+      const moderationActionTotalResult = await runDashboardQuery(session, "moderationActionTotal", moderationActionTotalQuery, params);
+      const suspensionTotalResult = await runDashboardQuery(session, "suspensionTotal", suspensionTotalQuery, params);
+
+      const channelRecord = channelResult.records[0];
+      const allChannelHealth = sanitize(channelRecord?.get("allChannelHealth") || []) as Array<Omit<ChannelHealthRow, "healthLabel">>;
+      const rawRows = allChannelHealth.slice(0, limit);
+      const channelHealth = rawRows.map((row) => {
+        const normalized = {
+          ...row,
+          oldestOpenIssueAgeDays: toNullableNumber(row.oldestOpenIssueAgeDays),
+          issuesPerHundredContributions: toNumber(row.issuesPerHundredContributions),
+        };
+        return {
+          ...normalized,
+          healthLabel: getHealthLabel(normalized),
+        };
+      });
+      const timeSeries = sanitize(timeSeriesResult.records[0]?.get("timeSeries") || []);
+      const issueSummary = issueSummaryResult.records[0];
+      const openIssueSummary = openIssueSummaryResult.records[0];
+      const totalModerationActionCount = toNumber(
+        moderationActionTotalResult.records[0]?.get("totalModerationActionCount")
+      );
+      const suspensionCount = toNumber(
+        suspensionTotalResult.records[0]?.get("suspensionCount")
+      );
+      const openIssueAges = (sanitize(openIssueSummary?.get("openIssueAges") || []) as unknown[])
+        .map(toNumber);
+      const issueAging = buildIssueAging(openIssueAges);
+      const medianOpenIssueAgeDays = getMedian(openIssueAges);
+      const summary = {
+        activeChannelCount: allChannelHealth.filter((row) => row.activityScore > 0).length,
+        discussionCount: allChannelHealth.reduce((total, row) => total + toNumber(row.discussionCount), 0),
+        commentCount: allChannelHealth.reduce((total, row) => total + toNumber(row.commentCount), 0),
+        eventCount: allChannelHealth.reduce((total, row) => total + toNumber(row.eventCount), 0),
+        downloadCount: allChannelHealth.reduce((total, row) => total + toNumber(row.downloadCount), 0),
+        voteCount: allChannelHealth.reduce((total, row) => total + toNumber(row.voteCount), 0),
+        openIssueCount: toNumber(openIssueSummary?.get("totalOpenIssueCount")),
+        issueOpenedCount: toNumber(issueSummary?.get("issueOpenedCount")),
+        issueClosedCount: toNumber(issueSummary?.get("issueClosedCount")),
+        moderationActionCount: totalModerationActionCount,
+        archivedContentCount: allChannelHealth.reduce((total, row) => total + toNumber(row.archivedContentCount), 0),
+        lockedContentCount: allChannelHealth.reduce((total, row) => total + toNumber(row.lockedContentCount), 0),
+        suspensionCount,
+        medianOpenIssueAgeDays,
+      };
+
+      return {
+        startDate,
+        endDate,
+        generatedAt: now.toISO(),
+        summary,
+        timeSeries,
+        channelHealth,
+        issueAging,
+        attentionItems: buildAttentionItems(channelHealth),
+      };
+    } catch (error) {
+      logger.error("Error fetching server health dashboard:", error);
+      throw new Error("Failed to fetch server health dashboard");
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getServerHealthDashboardResolver;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -20,6 +20,7 @@ import getPluginRunsForDownloadableFile from "./queries/getPluginRunsForDownload
 import getPipelineRuns from "./queries/getPipelineRuns.js";
 import publicCollectionsContaining from "./queries/publicCollectionsContaining.js";
 import getOwnEmail from "./queries/getOwnEmail.js";
+import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -108,6 +109,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     getOwnEmail: getOwnEmail({
       Email
+    }),
+    getServerHealthDashboard: getServerHealthDashboard({
+      driver
     })
   };
 }

--- a/hooks/notificationHelpers.test.ts
+++ b/hooks/notificationHelpers.test.ts
@@ -65,8 +65,9 @@ test("targets the right user and creates an unread notification", async () => {
   assert.equal(UserModel.calls[0].where.username, "alice");
   assert.equal(node.text, "you were mentioned");
   assert.equal(node.read, false);
-  // notificationType omitted when not supplied
-  assert.equal("notificationType" in node, false);
+  // notificationType defaults to "general" so the notification is never
+  // null-typed (which would hide it from both notification tabs).
+  assert.equal(node.notificationType, "general");
 });
 
 test("includes notificationType when provided", async () => {

--- a/hooks/notificationHelpers.ts
+++ b/hooks/notificationHelpers.ts
@@ -8,11 +8,18 @@ type CreateInAppNotificationInput = {
   notificationType?: string; // "feedback", "mention", "reply", "moderation", "scratchpad", etc.
 };
 
+// Default for callers that don't specify a category. Notifications must always
+// carry a notificationType: the General tab filters with NOT notificationType
+// "feedback", and Neo4j three-valued logic excludes null-typed rows from that
+// filter, so a null type would make the notification invisible in every tab
+// while still counting toward the unread badge.
+const DEFAULT_NOTIFICATION_TYPE = "general";
+
 export const createInAppNotification = async ({
   UserModel,
   username,
   text,
-  notificationType,
+  notificationType = DEFAULT_NOTIFICATION_TYPE,
 }: CreateInAppNotificationInput): Promise<boolean> => {
   try {
     const userUpdateResult = await UserModel.update({
@@ -25,7 +32,7 @@ export const createInAppNotification = async ({
                 node: {
                   text,
                   read: false,
-                  ...(notificationType && { notificationType }),
+                  notificationType,
                 },
               },
             ],

--- a/hooks/userMentionNotificationHook.ts
+++ b/hooks/userMentionNotificationHook.ts
@@ -246,6 +246,7 @@ export const notifyNewUserMentions = async ({
         UserModel,
         username: user.username,
         text: notificationText,
+        notificationType: "mention",
       });
 
       if (notificationUrl && user.notifyWhenTagged && user.email) {

--- a/permissions.ts
+++ b/permissions.ts
@@ -73,6 +73,7 @@ const permissionList = shield({
       // access should be able to read them. Clients that need the caller's own
       // email use the self-scoped `getOwnEmail` query.
       emails: deny,
+      getServerHealthDashboard: and(isAuthenticated, canManageMods),
     },
     User: {
       // Public fields - anyone can access

--- a/tests/integration/serverHealthDashboard.test.ts
+++ b/tests/integration/serverHealthDashboard.test.ts
@@ -64,7 +64,7 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
       title: 'Stale issue',
       isOpen: true,
       flaggedServerRuleViolation: true,
-      createdAt: datetime() - duration({days: 10})
+      createdAt: datetime() - duration({days: 20})
     })
     CREATE (channelIssue:Issue {
       id: 'issue-2',
@@ -136,6 +136,32 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
     result.attentionItems.some((item: any) => item.title === "Stale open issues"),
     `expected stale issue attention item, got ${JSON.stringify(result.attentionItems)}`
   );
+});
+
+test("getServerHealthDashboard buckets months-old open issues into the 30+ day aging bucket", async () => {
+  await run(
+    `
+    CREATE (oldServerIssue:Issue {
+      id: 'issue-old',
+      issueNumber: 10,
+      title: 'Six month old server request',
+      isOpen: true,
+      flaggedServerRuleViolation: true,
+      createdAt: datetime() - duration({days: 200})
+    })
+    `
+  );
+
+  const result = await env.resolvers.Query.getServerHealthDashboard(null, {
+    startDate: "2000-01-01",
+    endDate: "2100-01-01",
+    limit: 10,
+  });
+
+  const oldBucket = result.issueAging.find(
+    (bucket: any) => bucket.label === "30+ days"
+  );
+  assert.equal(oldBucket?.count, 1);
 });
 
 test("getServerHealthDashboard filters channel rows without limiting summary totals", async () => {

--- a/tests/integration/serverHealthDashboard.test.ts
+++ b/tests/integration/serverHealthDashboard.test.ts
@@ -1,0 +1,150 @@
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+test("getServerHealthDashboard returns summary, time series, channel rows, and attention items", async () => {
+  await run(
+    `
+    CREATE (general:Channel { uniqueName: 'general', displayName: 'General', createdAt: datetime() })
+    CREATE (quiet:Channel { uniqueName: 'quiet', displayName: 'Quiet', createdAt: datetime() })
+    CREATE (alice:User { username: 'alice' })
+    CREATE (bob:User { username: 'bob' })
+    CREATE (mod:ModerationProfile { displayName: 'Mod One', createdAt: datetime() })
+
+    CREATE (discussion:Discussion { id: 'disc-1', title: 'Discussion', createdAt: datetime(), hasDownload: true })
+    CREATE (dc:DiscussionChannel {
+      id: 'dc-1',
+      discussionId: 'disc-1',
+      channelUniqueName: 'general',
+      createdAt: datetime(),
+      archived: false,
+      locked: false
+    })
+    CREATE (comment:Comment { id: 'comment-1', text: 'hi', isRootComment: true, createdAt: datetime(), archived: false })
+    CREATE (event:Event {
+      id: 'event-1',
+      title: 'Event',
+      createdAt: datetime(),
+      startTime: datetime(),
+      endTime: datetime() + duration({days: 1}),
+      canceled: false,
+      deleted: false
+    })
+    CREATE (ec:EventChannel {
+      id: 'ec-1',
+      eventId: 'event-1',
+      channelUniqueName: 'general',
+      createdAt: datetime(),
+      archived: false
+    })
+    CREATE (issue:Issue {
+      id: 'issue-1',
+      issueNumber: 1,
+      channelUniqueName: 'general',
+      title: 'Stale issue',
+      isOpen: true,
+      createdAt: datetime() - duration({days: 10})
+    })
+    CREATE (action:ModerationAction {
+      id: 'action-1',
+      actionType: 'comment',
+      actionDescription: 'Reviewed',
+      createdAt: datetime()
+    })
+
+    CREATE (alice)-[:POSTED_DISCUSSION]->(discussion)
+    CREATE (bob)-[:AUTHORED_COMMENT]->(comment)
+    CREATE (alice)-[:POSTED_BY]->(event)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(general)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+    CREATE (dc)-[:CONTAINS_COMMENT]->(comment)
+    CREATE (ec)-[:POSTED_IN_CHANNEL]->(general)
+    CREATE (ec)-[:POSTED_IN_CHANNEL]->(event)
+    CREATE (general)-[:HAS_ISSUE]->(issue)
+    CREATE (issue)-[:ACTIVITY_ON_ISSUE]->(action)
+    CREATE (mod)-[:PERFORMED_MODERATION_ACTION]->(action)
+    CREATE (bob)-[:UPVOTED_DISCUSSION]->(dc)
+    CREATE (alice)-[:UPVOTED_COMMENT]->(comment)
+    `
+  );
+
+  const result = await env.resolvers.Query.getServerHealthDashboard(null, {
+    startDate: "2000-01-01",
+    endDate: "2100-01-01",
+    limit: 10,
+  });
+
+  assert.equal(result.summary.activeChannelCount, 1);
+  assert.equal(result.summary.discussionCount, 1);
+  assert.equal(result.summary.commentCount, 1);
+  assert.equal(result.summary.eventCount, 1);
+  assert.equal(result.summary.downloadCount, 1);
+  assert.equal(result.summary.voteCount, 2);
+  assert.equal(result.summary.openIssueCount, 1);
+  assert.equal(result.summary.issueOpenedCount, 1);
+  assert.equal(result.summary.moderationActionCount, 1);
+
+  const general = result.channelHealth.find(
+    (row: any) => row.channelUniqueName === "general"
+  );
+  assert.ok(general, `expected general row, got ${JSON.stringify(result.channelHealth)}`);
+  assert.equal(general.uniqueContributorCount, 2);
+  assert.equal(general.healthLabel, "Needs review");
+
+  assert.ok(result.timeSeries.length > 0);
+  assert.equal(result.issueAging.reduce((sum: number, bucket: any) => sum + bucket.count, 0), 1);
+  assert.ok(
+    result.attentionItems.some((item: any) => item.title === "Stale open issues"),
+    `expected stale issue attention item, got ${JSON.stringify(result.attentionItems)}`
+  );
+});
+
+test("getServerHealthDashboard filters channel rows without limiting summary totals", async () => {
+  await run(
+    `
+    CREATE (a:Channel { uniqueName: 'a', createdAt: datetime() })
+    CREATE (b:Channel { uniqueName: 'b', createdAt: datetime() })
+    CREATE (u:User { username: 'alice' })
+    CREATE (da:Discussion { id: 'da', title: 'A', createdAt: datetime() })
+    CREATE (db:Discussion { id: 'db', title: 'B', createdAt: datetime() })
+    CREATE (dca:DiscussionChannel { id: 'dca', discussionId: 'da', channelUniqueName: 'a', createdAt: datetime() })
+    CREATE (dcb:DiscussionChannel { id: 'dcb', discussionId: 'db', channelUniqueName: 'b', createdAt: datetime() })
+    CREATE (u)-[:POSTED_DISCUSSION]->(da)
+    CREATE (u)-[:POSTED_DISCUSSION]->(db)
+    CREATE (dca)-[:POSTED_IN_CHANNEL]->(a)
+    CREATE (dca)-[:POSTED_IN_CHANNEL]->(da)
+    CREATE (dcb)-[:POSTED_IN_CHANNEL]->(b)
+    CREATE (dcb)-[:POSTED_IN_CHANNEL]->(db)
+    `
+  );
+
+  const result = await env.resolvers.Query.getServerHealthDashboard(null, {
+    startDate: "2000-01-01",
+    endDate: "2100-01-01",
+    limit: 1,
+  });
+
+  assert.equal(result.channelHealth.length, 1);
+  assert.equal(result.summary.discussionCount, 2);
+  assert.equal(result.summary.activeChannelCount, 2);
+});

--- a/tests/integration/serverHealthDashboard.test.ts
+++ b/tests/integration/serverHealthDashboard.test.ts
@@ -63,7 +63,24 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
       channelUniqueName: 'general',
       title: 'Stale issue',
       isOpen: true,
+      flaggedServerRuleViolation: true,
       createdAt: datetime() - duration({days: 10})
+    })
+    CREATE (channelIssue:Issue {
+      id: 'issue-2',
+      issueNumber: 2,
+      channelUniqueName: 'general',
+      title: 'Channel-only issue',
+      isOpen: true,
+      flaggedServerRuleViolation: false,
+      createdAt: datetime() - duration({days: 20})
+    })
+    CREATE (serverIssue:Issue {
+      id: 'issue-3',
+      issueNumber: 3,
+      title: 'Server request',
+      isOpen: true,
+      createdAt: datetime() - duration({days: 2})
     })
     CREATE (action:ModerationAction {
       id: 'action-1',
@@ -81,6 +98,7 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
     CREATE (ec)-[:POSTED_IN_CHANNEL]->(general)
     CREATE (ec)-[:POSTED_IN_CHANNEL]->(event)
     CREATE (general)-[:HAS_ISSUE]->(issue)
+    CREATE (general)-[:HAS_ISSUE]->(channelIssue)
     CREATE (issue)-[:ACTIVITY_ON_ISSUE]->(action)
     CREATE (mod)-[:PERFORMED_MODERATION_ACTION]->(action)
     CREATE (bob)-[:UPVOTED_DISCUSSION]->(dc)
@@ -100,8 +118,8 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
   assert.equal(result.summary.eventCount, 1);
   assert.equal(result.summary.downloadCount, 1);
   assert.equal(result.summary.voteCount, 2);
-  assert.equal(result.summary.openIssueCount, 1);
-  assert.equal(result.summary.issueOpenedCount, 1);
+  assert.equal(result.summary.openIssueCount, 2);
+  assert.equal(result.summary.issueOpenedCount, 2);
   assert.equal(result.summary.moderationActionCount, 1);
 
   const general = result.channelHealth.find(
@@ -109,10 +127,11 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
   );
   assert.ok(general, `expected general row, got ${JSON.stringify(result.channelHealth)}`);
   assert.equal(general.uniqueContributorCount, 2);
+  assert.equal(general.openIssueCount, 1);
   assert.equal(general.healthLabel, "Needs review");
 
   assert.ok(result.timeSeries.length > 0);
-  assert.equal(result.issueAging.reduce((sum: number, bucket: any) => sum + bucket.count, 0), 1);
+  assert.equal(result.issueAging.reduce((sum: number, bucket: any) => sum + bucket.count, 0), 2);
   assert.ok(
     result.attentionItems.some((item: any) => item.title === "Stale open issues"),
     `expected stale issue attention item, got ${JSON.stringify(result.attentionItems)}`

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1874,6 +1874,82 @@ const typeDefinitions = gql`
     activities: [ModActivity!]!
   }
 
+  type ServerHealthSummary @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    activeChannelCount: Int!
+    discussionCount: Int!
+    commentCount: Int!
+    eventCount: Int!
+    downloadCount: Int!
+    voteCount: Int!
+    openIssueCount: Int!
+    issueOpenedCount: Int!
+    issueClosedCount: Int!
+    moderationActionCount: Int!
+    archivedContentCount: Int!
+    lockedContentCount: Int!
+    suspensionCount: Int!
+    medianOpenIssueAgeDays: Float
+  }
+
+  type ServerHealthTimeSeriesPoint @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    date: String!
+    discussions: Int!
+    comments: Int!
+    events: Int!
+    downloads: Int!
+    issuesOpened: Int!
+    moderationActions: Int!
+  }
+
+  type ChannelHealthRow @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    channelUniqueName: String!
+    displayName: String
+    channelIconURL: String
+    discussionCount: Int!
+    commentCount: Int!
+    eventCount: Int!
+    downloadCount: Int!
+    voteCount: Int!
+    uniqueContributorCount: Int!
+    openIssueCount: Int!
+    issueOpenedCount: Int!
+    moderationActionCount: Int!
+    archivedContentCount: Int!
+    lockedContentCount: Int!
+    oldestOpenIssueAgeDays: Int
+    issuesPerHundredContributions: Float
+    activityScore: Int!
+    healthLabel: String!
+  }
+
+  type IssueAgingBucket @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    label: String!
+    minDays: Int!
+    maxDays: Int
+    count: Int!
+  }
+
+  type ServerHealthAttentionItem @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    severity: String!
+    title: String!
+    description: String!
+    channelUniqueName: String
+    issueNumber: Int
+    metric: String
+    value: Float
+  }
+
+  type ServerHealthDashboard @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    startDate: String!
+    endDate: String!
+    generatedAt: DateTime!
+    summary: ServerHealthSummary!
+    timeSeries: [ServerHealthTimeSeriesPoint!]!
+    channelHealth: [ChannelHealthRow!]!
+    issueAging: [IssueAgingBucket!]!
+    attentionItems: [ServerHealthAttentionItem!]!
+  }
+
   type UserContributionData {
     username: String!
     displayName: String
@@ -1982,6 +2058,12 @@ const typeDefinitions = gql`
       endDate: String
       year: Int
     ): [ModDayData!]!
+    getServerHealthDashboard(
+      startDate: String
+      endDate: String
+      channelUniqueNames: [String!]
+      limit: Int
+    ): ServerHealthDashboard!
     isOriginalPosterSuspended(issueId: String!): Boolean
     safetyCheck: SafetyCheckResponse
     getServerPluginSecrets(


### PR DESCRIPTION
Bundles the backend changes committed to the local `main` branch.

## Changes
- **Server health dashboard query** — adds the `getServerHealthDashboard` query powering the admin dashboard.
- **Scope issue metrics** — dashboard issue counts/aging/moderation metrics are scoped to admin/server-scoped issues (server-rule-violation or channel-unscoped).
- **`duration.inDays` fix** — issue age and the activity time-series day range used `duration.between(...).days`, which returns only the days *component* of a logical duration. A 6-month-old issue read as ~0 days, so the aging chart never populated the 30+ day bucket and the activity chart rendered too few days. Switched to `duration.inDays(...).days` for total elapsed days.
- **Notification type** — `createInAppNotification` now defaults `notificationType` to `"general"` and always writes it; the raw-Cypher notification creators set explicit types (`moderation`/`event`); user mentions tagged `"mention"`. Previously null-typed notifications were invisible in both notification tabs while counting toward the badge.

## Tests
Integration tests updated/added (including a 200-day-old issue landing in the 30+ bucket) and the notification helper unit test; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)