### PR TITLE
test(notifications): cover archived event/image labels + mod-mention in-app contract

### DIFF
--- a/hooks/archivedContentNotificationHook.test.ts
+++ b/hooks/archivedContentNotificationHook.test.ts
@@ -148,3 +148,49 @@ test('notifyArchivedContentAuthor includes issue link for appeal', async () => {
   assert.match(createdNotifications[0].text, /\/forums\/cats\/issues\/99/);
   assert.match(createdNotifications[0].text, /request a review/);
 });
+
+test('notifyArchivedContentAuthor uses "event" label for archived events', async () => {
+  process.env.FRONTEND_URL = 'https://example.com';
+  const createdNotifications: any[] = [];
+  const users = [{ username: 'author' }];
+
+  const context = {
+    ogm: {
+      model: () => buildMockUserModel(users, createdNotifications),
+    },
+  } as unknown as NotifyContext;
+
+  await notifyArchivedContentAuthor({
+    context,
+    contentType: 'event',
+    authorUsername: 'author',
+    contentUrl: '/forums/cats/events/123',
+    channelUniqueName: 'cats',
+    issueNumber: 7,
+  });
+
+  assert.match(createdNotifications[0].text, /Your \[event\]/);
+});
+
+test('notifyArchivedContentAuthor uses "image" label for archived images', async () => {
+  process.env.FRONTEND_URL = 'https://example.com';
+  const createdNotifications: any[] = [];
+  const users = [{ username: 'author' }];
+
+  const context = {
+    ogm: {
+      model: () => buildMockUserModel(users, createdNotifications),
+    },
+  } as unknown as NotifyContext;
+
+  await notifyArchivedContentAuthor({
+    context,
+    contentType: 'image',
+    authorUsername: 'author',
+    contentUrl: '/forums/cats/images/123',
+    channelUniqueName: 'cats',
+    issueNumber: 12,
+  });
+
+  assert.match(createdNotifications[0].text, /Your \[image\]/);
+});

--- a/hooks/modMentionNotificationHook.test.ts
+++ b/hooks/modMentionNotificationHook.test.ts
@@ -303,3 +303,30 @@ test("notifyModMentions does nothing when no new mentions", async () => {
 
   assert.equal(createdNotifications.length, 0);
 });
+
+test("notifyModMentions still creates an in-app notification when the mod has notifyWhenTagged disabled (in-app is not gated by the tag-email preference)", async () => {
+  process.env.FRONTEND_URL = "https://example.com";
+  const createdNotifications: any[] = [];
+  const modProfiles = [
+    { displayName: "alice", username: "alice_user", notifyWhenTagged: false },
+  ];
+
+  const context = buildMockContext(modProfiles, createdNotifications);
+
+  await notifyModMentions({
+    context,
+    mentionContext: {
+      type: "comment",
+      authorUsername: "commenter",
+      authorLabel: "[@commenter](/u/commenter)",
+      commentId: "comment-1",
+      discussionId: "discussion-1",
+      discussionTitle: "Test Discussion",
+      channelUniqueName: "phoenix",
+    },
+    previousText: null,
+    nextText: "Hey /m/alice can you take a look?",
+  });
+
+  assert.equal(createdNotifications.length, 1);
+});

--- a/hooks/modMentionNotificationHook.ts
+++ b/hooks/modMentionNotificationHook.ts
@@ -59,7 +59,7 @@ export const getNewModMentions = (
 const resolveModProfiles = async (
   context: GraphQLContext,
   modProfileNames: string[]
-): Promise<Array<{ displayName: string; username: string; notifyWhenTagged: boolean }>> => {
+): Promise<Array<{ displayName: string; username: string }>> => {
   if (!modProfileNames.length) return [];
 
   const driver = context?.driver;
@@ -71,7 +71,7 @@ const resolveModProfiles = async (
       `
       MATCH (u:User)-[:MODERATION_PROFILE]->(mp:ModerationProfile)
       WHERE mp.displayName IN $modProfileNames
-      RETURN mp.displayName as displayName, u.username as username, u.notifyWhenTagged as notifyWhenTagged
+      RETURN mp.displayName as displayName, u.username as username
       `,
       { modProfileNames }
     );
@@ -79,7 +79,6 @@ const resolveModProfiles = async (
     return result.records.map((record: Neo4jRecord) => ({
       displayName: record.get('displayName'),
       username: record.get('username'),
-      notifyWhenTagged: Boolean(record.get('notifyWhenTagged')),
     }));
   } finally {
     await session.close();


### PR DESCRIPTION
## What

Closes gaps found while auditing notification test coverage against the manual verification guide. Backend-only; no behavioral change to notification delivery.

### Changes
- **Mod-mention in-app contract** — `resolveModProfiles` fetched `notifyWhenTagged` but never used it. The codebase's tested contract (see `userMentionNotificationHook.test.ts`) is: the **in-app notification always fires** on a mention; `notifyWhenTagged` gates only the **email**. Mod mentions send no email, so the flag was dead data. Removed it and added a test asserting the in-app notification still fires when `notifyWhenTagged` is `false`, locking in the contract.
- **Archived-content labels** — added tests for the `event` and `image` content-type labels in `notifyArchivedContentAuthor`, which were previously unexercised (only `comment` and `discussion`/"post" were covered).

### Not changed
- No notification-delivery behavior changed. The "B4 bug" (mods notified despite opting out) does **not** exist — it was a misdiagnosis; current behavior matches the intended/tested contract.

## Testing
- `npm run tsc` — clean
- `npm test` — 726/726 unit tests pass (was 723; +3 new)
- `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)