### PR TITLE
Test wiki suspension/redaction edges and report attribution

### DIFF
--- a/customResolvers/mutations/redactTextVersionRevision.test.ts
+++ b/customResolvers/mutations/redactTextVersionRevision.test.ts
@@ -296,6 +296,36 @@ test('redactTextVersionRevision rejects mismatched revision types', async () => 
   )
 })
 
+test('assertCanRedactRevision allows the revision author to redact their own wiki revision', async () => {
+  await assert.doesNotReject(
+    assertCanRedactRevision({
+      context: {
+        user: { username: 'alice', data: { ModerationProfile: null } }
+      } as unknown as GraphQLContext,
+      target: {
+        targetType: 'wiki',
+        targetId: 'wiki-1',
+        ownerUsername: 'alice',
+        ownerModProfileName: null,
+        channelUniqueName: 'cats'
+      },
+      revisionType: 'wiki',
+      // No mod permission: authorization must come from authorship alone.
+      checkModPermissions: async () => new Error('No mod permission'),
+      getServerMembership: async () => ({
+        isServerAdmin: false,
+        isServerModerator: false
+      }),
+      getUserData: async () => ({
+        username: 'alice',
+        email: null,
+        email_verified: false,
+        data: null
+      })
+    })
+  )
+})
+
 test('assertCanRedactRevision rejects non-authors without mod permission', async () => {
   await assert.rejects(
     assertCanRedactRevision({

--- a/rules/canEditWikiPagesRule.test.ts
+++ b/rules/canEditWikiPagesRule.test.ts
@@ -155,6 +155,29 @@ test("blocks wiki page creation when wiki is disabled for the channel", async ()
   assert.ok(result instanceof Error);
 });
 
+test("blocks wiki page creation for suspended users even when wiki is enabled", async () => {
+  const ctx = buildContext({
+    suspendedUsers: [{ username: "wiki-author" }],
+    channels: [{ uniqueName: "sourceit", wikiEnabled: true }],
+  });
+
+  const result = await evaluateCanEditWikiPagesRule(
+    {
+      input: [
+        {
+          channelUniqueName: "sourceit",
+          slug: "new-page",
+          title: "New Page",
+          body: "Created while suspended.",
+        },
+      ],
+    },
+    ctx
+  );
+
+  assert.ok(result instanceof Error);
+});
+
 test("blocks wiki page updates for suspended users when the suspended role cannot update the channel", async () => {
   const ctx = buildContext({
     suspendedUsers: [{ username: "wiki-author" }],

--- a/tests/integration/reportWikiEdit.test.ts
+++ b/tests/integration/reportWikiEdit.test.ts
@@ -91,3 +91,39 @@ test("throws when the wiki page does not exist", async () => {
     /Wiki page not found/i
   );
 });
+
+test("attributes the wiki page version author on the issue", async () => {
+  await run(
+    `MATCH (wp:WikiPage { id: 'wiki-1' })
+     MERGE (a:User { username: 'wiki-author' })
+     MERGE (a)-[:AUTHORED_VERSION]->(wp)`
+  );
+
+  await reportWikiEdit({});
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedWikiPageId: 'wiki-1' })
+     RETURN i.relatedUsername AS relatedUsername`
+  );
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].relatedUsername, "wiki-author");
+});
+
+test("records the reported revision id and attributes the revision author", async () => {
+  await run(
+    `MERGE (ra:User { username: 'rev-author' })
+     CREATE (ra)-[:AUTHORED_VERSION]->(:TextVersion {
+       id: 'rev-1', body: 'bad edit', createdAt: datetime()
+     })`
+  );
+
+  await reportWikiEdit({ wikiRevisionId: "rev-1" });
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedWikiPageId: 'wiki-1' })
+     RETURN i.relatedWikiRevisionId AS revisionId, i.relatedUsername AS relatedUsername`
+  );
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].revisionId, "rev-1");
+  assert.equal(issues[0].relatedUsername, "rev-author");
+});


### PR DESCRIPTION
Fills the remaining gaps in the wiki-moderation backend coverage (no behavior changes — tests only). Complements the existing `canEditWikiPagesRule`, `redactTextVersionRevision`, and `reportWikiEdit` tests.

## Unit
- **`canEditWikiPagesRule`**: wiki page *creation* is blocked for a suspended user even when the wiki is enabled — complements the existing update / child-create / `updateChannels`-home suspension cases.
- **`redactTextVersionRevision`**: `assertCanRedactRevision` allows the **revision author** to redact their own wiki revision via authorship alone (no mod permission), alongside the existing non-author-rejection case.

## Integration (TestContainers / Neo4j)
- **`reportWikiEdit`**: the opened issue records `relatedWikiRevisionId` and attributes the wiki edit author — the page version author, or the revision author when a `wikiRevisionId` is supplied.

## Verification
- `canEditWikiPagesRule` + `redactTextVersionRevision`: 21 unit tests pass.
- `reportWikiEdit` integration: 6/6 pass against a Neo4j TestContainer.
- Pre-commit hook (lint + tsc + full unit suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)