### PR TITLE
test(redaction): author/admin matrix (unit) + real Cypher type-detection (integration)

### DIFF
--- a/customResolvers/mutations/redactTextVersionRevision.test.ts
+++ b/customResolvers/mutations/redactTextVersionRevision.test.ts
@@ -355,3 +355,140 @@ test('assertCanRedactRevision rejects non-authors without mod permission', async
     /No mod permission/
   )
 })
+
+test('assertCanRedactRevision allows a comment author to redact their own comment revision', async () => {
+  await assert.doesNotReject(
+    assertCanRedactRevision({
+      context: {
+        user: { username: 'alice', data: { ModerationProfile: null } }
+      } as unknown as GraphQLContext,
+      target: {
+        targetType: 'comment',
+        targetId: 'comment-1',
+        ownerUsername: 'alice',
+        ownerModProfileName: null,
+        channelUniqueName: 'cats'
+      },
+      revisionType: 'comment',
+      // No mod permission: authorization must come from authorship alone.
+      checkModPermissions: async () => new Error('No mod permission'),
+      getServerMembership: async () => ({
+        isServerAdmin: false,
+        isServerModerator: false
+      }),
+      getUserData: async () => ({
+        username: 'alice',
+        email: null,
+        email_verified: false,
+        data: null
+      })
+    })
+  )
+})
+
+test('assertCanRedactRevision allows a discussion OP to redact their own discussion body revision', async () => {
+  await assert.doesNotReject(
+    assertCanRedactRevision({
+      context: {
+        user: { username: 'alice', data: { ModerationProfile: null } }
+      } as unknown as GraphQLContext,
+      target: {
+        targetType: 'discussion body',
+        targetId: 'discussion-1',
+        ownerUsername: 'alice',
+        ownerModProfileName: null,
+        channelUniqueName: 'cats'
+      },
+      revisionType: 'discussion body',
+      // No mod permission: authorization must come from authorship alone.
+      checkModPermissions: async () => new Error('No mod permission'),
+      getServerMembership: async () => ({
+        isServerAdmin: false,
+        isServerModerator: false
+      }),
+      getUserData: async () => ({
+        username: 'alice',
+        email: null,
+        email_verified: false,
+        data: null
+      })
+    })
+  )
+})
+
+test('assertCanRedactRevision allows a server admin to redact a revision they do not own', async () => {
+  let checkedModPermissions = false
+  await assert.doesNotReject(
+    assertCanRedactRevision({
+      context: {
+        user: { username: 'admin', data: { ModerationProfile: null } }
+      } as unknown as GraphQLContext,
+      target: {
+        targetType: 'comment',
+        targetId: 'comment-1',
+        ownerUsername: 'alice',
+        ownerModProfileName: null,
+        channelUniqueName: 'cats'
+      },
+      revisionType: 'comment',
+      // Not the author and no channel mod permission: authorization must come
+      // from server-admin status, which short-circuits the mod permission check.
+      checkModPermissions: async () => {
+        checkedModPermissions = true
+        return new Error('No mod permission')
+      },
+      getServerMembership: async () => ({
+        isServerAdmin: true,
+        isServerModerator: false
+      }),
+      getUserData: async () => ({
+        username: 'admin',
+        email: null,
+        email_verified: false,
+        data: null
+      })
+    })
+  )
+  assert.equal(checkedModPermissions, false)
+})
+
+test('redactTextVersionRevision lets a moderator with the edit permission redact a comment revision', async () => {
+  const updatedRevision = {
+    id: 'version-1',
+    body: REDACTED_REVISION_BODY
+  }
+  const { TextVersion, calls } = buildTextVersionModel({
+    findResult: [{ id: 'version-1', body: 'old text' }],
+    updateResult: { textVersions: [updatedRevision] }
+  })
+  const { driver } = buildDriver({
+    targetType: 'comment',
+    targetId: 'comment-1',
+    ownerUsername: 'alice',
+    ownerModProfileName: null,
+    channelUniqueName: 'cats'
+  })
+  const permissionCalls: any[] = []
+  const resolver = redactTextVersionRevision(
+    buildResolverInput({
+      TextVersion,
+      driver,
+      revisionType: 'comment',
+      checkModPermissions: async (input: any) => {
+        permissionCalls.push(input)
+        return true
+      }
+    })
+  )
+
+  await resolver(
+    null,
+    { textVersionId: 'version-1' },
+    { user: { username: 'mod', data: { ModerationProfile: { displayName: 'mod-cats' } } } } as unknown as GraphQLContext,
+    {} as unknown as GraphQLResolveInfo
+  )
+
+  assert.equal(calls.update.length, 1)
+  assert.deepEqual(permissionCalls[0].channelConnections, ['cats'])
+  assert.equal(permissionCalls[0].permissionCheck, 'canEditComments')
+})

--- a/tests/integration/revisionRedaction.test.ts
+++ b/tests/integration/revisionRedaction.test.ts
@@ -1,0 +1,140 @@
+// Integration tests for the revision-redaction mutations against live Neo4j.
+//
+// The unit tests (customResolvers/mutations/redactTextVersionRevision.test.ts)
+// mock getRevisionRedactionTarget, so they never exercise the real Cypher that
+// walks Comment / Discussion / WikiPage -> TextVersion to resolve the revision's
+// type, owner, and channel. These tests do, against a real graph — covering the
+// author-authorship path for each of the three supported parent types plus the
+// mismatched-mutation rejection.
+//
+// The server-admin and channel-mod-permission branches are covered by the unit
+// tests + the dedicated permission-rule tests; they depend on a cached
+// ServerConfig / SERVER_CONFIG_NAME that is awkward to seed reliably in the
+// shared container, so they are intentionally not re-exercised here.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import type { GraphQLContext } from "../../types/context.js";
+import type { GraphQLResolveInfo } from "graphql";
+import { REDACTED_REVISION_BODY } from "../../customResolvers/mutations/redactTextVersionRevision.js";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+// An authenticated context for `username`; setUserDataOnContext decodes the
+// mock JWT, so the resolver resolves the caller from these claims.
+const ctxFor = (username: string) =>
+  modContext(
+    env,
+    mockToken({ username, email: `${username}@e2e.test` })
+  ) as unknown as GraphQLContext;
+
+const bodyOf = async (textVersionId: string) => {
+  const rows = await run(
+    `MATCH (v:TextVersion { id: $textVersionId }) RETURN v.body AS body`,
+    { textVersionId }
+  );
+  return rows[0]?.body as string | undefined;
+};
+
+const info = {} as unknown as GraphQLResolveInfo;
+
+test("a comment author can redact their own comment revision", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (c:Comment { id: 'c1', text: 'old text', isRootComment: true, createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-comment', body: 'old text', createdAt: datetime() })
+     CREATE (c)-[:HAS_VERSION]->(v)
+     CREATE (alice)-[:AUTHORED_COMMENT]->(c)`
+  );
+
+  await env.resolvers.Mutation.deleteCommentRevision(
+    null,
+    { textVersionId: "v-comment" },
+    ctxFor("alice"),
+    info
+  );
+
+  assert.equal(await bodyOf("v-comment"), REDACTED_REVISION_BODY);
+});
+
+test("a discussion OP can redact their own discussion body revision", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (d:Discussion { id: 'd1', title: 'My Discussion', createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-discussion', body: 'old body', createdAt: datetime() })
+     CREATE (d)-[:HAS_BODY_VERSION]->(v)
+     CREATE (alice)-[:POSTED_DISCUSSION]->(d)`
+  );
+
+  await env.resolvers.Mutation.deleteDiscussionBodyRevision(
+    null,
+    { textVersionId: "v-discussion" },
+    ctxFor("alice"),
+    info
+  );
+
+  assert.equal(await bodyOf("v-discussion"), REDACTED_REVISION_BODY);
+});
+
+test("a wiki page original author can redact a wiki revision", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (w:WikiPage { id: 'w1', title: 'My Wiki', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-wiki', body: 'old wiki', createdAt: datetime() })
+     CREATE (w)-[:HAS_VERSION]->(v)
+     CREATE (alice)-[:AUTHORED_WIKI_PAGE]->(w)`
+  );
+
+  await env.resolvers.Mutation.deleteWikiRevision(
+    null,
+    { textVersionId: "v-wiki" },
+    ctxFor("alice"),
+    info
+  );
+
+  assert.equal(await bodyOf("v-wiki"), REDACTED_REVISION_BODY);
+});
+
+test("calling deleteCommentRevision with a wiki revision id is rejected", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (w:WikiPage { id: 'w1', title: 'My Wiki', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-wiki', body: 'old wiki', createdAt: datetime() })
+     CREATE (w)-[:HAS_VERSION]->(v)
+     CREATE (alice)-[:AUTHORED_WIKI_PAGE]->(w)`
+  );
+
+  await assert.rejects(
+    env.resolvers.Mutation.deleteCommentRevision(
+      null,
+      { textVersionId: "v-wiki" },
+      ctxFor("alice"),
+      info
+    ),
+    /comment revision not found/
+  );
+
+  // The wiki revision is untouched by the mismatched mutation.
+  assert.equal(await bodyOf("v-wiki"), "old wiki");
+});


### PR DESCRIPTION
## What

Closes test gaps in the revision-redaction permission model (`deleteCommentRevision` / `deleteDiscussionBodyRevision` / `deleteWikiRevision`).

### Unit (`customResolvers/mutations/redactTextVersionRevision.test.ts`, +4)
Adds the missing authorization-matrix cases:
- comment **author** redacts own comment revision
- discussion **OP** redacts own discussion body revision
- **server admin** redacts a revision they don't own (and the mod-permission check is short-circuited)
- moderator with **`canEditComments`** redacts a comment revision — the `comment → canEditComments` mapping was previously only covered for discussions/wiki

### Integration (`tests/integration/revisionRedaction.test.ts`, new)
The unit tests mock `getRevisionRedactionTarget`, so the real Cypher that walks `Comment`/`Discussion`/`WikiPage → TextVersion` to resolve the revision's type/owner/channel was **never exercised**. These run it against live Neo4j:
- comment / discussion / wiki **author** redaction end-to-end (verifies type-detection for all three parent types + the body becomes `[deleted]`)
- **mismatched mutation** rejected — `deleteCommentRevision` with a wiki revision id throws "comment revision not found" and leaves the wiki revision untouched

### Scope note
The server-admin and channel-mod-permission *branches* are covered at the unit level (above) and by the dedicated `hasChannelModPermission` / `getServerScopedMembership` tests. They depend on a cached `ServerConfig` + `SERVER_CONFIG_NAME`, which is awkward to seed reliably in the shared testcontainer, so they're intentionally not re-exercised at the integration level — the integration suite focuses on the DB-specific risk (the type-detection Cypher).

## Testing
- `npm run tsc` — clean
- `npm test` (unit) — 730/730 pass (+4)
- `npm run test:integration -- tests/integration/revisionRedaction.test.ts` — 4/4 pass against Neo4j
- `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)