### PR TITLE
test(image-mod): image moderation permission + workflow coverage

### DIFF
--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -147,3 +147,37 @@ for (const { name, op } of authGatedReports) {
     assert.equal((result.data as Record<string, unknown> | null)?.[name], null);
   });
 }
+
+// The image archive/remove mutations are gated `and(isAuthenticated, <perm>)`
+// (canArchiveAndUnarchiveImage / canPermanentlyRemoveImage). Like the reports
+// above, an unauthenticated request must fail with the not-authenticated error
+// rather than the "Not Authorised!" default-deny fallback — proving the rule is
+// actually attached, not that the mutation is unmapped.
+const authGatedImageMod: Array<{ name: string; op: string }> = [
+  {
+    name: "archiveImage",
+    op: `mutation { archiveImage(imageId: "i", selectedForumRules: [], selectedServerRules: [], reportText: "t") { id } }`,
+  },
+  {
+    name: "unarchiveImage",
+    op: `mutation { unarchiveImage(imageId: "i") { id } }`,
+  },
+  {
+    name: "permanentlyRemoveImage",
+    op: `mutation { permanentlyRemoveImage(imageId: "i") { id } }`,
+  },
+];
+
+for (const { name, op } of authGatedImageMod) {
+  test(`${name} is wired (unauthenticated -> notAuthenticated, not default-deny)`, async () => {
+    const result = await execUnauthenticated(op);
+
+    assert.ok(result.errors && result.errors.length > 0, `${name} should error`);
+    assert.equal(
+      result.errors[0].message,
+      ERROR_MESSAGES.channel.notAuthenticated,
+      `${name} should be auth-gated, got: ${result.errors[0].message}`
+    );
+    assert.equal((result.data as Record<string, unknown> | null)?.[name], null);
+  });
+}

--- a/tests/integration/imageModerationCoverage.test.ts
+++ b/tests/integration/imageModerationCoverage.test.ts
@@ -1,0 +1,166 @@
+// Additional image-moderation integration coverage that the per-resolver tests
+// don't exercise: channel-scoped report/archive (the album-image case), the
+// BANNER variant of reportChannelImage, report idempotency (a second report
+// reopens/append rather than duplicating the issue), and re-removal rejection.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One" });
+});
+
+const ctx = () => modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }));
+
+const seedImage = () =>
+  run(
+    `CREATE (img:Image { id: 'img-1', url: 'https://example.com/pic.jpg', archived: false, permanentlyRemoved: false, scanStatus: 'PENDING' })
+     CREATE (u:User { username: 'uploader1' })
+     CREATE (u)-[:UPLOADED_IMAGE]->(img)`
+  );
+
+const reportImage = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.reportImage(
+    null,
+    { imageId: "img-1", reportText: "bad", selectedForumRules: [], selectedServerRules: [], channelUniqueName: null, ...args },
+    ctx()
+  );
+
+const archiveImage = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.archiveImage(
+    null,
+    { imageId: "img-1", reportText: "bad", selectedForumRules: [], selectedServerRules: [], channelUniqueName: null, ...args },
+    ctx()
+  );
+
+const reportChannelImage = (args: Record<string, unknown>) =>
+  env.resolvers.Mutation.reportChannelImage(null, args, ctx());
+
+const permanentlyRemoveImage = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.permanentlyRemoveImage(
+    null,
+    { imageId: "img-1", explanation: "remove", ...args },
+    ctx()
+  );
+
+// --- channel-scoped report/archive (album images) ---
+
+test("reportImage (channel-scoped) creates a channel Issue with a forum rule", async () => {
+  await run(`CREATE (:Channel { uniqueName: 'cats', displayName: 'Cats' })`);
+  await seedImage();
+
+  await reportImage({ channelUniqueName: "cats", selectedForumRules: ["Be kind"] });
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' })
+     RETURN i.channelUniqueName AS channel, i.isOpen AS isOpen`
+  );
+  assert.equal(issues.length, 1, "one channel-scoped issue");
+  assert.equal(issues[0].channel, "cats");
+
+  const actions = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  assert.ok((actions[0].types as string[]).includes("report"));
+});
+
+test("archiveImage (channel-scoped) archives the image and opens a channel Issue", async () => {
+  await run(`CREATE (:Channel { uniqueName: 'cats', displayName: 'Cats' })`);
+  await seedImage();
+
+  await archiveImage({ channelUniqueName: "cats", selectedForumRules: ["Be kind"] });
+
+  const img = await run(
+    `MATCH (i:Image { id: 'img-1' }) RETURN i.archived AS archived`
+  );
+  assert.equal(img[0].archived, true, "image is archived");
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' })
+     RETURN i.channelUniqueName AS channel`
+  );
+  assert.equal(issues[0].channel, "cats");
+
+  const actions = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  const types = actions[0].types as string[];
+  assert.ok(types.includes("archive"), `got ${JSON.stringify(types)}`);
+});
+
+// --- reportChannelImage BANNER (only ICON was covered) ---
+
+test("reportChannelImage opens a server-scoped Issue for a channel banner", async () => {
+  await run(
+    `CREATE (:Channel { uniqueName: 'badforum', displayName: 'Bad Forum', channelBannerURL: 'https://example.com/banner.png' })`
+  );
+
+  await reportChannelImage({
+    channelUniqueName: "badforum",
+    imageType: "BANNER",
+    reportText: "bad banner",
+    selectedServerRules: ["No inappropriate content"],
+  });
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedChannelBannerName: 'badforum' })
+     RETURN i.channelUniqueName AS channel, i.isOpen AS isOpen`
+  );
+  assert.equal(issues.length, 1, "one banner report issue");
+  assert.equal(issues[0].channel, null, "channel image reports are server-scoped");
+});
+
+// --- idempotency ---
+
+test("a second reportImage reopens the existing Issue and appends an action", async () => {
+  await seedImage();
+
+  await reportImage({ selectedServerRules: ["No inappropriate content"] });
+  await reportImage({ selectedServerRules: ["No inappropriate content"] });
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' }) RETURN count(i) AS n`
+  );
+  assert.equal(Number(issues[0].n), 1, "still exactly one issue for the image");
+
+  const actions = await run(
+    `MATCH (i:Issue { relatedImageId: 'img-1' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction { actionType: 'report' })
+     RETURN count(a) AS n`
+  );
+  assert.equal(Number(actions[0].n), 2, "both reports recorded on the one issue");
+});
+
+// --- re-removal rejection ---
+
+test("permanentlyRemoveImage rejects a second removal of the same image", async () => {
+  await seedImage();
+  await permanentlyRemoveImage();
+
+  await assert.rejects(
+    permanentlyRemoveImage(),
+    /already been permanently removed/i
+  );
+});

--- a/tests/integration/imagePermissions.test.ts
+++ b/tests/integration/imagePermissions.test.ts
@@ -1,0 +1,136 @@
+// Permission-enforcement tests for the image moderation mutations, run through
+// the REAL schema + graphql-shield against a live Neo4j (so the permission rules
+// actually execute against seeded data). The resolver-direct integration tests
+// exercise the happy path as a seeded moderator; these prove the security
+// boundary: a logged-in user WITHOUT the relevant permission is denied — and is
+// denied by the permission rule (not merely the isAuthenticated check).
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { graphql, type GraphQLSchema } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
+import { mockToken } from "./imageModerationHarness.js";
+import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
+
+const SERVER_CONFIG_NAME = "ImagePermTestServer";
+
+let container: StartedNeo4jContainer;
+let schema: GraphQLSchema;
+let driver: Driver;
+let ogm: any;
+
+before(async () => {
+  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  process.env.NEO4J_URI = container.getBoltUri();
+  process.env.NEO4J_USER = container.getUsername();
+  process.env.NEO4J_PASSWORD = container.getPassword();
+  process.env.E2E_MOCK_AUTH = "true";
+  process.env.SERVER_CONFIG_NAME = SERVER_CONFIG_NAME;
+
+  const { buildPermissionedSchema } = await import(
+    "../helpers/buildPermissionedSchema.js"
+  );
+  ({ schema, driver, ogm } = await buildPermissionedSchema());
+  await ogm.init();
+}, { timeout: 240000 });
+
+after(async () => {
+  await driver?.close();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  const session = driver.session();
+  try {
+    await session.run("MATCH (n) DETACH DELETE n");
+    await session.run(
+      `CREATE (:ServerConfig { serverName: $serverName })
+       CREATE (:User { username: 'regular' })
+       CREATE (:Image { id: 'img-1', url: 'https://example.com/i.png' })`,
+      { serverName: SERVER_CONFIG_NAME }
+    );
+  } finally {
+    await session.close();
+  }
+});
+
+const asUser = (username: string) => ({
+  driver,
+  ogm,
+  req: {
+    headers: {
+      authorization: `Bearer ${mockToken({ username, email: `${username}@e2e.test` })}`,
+    },
+    body: {},
+  },
+});
+
+const exec = (source: string, contextValue: unknown) =>
+  graphql({ schema, source, contextValue });
+
+// Helper: a denied-but-authenticated result has errors, nulls the field, and the
+// error is NOT the not-authenticated message (which would mean the auth check,
+// not the permission rule, blocked it).
+const assertAuthenticatedDenial = (result: any, field: string) => {
+  assert.ok(
+    result.errors && result.errors.length > 0,
+    `${field} should be denied`
+  );
+  assert.notEqual(
+    result.errors[0].message,
+    ERROR_MESSAGES.channel.notAuthenticated,
+    `${field} should be denied by the permission rule, not the auth check (got: ${result.errors[0].message})`
+  );
+  assert.equal(result.data?.[field], null, `${field} resolver must not run`);
+};
+
+test("a logged-in non-moderator cannot archive an image", async () => {
+  const result = await exec(
+    `mutation {
+       archiveImage(imageId: "img-1", selectedForumRules: [], selectedServerRules: ["No NSFW"], reportText: "x") { id }
+     }`,
+    asUser("regular")
+  );
+
+  assertAuthenticatedDenial(result, "archiveImage");
+
+  // The image must not have been archived.
+  const session = driver.session();
+  try {
+    const res = await session.run(
+      `MATCH (i:Image { id: 'img-1' }) RETURN coalesce(i.archived, false) AS archived`
+    );
+    assert.equal(res.records[0].get("archived"), false);
+  } finally {
+    await session.close();
+  }
+});
+
+test("a logged-in non-moderator cannot unarchive an image", async () => {
+  const result = await exec(
+    `mutation { unarchiveImage(imageId: "img-1") { id } }`,
+    asUser("regular")
+  );
+
+  assertAuthenticatedDenial(result, "unarchiveImage");
+});
+
+test("a logged-in non-moderator cannot permanently remove an image", async () => {
+  const result = await exec(
+    `mutation { permanentlyRemoveImage(imageId: "img-1") { id } }`,
+    asUser("regular")
+  );
+
+  assertAuthenticatedDenial(result, "permanentlyRemoveImage");
+
+  const session = driver.session();
+  try {
+    const res = await session.run(
+      `MATCH (i:Image { id: 'img-1' }) RETURN coalesce(i.permanentlyRemoved, false) AS removed`
+    );
+    assert.equal(res.records[0].get("removed"), false);
+  } finally {
+    await session.close();
+  }
+});


### PR DESCRIPTION
Adds backend test coverage for the image moderation workflows.

## HIGH — permission gating (`e410ee3`)
- **Wiring** (`tests/auth/mutationAuth.test.ts`): `archiveImage`, `unarchiveImage`, `permanentlyRemoveImage` reject unauthenticated callers with `notAuthenticated`, proving the permission rules are attached in the shield map.
- **Enforcement** (`tests/integration/imagePermissions.test.ts`): a logged-in **non-moderator** is denied archive / unarchive / permanently-remove via the real permissioned schema (`buildPermissionedSchema` + authenticated context) — error present, not the `notAuthenticated` message, and the mutation field resolves to null.

## MEDIUM — scope & lifecycle (`50e22ee`)
- `tests/integration/imageModerationCoverage.test.ts`:
  - channel-scoped `reportImage` / `archiveImage`
  - `reportChannelImage` with `imageType: BANNER`
  - report idempotency — a second `reportImage` reopens and appends to the same moderation issue rather than creating a duplicate
  - `permanentlyRemoveImage` rejects re-removal of an already-removed image

All new integration tests run against testcontainers Neo4j and pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)