### PR TITLE
Remove dead favorite/bookmark mutation stubs

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -328,11 +328,7 @@ const permissionList = shield({
       deleteCollections: and(isAuthenticated, isCollectionOwner),
       removeFromCollection: and(isAuthenticated, isCollectionOwner),
       reorderCollectionItem: and(isAuthenticated, isCollectionOwner),
-      toggleBookmark: and(isAuthenticated, allow),
-      addToFavorites: and(isAuthenticated, allow),
       shareCollectionAsDiscussion: and(isAuthenticated, isCollectionOwner),
-      addToOwnedDownloads: and(isAuthenticated, allow),
-      initializeUserFavorites: and(isAuthenticated, allow),
 
       refreshPlugins: and(isAuthenticated, canManagePlugins),
       installPluginVersion: and(isAuthenticated, canManagePlugins),

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1027,10 +1027,6 @@ const typeDefinitions = gql`
     removeFromCollection(collectionId: ID!, itemId: ID!, itemType: CollectionItemType!): Boolean!
     reorderCollectionItem(collectionId: ID!, itemId: ID!, newPosition: Int!): Boolean!
 
-    # Bookmarking shortcuts
-    toggleBookmark(itemId: ID!, itemType: CollectionItemType!): Boolean!
-    addToFavorites(itemId: ID!, itemType: CollectionItemType!): Boolean!
-
     # Share collection as discussion
     shareCollectionAsDiscussion(
       collectionId: ID!,
@@ -1041,16 +1037,12 @@ const typeDefinitions = gql`
     ): Discussion!
 
     # Library management
-    addToOwnedDownloads(pluginVersionId: ID!): Boolean!
     trackDownload(downloadableFileId: ID!, discussionId: ID!): Boolean!
     updateDownloadableFileSupportSettings(
       downloadableFileId: ID!
       discussionId: ID!
       input: DownloadSupportSettingsInput!
     ): Boolean!
-
-    # Initialize user's default favorites collections
-    initializeUserFavorites: Boolean!
 
     # Image upload with automatic uploader assignment
     createImageWithUploader(input: CreateImageInput!): Image!


### PR DESCRIPTION
## What

Removes four mutations that were **declared but never implemented**:

- `toggleBookmark`
- `addToFavorites`
- `addToOwnedDownloads`
- `initializeUserFavorites`

Each was present in `typeDefs.ts` and had a graphql-shield rule (`and(isAuthenticated, allow)`) in `permissions.ts`, but had **no resolver** — they're absent from `mutationResolvers.ts` and have no resolver file. As non-null `Boolean!` fields with no resolver, they would error if ever called.

## Why they're safe to delete

- **Unimplemented:** no resolver anywhere in the backend.
- **Unused:** the frontend's favorites/bookmark features call entirely different mutations (`ADD_FAVORITE_COMMENT`, `ADD_FAVORITE_DISCUSSION`, `ADD_FAVORITE_IMAGE`, …), not these.

Net effect: removes 8 lines of dead schema + 4 dead `allow` shield rules, shrinking the API/auth surface.

## Verification
- `tsc --noEmit` clean.
- Schema still builds offline (`npm run logSchema`) — the four are gone, the live `trackDownload` mutation is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)