### PR TITLE
Test owner actor attribution for download label changes

### DIFF
--- a/tests/integration/updateDownloadLabels.test.ts
+++ b/tests/integration/updateDownloadLabels.test.ts
@@ -87,6 +87,37 @@ test("owner removing a label disconnects it and records 'removed' history", asyn
   assert.ok(Number(removed[0].n) >= 1, "at least one 'removed' history entry expected");
 });
 
+test("attributes an owner's label change to the acting user (ActorUser)", async () => {
+  await updateLabels(["fo-1"]);
+
+  const userActor = await run(
+    `MATCH (:User { username: 'test-owner' })-[:MADE_LABEL_CHANGE]->(h:LabelChangeHistory { actionType: 'added' })
+     RETURN count(h) AS n`
+  );
+  assert.ok(
+    Number(userActor[0].n) >= 1,
+    "owner change should be attributed to the acting User"
+  );
+
+  const modActor = await run(
+    `MATCH (:ModerationProfile)-[:MADE_LABEL_CHANGE]->(:LabelChangeHistory)
+     RETURN count(*) AS n`
+  );
+  assert.equal(
+    Number(modActor[0].n),
+    0,
+    "owner change should not be attributed to a moderator profile"
+  );
+});
+
+// NOTE: the mod -> ActorMod attribution path is intentionally not integration
+// tested here. updateDownloadLabels resolves the actor via setUserDataOnContext,
+// which only populates ModerationProfile.displayName; the resolver's mod
+// permission check reads ModeratedChannels / AdminOfServers /
+// ModerationProfile.ModChannelRoles, none of which that helper loads, so a
+// non-owner moderator is currently always rejected (see analysis notes). Once
+// the resolver loads real mod permissions, add an ActorMod attribution test.
+
 test("a non-owner without mod permission is rejected", async () => {
   await assert.rejects(
     updateLabels(["fo-1"], modContext(env, mockToken({ username: "rando", email: "r@e2e.test" }))),


### PR DESCRIPTION
Adds the actor-attribution coverage gap for download label changes (tests only).

## Integration (TestContainers / Neo4j)
- Asserts an owner's label change is attributed to the acting **User** via `ActorUser` (`MADE_LABEL_CHANGE`), and **not** to any moderator profile — complementing the existing added/removed-history and non-owner-rejection tests.

## Why no mod → ActorMod test
While writing this I found the mod attribution path is currently **unreachable**: `updateDownloadLabels` resolves the actor via `setUserDataOnContext`, which only populates `ModerationProfile.displayName`, but the resolver's mod-permission check reads `ModeratedChannels` / `AdminOfServers` / `ModerationProfile.ModChannelRoles` — none of which that helper loads. So a non-owner moderator is **always rejected** by this resolver, and the `ActorMod` branch never runs. This looks like a latent backend bug (mods can't edit download labels), so I documented it in the test file rather than working around it. Worth a follow-up to load real mod permissions in the resolver.

Verification: `updateDownloadLabels` integration 4/4 pass; pre-commit (lint + tsc + full unit suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)