### PR TITLE
Enforce ServerConfig.enableDownloads server-side

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -33,6 +33,7 @@ const {
   updateChannelInputIsValid,
   createDiscussionInputIsValid,
   updateDiscussionInputIsValid,
+  serverDownloadsEnabled,
   createEventInputIsValid,
   updateEventInputIsValid,
   createCommentInputIsValid,
@@ -175,7 +176,7 @@ const permissionList = shield({
       deleteEmails: and(isAuthenticated, isAccountOwner),
       deleteUsers: and(isAuthenticated, isAccountOwner),
     
-      createDiscussionWithChannelConnections: and(isAuthenticated, createDiscussionInputIsValid, canCreateDiscussion),
+      createDiscussionWithChannelConnections: and(isAuthenticated, createDiscussionInputIsValid, canCreateDiscussion, serverDownloadsEnabled),
       updateDiscussionWithChannelConnections: and(isAuthenticated, updateDiscussionInputIsValid, or(isDiscussionOwner, canEditDiscussions)),
       deleteDiscussions: and(isAuthenticated, isDiscussionOwner),
       updateDiscussions: and(isAuthenticated, updateDiscussionInputIsValid, or(isDiscussionOwner, canEditDiscussions)),

--- a/rules/errorMessages.ts
+++ b/rules/errorMessages.ts
@@ -47,6 +47,10 @@ export const ERROR_MESSAGES = {
     notFound: "Collection not found.",
     notOwner: "You must be the owner of this collection to do that.",
   },
+  download: {
+    notEnabled:
+      "Downloads are not enabled on this server. An administrator must turn on downloads in the server settings before downloads can be created.",
+  },
   album: {
     noId: "You must provide an album id.",
     notFound: "Album not found.",

--- a/rules/permission/getServerConfigForPermissions.ts
+++ b/rules/permission/getServerConfigForPermissions.ts
@@ -28,6 +28,7 @@ export const getServerConfigForPermissions = async (context: GraphQLContext) => 
     cache.serverConfigPromise = ServerConfig.find({
       where: { serverName: process.env.SERVER_CONFIG_NAME },
       selectionSet: `{
+        enableDownloads
         DefaultServerRole {
           ${SERVER_ROLE_CAPS}
         }

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -37,6 +37,7 @@ import {
   createDiscussionInputIsValid,
   updateDiscussionInputIsValid,
 } from "./validation/discussionIsValid.js";
+import { serverDownloadsEnabled } from "./validation/serverDownloadsEnabled.js";
 import {
   createCommentInputIsValid,
   updateCommentInputIsValid,
@@ -128,6 +129,7 @@ const ruleList = {
   updateCommentInputIsValid,
   createDiscussionInputIsValid,
   updateDiscussionInputIsValid,
+  serverDownloadsEnabled,
   createEventInputIsValid,
   updateEventInputIsValid,
   createDownloadableFileInputIsValid,

--- a/rules/validation/serverDownloadsEnabled.test.ts
+++ b/rules/validation/serverDownloadsEnabled.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  inputCreatesDownload,
+  evaluateServerDownloadsEnabled,
+} from "./serverDownloadsEnabled.js";
+import { ERROR_MESSAGES } from "../errorMessages.js";
+
+const downloadItem = {
+  discussionCreateInput: { hasDownload: true },
+  channelConnections: ["cats"],
+};
+const plainItem = {
+  discussionCreateInput: { hasDownload: false },
+  channelConnections: ["cats"],
+};
+
+test("inputCreatesDownload detects a download in the input", () => {
+  assert.equal(inputCreatesDownload([downloadItem]), true);
+  assert.equal(inputCreatesDownload([plainItem, downloadItem]), true);
+});
+
+test("inputCreatesDownload is false for non-download / empty / nullish input", () => {
+  assert.equal(inputCreatesDownload([plainItem]), false);
+  assert.equal(
+    inputCreatesDownload([{ discussionCreateInput: {}, channelConnections: [] }]),
+    false
+  );
+  assert.equal(inputCreatesDownload([]), false);
+  assert.equal(inputCreatesDownload(null), false);
+  assert.equal(inputCreatesDownload(undefined), false);
+});
+
+test("a non-download create is always allowed, regardless of the flag", () => {
+  assert.equal(
+    evaluateServerDownloadsEnabled({ input: [plainItem], enableDownloads: false }),
+    true
+  );
+  assert.equal(
+    evaluateServerDownloadsEnabled({ input: [plainItem], enableDownloads: null }),
+    true
+  );
+});
+
+test("a download create is allowed only when enableDownloads is exactly true", () => {
+  assert.equal(
+    evaluateServerDownloadsEnabled({ input: [downloadItem], enableDownloads: true }),
+    true
+  );
+});
+
+test("a download create is blocked when downloads are off (false / null / undefined)", () => {
+  for (const enableDownloads of [false, null, undefined]) {
+    assert.equal(
+      evaluateServerDownloadsEnabled({ input: [downloadItem], enableDownloads }),
+      ERROR_MESSAGES.download.notEnabled,
+      `expected block for enableDownloads=${String(enableDownloads)}`
+    );
+  }
+});

--- a/rules/validation/serverDownloadsEnabled.ts
+++ b/rules/validation/serverDownloadsEnabled.ts
@@ -1,0 +1,73 @@
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import { getServerConfigForPermissions } from "../permission/getServerConfigForPermissions.js";
+import { ERROR_MESSAGES } from "../errorMessages.js";
+
+// Server-side enforcement of the `ServerConfig.enableDownloads` feature flag.
+//
+// A "download" is a Discussion created with `hasDownload: true` (the custom
+// createDiscussionWithChannelConnections resolver attaches a DownloadableFile and
+// runs the channel plugin pipeline for those). The frontend already hides the
+// downloads tab + create UI when `enableDownloads` is not true, but that gate is
+// cosmetic — a direct API call could still create a download. This rule closes
+// that gap.
+//
+// Semantics match the frontend's `Boolean(enableDownloads)`: downloads are
+// allowed ONLY when the flag is explicitly `true`. A server whose downloads tab
+// is currently visible already has `enableDownloads === true`, so this does not
+// regress any instance that legitimately offers downloads today; it only blocks
+// direct-API creation on servers where downloads are off (null/false).
+
+type CreateDiscussionItem = {
+  discussionCreateInput?: { hasDownload?: boolean | null } | null;
+  channelConnections?: string[];
+};
+
+export type CreateDiscussionArgs = {
+  input?: CreateDiscussionItem[] | null;
+};
+
+/** True when any item in the create input attaches a download. */
+export const inputCreatesDownload = (
+  input: CreateDiscussionItem[] | null | undefined
+): boolean =>
+  Array.isArray(input) &&
+  input.some((item) => item?.discussionCreateInput?.hasDownload === true);
+
+/**
+ * Pure decision: allow unless the input creates a download AND the server does
+ * not have downloads enabled. Returns `true` to allow, or an error message.
+ */
+export const evaluateServerDownloadsEnabled = ({
+  input,
+  enableDownloads,
+}: {
+  input: CreateDiscussionItem[] | null | undefined;
+  enableDownloads: boolean | null | undefined;
+}): true | string => {
+  if (!inputCreatesDownload(input)) {
+    return true; // Not a download — this rule is a no-op.
+  }
+  return enableDownloads === true ? true : ERROR_MESSAGES.download.notEnabled;
+};
+
+export const serverDownloadsEnabled = rule({ cache: "contextual" })(
+  async (
+    _parent: unknown,
+    args: CreateDiscussionArgs,
+    ctx: GraphQLContext,
+    _info: GraphQLResolveInfo
+  ) => {
+    // Avoid the ServerConfig read entirely when no download is being created.
+    if (!inputCreatesDownload(args.input)) {
+      return true;
+    }
+    const serverConfig = await getServerConfigForPermissions(ctx);
+    const result = evaluateServerDownloadsEnabled({
+      input: args.input,
+      enableDownloads: serverConfig?.enableDownloads,
+    });
+    return result === true ? true : new Error(result);
+  }
+);


### PR DESCRIPTION
## What

Adds **server-side enforcement** of the `ServerConfig.enableDownloads` feature flag. Until now the gate was **frontend-only**: `ChannelTabs` hides the Downloads tab and the create UI when downloads are off, but a direct API call to `createDiscussionWithChannelConnections` with `hasDownload: true` could still create a download on a server with downloads disabled.

A new graphql-shield rule, `serverDownloadsEnabled`, is added to that mutation's chain:

```
createDiscussionWithChannelConnections:
  and(isAuthenticated, createDiscussionInputIsValid, canCreateDiscussion, serverDownloadsEnabled)
```

It blocks creating a download unless `ServerConfig.enableDownloads === true`. Non-download discussion creates are unaffected (the rule short-circuits to `allow`).

## Semantics & safety

The allow condition (`enableDownloads === true`) **matches the frontend's `Boolean(enableDownloads)` exactly**. That makes the rollout safe:

- Any server whose Downloads tab is currently **visible** already has `enableDownloads === true` → this rule allows it. **No instance that legitimately offers downloads today is regressed.**
- On servers where downloads are off (`null`/`false`), the tab is already hidden, so there's no legitimate UI creation path — this rule simply closes the **direct-API** gap.

There is intentionally **no admin bypass**: "downloads off" is a server-wide feature switch; an admin enables downloads by toggling the setting, not by being exempt from the rule.

## Design

- **Pure, unit-tested core** (`rules/validation/serverDownloadsEnabled.ts`): `inputCreatesDownload(input)` + `evaluateServerDownloadsEnabled({ input, enableDownloads })`, following the codebase's extract-pure-function rule pattern.
- `getServerConfigForPermissions` now selects `enableDownloads` — reuses the existing request-scoped ServerConfig cache, so **no extra DB round trip** (the chain already fetches it for `canCreateDiscussion`).
- New error message `download.notEnabled`.

## Scope note

Downloads are *attached at creation* (via `hasDownload` + the channel plugin pipeline); the update path (`updateDiscussionWithChannelConnections`) does not read `hasDownload`, so creation is the meaningful vector and the one gated here.

## Verification
- `tsc --noEmit` clean.
- **5/5** unit tests (download detection + all enable/disable/non-download branches).
- Schema builds offline (`npm run logSchema`); rule confirmed registered in the shield map and wired into the mutation chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)