### PR TITLE
Test that owner label changes create no ModerationAction

### DIFF
--- a/tests/integration/updateDownloadLabels.test.ts
+++ b/tests/integration/updateDownloadLabels.test.ts
@@ -110,6 +110,19 @@ test("attributes an owner's label change to the acting user (ActorUser)", async 
   );
 });
 
+test("an owner's label change does not create a ModerationAction", async () => {
+  await updateLabels(["fo-1"]);
+
+  const actions = await run(
+    `MATCH (m:ModerationAction) RETURN count(m) AS n`
+  );
+  assert.equal(
+    Number(actions[0].n),
+    0,
+    "owner self-edit should not create a moderation action"
+  );
+});
+
 // NOTE: the mod -> ActorMod attribution path is intentionally not integration
 // tested here. updateDownloadLabels resolves the actor via setUserDataOnContext,
 // which only populates ModerationProfile.displayName; the resolver's mod


### PR DESCRIPTION
Follow-up coverage that landed after #91 was merged — re-submitted as its own PR.

Adds an integration assertion to `tests/integration/updateDownloadLabels.test.ts`: an owner's self-edit of download labels creates **no** `ModerationAction` (the ModerationAction path is mod-only). Complements the existing owner `ActorUser` attribution and non-owner rejection tests.

Verified: `updateDownloadLabels` integration 5/5; pre-commit (lint + tsc + full unit suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)