### PR TITLE
Block content creation in locked channels (+ tests)

### DIFF
--- a/rules/errorMessages.ts
+++ b/rules/errorMessages.ts
@@ -31,6 +31,7 @@ export const ERROR_MESSAGES = {
     notVerified: "You must verify your email address to do that.",
     notOwner: "You must be the owner of this channel to do that.",
     noChannelPermission: "You do not have permission to do that in this channel.",
+    locked: "This forum is locked. New discussions, events, and comments cannot be created until a server moderator unlocks it.",
     notMod: "You need to be a moderator to do that.",
     noModRole: "You need to have a moderator role to do that.",
     noModPermission: "You do not have permission to do that as a moderator.",

--- a/rules/permission/hasChannelPermission.ts
+++ b/rules/permission/hasChannelPermission.ts
@@ -259,23 +259,55 @@ type CheckChannelPermissionInput = {
   permissionCheck: keyof ChannelRole;
 };
 
+/**
+ * A locked channel is frozen: no new discussions, events, comments, or wiki
+ * edits may be created by anyone — including channel owners and server admins.
+ * A server moderator with `canLockChannel` must unlock the forum first (this
+ * mirrors the per-entity lock convention in contentCreationRules, where a
+ * locked discussion/event/comment is read-only regardless of the actor).
+ *
+ * Returns an Error when the channel is locked, otherwise null.
+ */
+async function getChannelLockError(
+  channelName: string,
+  context: GraphQLContext
+): Promise<Error | null> {
+  const Channel = context.ogm.model("Channel");
+  const channel = await Channel.find({
+    where: { uniqueName: channelName },
+    selectionSet: `{ locked }`,
+  });
+
+  if (channel?.[0]?.locked) {
+    return new Error(ERROR_MESSAGES.channel.locked);
+  }
+  return null;
+}
+
 // Helper function to check channel permissions across multiple channels
 export async function checkChannelPermissions(
   input: CheckChannelPermissionInput
 ) {
   const { channelConnections, context, permissionCheck } = input;
-  
+
   // Check for JWT errors first (expired tokens, etc.)
   if (context.jwtError) {
     return context.jwtError;
   }
-  
+
   // Check if we have valid channel connections
   if (!channelConnections || channelConnections.length === 0 || !channelConnections[0]) {
     return new Error("No channel specified for this operation.");
   }
 
   for (const channelConnection of channelConnections) {
+    // A locked forum blocks content creation for everyone; surface a clear
+    // reason before falling through to the per-role permission check.
+    const lockError = await getChannelLockError(channelConnection, context);
+    if (lockError) {
+      return lockError;
+    }
+
     const permissionResult = await hasChannelPermission({
       permission: permissionCheck,
       channelName: channelConnection,

--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -147,3 +147,35 @@ for (const { name, op } of authGatedReports) {
     assert.equal((result.data as Record<string, unknown> | null)?.[name], null);
   });
 }
+
+// Channel lock/unlock are gated `and(isAuthenticated, canLockChannel)` — a
+// server-mod-scoped capability. The full role matrix (who holds canLockChannel)
+// is covered at the rule level in hasServerModPermission.test.ts; here we prove
+// the rules are actually attached to these mutations, so an unauthenticated
+// request fails with notAuthenticated rather than slipping through or hitting
+// the default-deny fallback.
+const authGatedChannelLock: Array<{ name: string; op: string }> = [
+  {
+    name: "lockChannel",
+    op: `mutation { lockChannel(channelUniqueName: "c", reason: "r") { uniqueName } }`,
+  },
+  {
+    name: "unlockChannel",
+    op: `mutation { unlockChannel(channelUniqueName: "c") { uniqueName } }`,
+  },
+];
+
+for (const { name, op } of authGatedChannelLock) {
+  test(`${name} is auth-gated (unauthenticated -> notAuthenticated, not default-deny)`, async () => {
+    const result = await execUnauthenticated(op);
+
+    assert.ok(result.errors && result.errors.length > 0, `${name} should error`);
+    assert.equal(
+      result.errors[0].message,
+      ERROR_MESSAGES.channel.notAuthenticated,
+      `${name} should be auth-gated, got: ${result.errors[0].message}`
+    );
+    // Channel is nullable, so a denied field nulls itself (rather than all of data).
+    assert.equal((result.data as Record<string, unknown> | null)?.[name], null);
+  });
+}

--- a/tests/integration/channelLockEdgeCases.test.ts
+++ b/tests/integration/channelLockEdgeCases.test.ts
@@ -1,0 +1,173 @@
+// Integration tests for channel lock/unlock/report edge cases against live
+// Neo4j, complementing lockChannel.test.ts and channelModeration.test.ts (which
+// cover the happy paths). These focus on cross-mutation interactions and
+// cleanup the existing suites don't assert:
+//
+//   - unlock leaves the issue OPEN, records an unlock_channel action, and
+//     disconnects the LockedBy ModerationProfile (lock-state cleanup)
+//   - report-then-lock funnels into a SINGLE server-scoped issue carrying both
+//     the report and lock_channel actions (issue de-duplication)
+//   - admin notifications: every admin is notified, no admins is graceful, and
+//     the unlock notification differs from the lock one
+//
+// We call the resolvers directly via the harness (the shield/permission wiring
+// is covered separately by the auth tests).
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One", email: "mod1@e2e.test" });
+});
+
+const ctx = () => modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }));
+
+const lockChannel = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.lockChannel(
+    null,
+    { channelUniqueName: "test-channel", reason: "Spam wave", ...args },
+    ctx()
+  );
+
+const unlockChannel = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.unlockChannel(
+    null,
+    { channelUniqueName: "test-channel", reason: "Resolved", ...args },
+    ctx()
+  );
+
+const reportChannel = (args: Record<string, unknown> = {}) =>
+  env.resolvers.Mutation.reportChannel(
+    null,
+    {
+      channelUniqueName: "test-channel",
+      reportText: "Violates server rules",
+      selectedServerRules: ["No spam"],
+      ...args,
+    },
+    ctx()
+  );
+
+const createChannel = (admins: string[] = []) =>
+  run(
+    `CREATE (c:Channel { uniqueName: 'test-channel', displayName: 'Test Channel', locked: false })
+     WITH c
+     UNWIND $admins AS adminName
+     CREATE (:User { username: adminName })-[:ADMIN_OF_CHANNEL]->(c)`,
+    { admins }
+  );
+
+// --- Unlock: issue state + LockedBy cleanup ---
+
+test("unlock leaves the related issue open and records an unlock_channel action", async () => {
+  await createChannel();
+  await lockChannel();
+  await unlockChannel();
+
+  const issue = await run(
+    `MATCH (i:Issue { relatedChannelUniqueName: 'test-channel' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN i.isOpen AS isOpen, collect(a.actionType) AS types`
+  );
+  assert.deepEqual(
+    { isOpen: issue[0].isOpen, hasLock: (issue[0].types as string[]).includes("lock_channel"), hasUnlock: (issue[0].types as string[]).includes("unlock_channel") },
+    { isOpen: true, hasLock: true, hasUnlock: true }
+  );
+});
+
+test("unlock disconnects the LockedBy moderation profile", async () => {
+  await createChannel();
+  await lockChannel();
+  await unlockChannel();
+
+  const lockedBy = await run(
+    `MATCH (c:Channel { uniqueName: 'test-channel' })
+     OPTIONAL MATCH (c)<-[:LOCKED_CHANNEL]-(mp:ModerationProfile)
+     RETURN c.locked AS locked, c.lockedAt AS lockedAt, c.lockReason AS reason, mp.displayName AS lockedBy`
+  );
+  assert.deepEqual(lockedBy[0], { locked: false, lockedAt: null, reason: null, lockedBy: null });
+});
+
+// --- Report then lock: single issue carries both actions ---
+
+test("reporting then locking a channel funnels both actions into one server-scoped issue", async () => {
+  await createChannel();
+  await reportChannel();
+  await lockChannel();
+
+  const issues = await run(
+    `MATCH (i:Issue { relatedChannelUniqueName: 'test-channel' }) RETURN count(i) AS n`
+  );
+  assert.equal(Number(issues[0].n), 1, "report and lock share a single issue");
+});
+
+test("the shared report+lock issue carries both the report and lock_channel actions", async () => {
+  await createChannel();
+  await reportChannel();
+  await lockChannel();
+
+  const actions = await run(
+    `MATCH (:Issue { relatedChannelUniqueName: 'test-channel' })-[:ACTIVITY_ON_ISSUE]->(a:ModerationAction)
+     RETURN collect(a.actionType) AS types`
+  );
+  const types = (actions[0].types as string[]).sort();
+  assert.deepEqual(types, ["lock_channel", "report"]);
+});
+
+// --- Notification edge cases ---
+
+test("locking notifies every channel admin", async () => {
+  await createChannel(["admin1", "admin2", "admin3"]);
+  await lockChannel();
+
+  const notified = await run(
+    `MATCH (u:User)-[:HAS_NOTIFICATION]->(n:Notification)
+     WHERE n.text CONTAINS 'has been locked'
+     RETURN collect(u.username) AS users`
+  );
+  assert.deepEqual((notified[0].users as string[]).sort(), ["admin1", "admin2", "admin3"]);
+});
+
+test("locking a channel with no admins succeeds without creating notifications", async () => {
+  await createChannel([]);
+  const result = await lockChannel();
+
+  const notifs = await run(`MATCH (n:Notification) RETURN count(n) AS n`);
+  assert.deepEqual({ locked: result?.locked, notifications: Number(notifs[0].n) }, { locked: true, notifications: 0 });
+});
+
+test("unlocking notifies admins with an unlock message distinct from the lock one", async () => {
+  await createChannel(["admin1"]);
+  await lockChannel();
+  await unlockChannel();
+
+  const notifs = await run(
+    `MATCH (:User { username: 'admin1' })-[:HAS_NOTIFICATION]->(n:Notification)
+     RETURN collect(n.text) AS texts`
+  );
+  const texts = notifs[0].texts as string[];
+  assert.equal(
+    texts.some((t) => /has been unlocked/i.test(t)) && texts.some((t) => /has been locked/i.test(t)),
+    true
+  );
+});

--- a/tests/integration/channelLockEnforcement.test.ts
+++ b/tests/integration/channelLockEnforcement.test.ts
@@ -1,0 +1,105 @@
+// Integration tests for the locked-channel content-creation block against live
+// Neo4j. A locked forum is frozen: new discussions, events, and comments are
+// rejected for everyone — including channel owners — until a server moderator
+// unlocks it.
+//
+// The enforcement lives in checkChannelPermissions (the shared chokepoint that
+// canCreateDiscussion / canCreateEvent / canCreateComment all funnel through),
+// so we exercise that helper directly against a real database. This needs the
+// OGM + live Neo4j because the gate reads the channel's `locked` flag from the
+// graph. The end-to-end shield wiring of the create mutations is covered by the
+// auth tests; here we prove the lock gate itself, across all three content
+// permissions and against the channel-owner bypass.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+import { checkChannelPermissions } from "../../rules/permission/hasChannelPermission.js";
+import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+  // hasChannelPermission resolves the server-config default roles by this name
+  // when it reaches the non-owner path; seed it so the unlocked control case is
+  // deterministic.
+  process.env.SERVER_CONFIG_NAME = "E2ETestServer";
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await run(`CREATE (:ServerConfig { serverName: 'E2ETestServer' })`);
+  // owner1 is a channel admin (ADMIN_OF_CHANNEL) of both forums, so the "locked
+  // blocks even owners" and "unlocked allows owners" cases differ only by the
+  // channel's lock state.
+  await run(`CREATE (:User { username: 'owner1' })`);
+  await run(`CREATE (:User { username: 'member1' })`);
+  await run(
+    `CREATE (lc:Channel { uniqueName: 'locked-channel', displayName: 'Locked', locked: true })
+     CREATE (oc:Channel { uniqueName: 'open-channel', displayName: 'Open', locked: false })
+     WITH lc, oc
+     MATCH (o:User { username: 'owner1' })
+     CREATE (o)-[:ADMIN_OF_CHANNEL]->(lc)
+     CREATE (o)-[:ADMIN_OF_CHANNEL]->(oc)`
+  );
+});
+
+const contextFor = (username: string) =>
+  modContext(env, mockToken({ username, email: `${username}@e2e.test` }));
+
+const check = (channel: string, permission: string, username: string) =>
+  checkChannelPermissions({
+    channelConnections: [channel],
+    context: contextFor(username) as any,
+    permissionCheck: permission as any,
+  });
+
+test("a locked channel blocks discussion creation", async () => {
+  const result = await check("locked-channel", "canCreateDiscussion", "member1");
+  assert.equal(
+    (result as Error).message,
+    ERROR_MESSAGES.channel.locked
+  );
+});
+
+test("a locked channel blocks event creation", async () => {
+  const result = await check("locked-channel", "canCreateEvent", "member1");
+  assert.equal(
+    (result as Error).message,
+    ERROR_MESSAGES.channel.locked
+  );
+});
+
+test("a locked channel blocks comment creation", async () => {
+  const result = await check("locked-channel", "canCreateComment", "member1");
+  assert.equal(
+    (result as Error).message,
+    ERROR_MESSAGES.channel.locked
+  );
+});
+
+test("a locked channel blocks even a channel owner (frozen for everyone)", async () => {
+  const result = await check("locked-channel", "canCreateDiscussion", "owner1");
+  assert.equal(
+    (result as Error).message,
+    ERROR_MESSAGES.channel.locked
+  );
+});
+
+test("an unlocked channel allows a channel owner to create content (the gate is specific to lock state)", async () => {
+  const result = await check("open-channel", "canCreateDiscussion", "owner1");
+  assert.equal(result, true);
+});


### PR DESCRIPTION
## Summary

A locked forum is now actually frozen on the server: new discussions, events, comments, and wiki edits are rejected for everyone (including channel owners and server admins) until a server moderator unlocks it. Previously the lock state existed and was displayed, but the backend never enforced it on content creation.

Enforcement lives at the shared `checkChannelPermissions` chokepoint (`rules/permission/hasChannelPermission.ts`) — the single path that `canCreateDiscussion`, `canCreateEvent`, `canCreateComment`, and `canUpdateChannel` (wiki) all funnel through — so the block is uniform and mirrors the existing per-entity lock convention (`contentCreationRules.ts`). Mod feedback and moderation actions stay available so a server mod can still unlock.

## Changes

- `rules/permission/hasChannelPermission.ts` — reject content creation when the channel is `locked`, before the per-role checks, with a clear message.
- `rules/errorMessages.ts` — new `channel.locked` message.

## Tests (14 new, all green)

- **Integration (live Neo4j via testcontainers):**
  - `channelLockEnforcement.test.ts` (5) — locked channel blocks discussion/event/comment creation, blocks even a channel owner, and an unlocked channel still allows the owner (gate is lock-specific).
  - `channelLockEdgeCases.test.ts` (7) — unlock leaves the issue open + records an `unlock_channel` action + disconnects `LockedBy`; report-then-lock funnels into one server-scoped issue; admin notifications (all admins / no-admins graceful / unlock text distinct).
- **Auth wiring (offline graphql-shield):** `mutationAuth.test.ts` (2) — `lockChannel`/`unlockChannel` are gated by `and(isAuthenticated, canLockChannel)`.

`npm run tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)