### PR TITLE
Share one provisioning seam (provisionServerDefaultsFromOgm) + reconcile roadmap doc

### DIFF
--- a/build_scripts/provisionServerDefaults.ts
+++ b/build_scripts/provisionServerDefaults.ts
@@ -12,7 +12,7 @@
 import "dotenv/config";
 import neo4j from "neo4j-driver";
 import { createOgmAndModels } from "../customResolvers/resolverDeps.js";
-import { provisionServerDefaults } from "../seedData/provisionServerDefaults.js";
+import { provisionServerDefaultsFromOgm } from "../seedData/provisionServerDefaults.js";
 
 const uri = process.env.NEO4J_URI || "bolt://localhost:7687";
 const user = process.env.NEO4J_USER || "neo4j";
@@ -32,10 +32,7 @@ const run = async () => {
   await deps.ogm.init();
 
   try {
-    const result = await provisionServerDefaults({
-      ServerRole: deps.ServerRole,
-      ModServerRole: deps.ModServerRole,
-      ServerConfig: deps.ServerConfig,
+    const result = await provisionServerDefaultsFromOgm(deps.ogm, {
       serverName: serverName as string,
       log: (message) => console.log(`[provision] ${message}`),
     });

--- a/docs/isadmin-phaseout-design.md
+++ b/docs/isadmin-phaseout-design.md
@@ -1,7 +1,9 @@
 # Design: Phasing out `isAdmin` → symmetric, role-based permissions
 
 Status: **Implemented** (PR-1 → PR-4c; see §7 Phasing for the per-stage status).
-The remaining work is rollout/cleanup, not the core model. · Related: PR #64
+All code stages and the tag-field cleanup (§8.6) have shipped; the **only**
+remaining item is the per-environment provisioning rollout (PR-2's last step —
+wire `SUPERADMIN_EMAIL` + run `npm run provision` per env). · Related: PR #64
 (P0), PR #65 (P1). For the resulting system, see
 [permission-system.md](./permission-system.md).
 
@@ -206,8 +208,8 @@ production):
 
 ### Phasing (separate PRs)
 
-1. **PR-1 — evaluator & schema groundwork. 🟡 IN PROGRESS.** No call sites
-   converted → no behavior change.
+1. **PR-1 — evaluator & schema groundwork. ✅ DONE.** No call sites
+   converted in this stage → no behavior change; the conversions land in PR-3.
    - ✅ Schema: admin "creative" caps on `ServerRole`
      (`canManageServerSettings/Plugins/Roles/Mods/Admins/SuperAdmins`); destructive
      caps on `ModServerRole` (`canRemoveDiscussionChannel/EventChannel`);
@@ -225,13 +227,23 @@ production):
      `Channel.ElevatedChannelRole` field added (codegen run); `hasChannelPermission`
      resolves owners via `evaluateChannelOwnerPermission` (fallback to all-perms
      until a role is configured). Unit test added.
-2. **PR-2 (seed defaults + migration). 🟡 IN PROGRESS.**
+2. **PR-2 (seed defaults + migration). 🟡 CODE DONE; one rollout step left.**
    - ✅ `seedData/` single-source-of-truth module + idempotent
      `provisionServerDefaults` (roles, config wiring, admin→SuperAdmin backfill);
      `npm run provision` entry; unit tests.
-   - 🔲 Adopt `provisionServerDefaults` in integration-test setup (incremental).
-   - 🔲 Wire env root (`SUPERADMIN_EMAIL`) in deploy config; run provisioning per
-     environment in a maintenance window.
+   - ✅ Adopt provisioning in integration-test setup. The model-wiring boilerplate
+     (`ogm.model("ServerRole")` × 3) now lives in one shared seam,
+     `provisionServerDefaultsFromOgm(ogm, { serverName })`, used by **both** the
+     production entry point (`build_scripts/provisionServerDefaults.ts`) and the
+     role-exercising integration tests (`authenticatedRoles`,
+     `provisionServerDefaults`). Adoption is **deliberately selective**: only tests
+     that exercise the role/capability resolution path provision the defaults;
+     the rest keep creating a bare `ServerConfig` (a one-line Cypher `CREATE`)
+     because full provisioning there would add cost without coverage.
+   - 🔲 **(Only remaining item — ops.)** Wire env root (`SUPERADMIN_EMAIL`) in each
+     environment's deploy config and run provisioning per environment in a
+     maintenance window. Until this is verified per-environment, `isAdmin` +
+     the default-role fallbacks keep current behavior, so there is no rush.
 3. **PR-3 — ✅ DONE.** PR-3a (#72) converted Category-A call sites to capability
    checks; PR-3b (#73) dropped `isAdmin` from the Category-B ORs and removed the
    `isAdmin` rule, replacing it with a server-admin + root override
@@ -314,27 +326,32 @@ it. Frontend: none required until PR-5.
 5. **`deleteDiscussionChannels` / `deleteEventChannels`** → destructive caps on
    **`ModServerRole`** (`canRemoveDiscussionChannel` / `canRemoveEventChannel`).
    (Schema added in PR-1; call sites convert in PR-3.)
-6. **Roles are permissions-only; display tags derive from membership.** The
-   ADMIN/MOD tag must come from the user's relationship to `ServerConfig`
+6. **Roles are permissions-only; display tags derive from membership. ✅ DONE.**
+   The ADMIN/MOD tag comes from the user's relationship to `ServerConfig`
    (`Admins`/`SuperAdmins`) / `Channel` (`Moderators`), **not** from a role flag.
-   The seed roles no longer set `showAdminTag` / `showModTag` (PR-2). The legacy
-   schema fields are slated for removal in a dedicated follow-up — they are
-   currently read by ~5 backend cypher queries and several frontend components,
-   so the removal is a coordinated backend+frontend change:
-   - Backend: derive the tag in the comment/post queries from membership; drop
-     `showAdminTag` (`ServerRole`) and `showModTag` (`ChannelRole`) from the schema
-     and `getServerConfigForPermissions`'s fetch.
-   - Frontend: have the tag-rendering components/queries read membership-derived
-     data instead of the role flag.
+   The coordinated backend+frontend removal shipped:
+   - Backend: `showAdminTag` (`ServerRole`) and `showModTag` (`ChannelRole`) were
+     dropped from the schema (`typeDefs.ts`) and `getServerConfigForPermissions`'s
+     fetch. The channel MOD signal is now the `authorIsChannelModerator` `@cypher`
+     field, derived from `Channel.Moderators` (also populated inside the custom
+     `getDiscussionsInChannel` resolver so channel-scoped lists carry it).
+   - Frontend: the tag-rendering components read membership-derived data. Author
+     badges across discussions, events, downloads, comments and the mod activity
+     feed now resolve through a single `getAuthorBadges()` helper
+     (Server Admin / Server Mod / Forum Admin / Forum Mod). See the multiforum-nuxt
+     badge-unification work.
 
 Note: items 2 and 4 mean the earlier `canManageServerMembers` capability is
 dropped from the taxonomy (§4).
 
-## 9. Testing
-- Unit: extend `hasServerPermission.test.ts` / `hasServerModPermission.test.ts`
-  for the root override, the admin tier, the suspended-admin path, and the
-  generalized default-role fallback (pure-function seams already exist).
-- Unit: one test per new capability rule (granted via admin role / via default
-  role / denied) following the existing `evaluate*` pattern.
-- Integration: extend `authenticatedRoles.test.ts` — a restricted admin passes a
-  granted capability and is denied `canManageAdmins`; root passes everything.
+## 9. Testing — ✅ shipped
+- Unit: `hasServerPermission.test.ts` / `hasServerModPermission.test.ts` cover the
+  root override, the admin tier, the suspended-admin path, and the generalized
+  default-role fallback (via the pure-function seams).
+- Unit: per-capability-rule tests follow the existing `evaluate*` pattern;
+  `serverAdminOverride.test.ts` covers the suspension-aware override (PR-3.5);
+  `roleEscalation` / `nestedRoleEscalation` cover the no-escalation invariant (PR-4/4b).
+- Integration: `authenticatedRoles.test.ts` runs an admin-gated mutation as
+  unauthenticated / non-admin / admin against live Neo4j; `provisionServerDefaults.test.ts`
+  verifies provisioning + idempotency + backfill. Both seed via the shared
+  `provisionServerDefaultsFromOgm` helper (PR-2).

--- a/seedData/provisionServerDefaults.test.ts
+++ b/seedData/provisionServerDefaults.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { provisionServerDefaults } from "./provisionServerDefaults.js";
+import {
+  provisionServerDefaults,
+  provisionServerDefaultsFromOgm,
+} from "./provisionServerDefaults.js";
 import {
   DEFAULT_SERVER_ROLES,
   DEFAULT_MOD_SERVER_ROLES,
@@ -135,6 +138,38 @@ test("backfill promotes only admins that are not already super-admins", async ()
     (u) => u.update?.SuperAdmins
   );
   assert.ok(backfillUpdate, "expected a SuperAdmins backfill update");
+});
+
+test("provisionServerDefaultsFromOgm resolves the three models off the OGM and delegates", async () => {
+  const ServerRole = makeRoleModel(false);
+  const ModServerRole = makeRoleModel(false);
+  const ServerConfig = makeServerConfigModel(null);
+  const requested: string[] = [];
+  const ogm = {
+    model: (name: string) => {
+      requested.push(name);
+      const byName: Record<string, unknown> = {
+        ServerRole: ServerRole.model,
+        ModServerRole: ModServerRole.model,
+        ServerConfig: ServerConfig.model,
+      };
+      return byName[name];
+    },
+  };
+
+  const result = await provisionServerDefaultsFromOgm(ogm, {
+    serverName: "Test Server",
+  });
+
+  // It pulled exactly the three role/config models from the OGM...
+  assert.deepEqual(requested.sort(), [
+    "ModServerRole",
+    "ServerConfig",
+    "ServerRole",
+  ]);
+  // ...and the underlying provisioning ran against them.
+  assert.equal(ServerRole.calls.create.length, DEFAULT_SERVER_ROLES.length);
+  assert.equal(result.serverConfigCreated, true);
 });
 
 test("backfill is a no-op when all admins are already super-admins", async () => {

--- a/seedData/provisionServerDefaults.ts
+++ b/seedData/provisionServerDefaults.ts
@@ -163,3 +163,31 @@ export const provisionServerDefaults = async (
     adminsBackfilledToSuperAdmins: adminsToPromote,
   };
 };
+
+// Minimal OGM shape: anything exposing `.model(name)` (the real `@neo4j/graphql`
+// OGM, or a test double). Avoids importing the concrete OGM type here.
+export type OgmLike = {
+  model: (name: string) => unknown;
+};
+
+// Convenience wrapper that resolves the three role/config models from an OGM
+// instance and delegates to `provisionServerDefaults`. This is the seam shared
+// by every caller — the production entry point (build_scripts) and the
+// role-exercising integration tests — so the `ogm.model("ServerRole")` wiring
+// lives in exactly one place.
+//
+// Note: most integration tests only need a bare `ServerConfig` and should keep
+// creating one directly (a one-line Cypher CREATE) rather than calling this —
+// full provisioning is only worth its cost where a test actually exercises the
+// role/capability resolution path. See docs/isadmin-phaseout-design.md §7 (PR-2).
+export const provisionServerDefaultsFromOgm = (
+  ogm: OgmLike,
+  options: { serverName: string; log?: (message: string) => void }
+): Promise<ProvisionServerDefaultsResult> =>
+  provisionServerDefaults({
+    ServerRole: ogm.model("ServerRole") as ServerRoleModel,
+    ModServerRole: ogm.model("ModServerRole") as ModServerRoleModel,
+    ServerConfig: ogm.model("ServerConfig") as ServerConfigModel,
+    serverName: options.serverName,
+    log: options.log,
+  });

--- a/tests/integration/authenticatedRoles.test.ts
+++ b/tests/integration/authenticatedRoles.test.ts
@@ -63,15 +63,10 @@ before(async () => {
   // Provision the default roles so a non-admin resolves the real
   // DefaultServerRole (which lacks the admin capabilities) — exercising the
   // post-migration permission path that the capability checks rely on.
-  const { provisionServerDefaults } = await import(
+  const { provisionServerDefaultsFromOgm } = await import(
     "../../seedData/provisionServerDefaults.js"
   );
-  await provisionServerDefaults({
-    ServerRole: ogm.model("ServerRole"),
-    ModServerRole: ogm.model("ModServerRole"),
-    ServerConfig: ogm.model("ServerConfig"),
-    serverName: SERVER_CONFIG_NAME,
-  });
+  await provisionServerDefaultsFromOgm(ogm, { serverName: SERVER_CONFIG_NAME });
 }, { timeout: 240000 });
 
 after(async () => {

--- a/tests/integration/provisionServerDefaults.test.ts
+++ b/tests/integration/provisionServerDefaults.test.ts
@@ -15,15 +15,10 @@ const SERVER_CONFIG_NAME = "ProvisionTestServer";
 let container: StartedNeo4jContainer;
 let driver: Driver;
 let ogm: any;
-let provisionServerDefaults: any;
+let provisionServerDefaultsFromOgm: any;
 
 const provision = () =>
-  provisionServerDefaults({
-    ServerRole: ogm.model("ServerRole"),
-    ModServerRole: ogm.model("ModServerRole"),
-    ServerConfig: ogm.model("ServerConfig"),
-    serverName: SERVER_CONFIG_NAME,
-  });
+  provisionServerDefaultsFromOgm(ogm, { serverName: SERVER_CONFIG_NAME });
 
 before(async () => {
   container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
@@ -37,7 +32,7 @@ before(async () => {
   );
   ({ driver, ogm } = await buildPermissionedSchema());
   await ogm.init();
-  ({ provisionServerDefaults } = await import(
+  ({ provisionServerDefaultsFromOgm } = await import(
     "../../seedData/provisionServerDefaults.js"
   ));
 


### PR DESCRIPTION
## What

Two related cleanups, both in the isAdmin phase-out area:

### 1. Reuse: one shared provisioning seam
The `ogm.model("ServerRole")` × 3 model-wiring was copy-pasted in **three** places. Extract a single seam:

```ts
provisionServerDefaultsFromOgm(ogm, { serverName, log? })
```

It resolves the three role/config models off the OGM and delegates to `provisionServerDefaults`. Now used by **both**:
- the production entry point (`build_scripts/provisionServerDefaults.ts`), and
- the role-exercising integration tests (`authenticatedRoles`, `provisionServerDefaults`).

**Provisioning in tests stays deliberately selective** (per the reviewer's intuition): only tests that exercise the role/capability resolution path provision the defaults. The many tests that just need a `ServerConfig` keep their one-line Cypher `CREATE` — full provisioning there would be cost without coverage. This is documented at the helper and in the design doc.

### 2. Docs: reconcile the roadmap with what actually shipped
`docs/isadmin-phaseout-design.md`:
- **PR-1** `🟡 IN PROGRESS` → **✅ DONE** (all bullets were already done).
- **PR-2** → **code done; one ops step left**. The "adopt provisioning in tests" item is ✅ (via the shared helper); the only remaining item is the per-environment rollout (`SUPERADMIN_EMAIL` + `npm run provision`), which is intentionally deferrable.
- **§8.6 tag-field removal** → **✅ shipped** (`showAdminTag`/`showModTag` dropped from schema; badges now membership-derived via `authorIsChannelModerator` + a unified frontend `getAuthorBadges`).
- **§9 Testing** → past tense, naming the unit + integration tests that landed.
- Top status line tightened to name the single remaining item.

## Verification
- `tsc --noEmit` clean.
- Provisioning unit suite **7/7** (incl. a new test for the wrapper resolving the three models off the OGM).
- Integration against live Neo4j: `provisionServerDefaults` **4/4**, `authenticatedRoles` **9/9** — both now seeding through the shared helper.
- ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)