### PR TITLE
test(suspension): integration coverage for valid issue links in block notifications

### DIFF
--- a/tests/integration/suspensionNotificationLinks.test.ts
+++ b/tests/integration/suspensionNotificationLinks.test.ts
@@ -1,0 +1,142 @@
+// Integration tests for the suspension-block notification's issue link against
+// live Neo4j.
+//
+// Both getActiveSuspension and suspensionNotification have unit tests, but those
+// mock the driver — so the chain that makes the link "valid" is never exercised
+// against a real graph: (a) resolving the related issue's number from the
+// suspension's (:Suspension)-[:HAS_CONTEXT]->(:Issue) edge, and (b) persisting a
+// notification whose markdown link points at that real issue. These tests drive
+// the two real DB-touching layers, using a suspension created by the actual
+// suspendUser resolver.
+//
+// Channel scope only: getActiveSuspension takes ogm/driver directly, whereas the
+// server-scoped path depends on a cached ServerConfig + SERVER_CONFIG_NAME that
+// is awkward to seed reliably here. The server link format (/admin/issues/N) is
+// covered by the suspensionNotification unit tests.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  seedModerator,
+  mockToken,
+  modContext,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+import { getActiveSuspension } from "../../rules/permission/getActiveSuspension.js";
+import { createSuspensionNotification } from "../../rules/permission/suspensionNotification.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seedModerator({ username: "mod1", modDisplayName: "Mod One" });
+  // A channel-scoped Issue targeting "baduser", and the channel that owns it.
+  await run(
+    `CREATE (ch:Channel { uniqueName: 'test-channel', displayName: 'Test Channel', createdAt: datetime() })
+     CREATE (target:User { username: 'baduser', displayName: 'Bad User', createdAt: datetime() })
+     CREATE (i:Issue {
+        id: 'issue-1', issueNumber: 1, isOpen: true,
+        channelUniqueName: 'test-channel', relatedUsername: 'baduser',
+        title: 'Report against baduser', authorName: 'Mod One', createdAt: datetime()
+     })
+     CREATE (ch)-[:HAS_ISSUE]->(i)`
+  );
+  // Create a real, indefinite suspension for baduser tied to issue-1 via the
+  // actual resolver, so the suspension graph (including its issue context) is
+  // shaped exactly as production builds it.
+  await env.resolvers.Mutation.suspendUser(
+    null,
+    {
+      issueId: "issue-1",
+      suspendIndefinitely: true,
+      explanation: "Repeated rule violations",
+    },
+    modContext(env, mockToken({ username: "mod1", email: "mod1@e2e.test" }))
+  );
+});
+
+const notificationsFor = (username: string) =>
+  run(
+    `MATCH (:User { username: $username })-[:HAS_NOTIFICATION]->(n:Notification)
+     RETURN n.text AS text`,
+    { username }
+  );
+
+const userModel = () => env.ogm.model("User");
+
+test("getActiveSuspension resolves the related issue number from the suspension graph", async () => {
+  const info = await getActiveSuspension({
+    ogm: env.ogm,
+    driver: env.driver,
+    channelUniqueName: "test-channel",
+    username: "baduser",
+  });
+
+  assert.equal(info.isSuspended, true);
+  assert.equal(info.relatedIssueNumber, 1);
+});
+
+test("the suspension block notification links to the related issue with a valid URL", async () => {
+  const info = await getActiveSuspension({
+    ogm: env.ogm,
+    driver: env.driver,
+    channelUniqueName: "test-channel",
+    username: "baduser",
+  });
+
+  await createSuspensionNotification({
+    UserModel: userModel(),
+    username: "baduser",
+    scopeName: "test-channel",
+    scopeType: "channel",
+    permission: "canCreateDiscussion",
+    relatedIssueId: info.relatedIssueId,
+    relatedIssueNumber: info.relatedIssueNumber,
+    suspendedUntil: info.activeSuspension?.suspendedUntil || null,
+    suspendedIndefinitely:
+      info.activeSuspension?.suspendedIndefinitely || null,
+    actorType: "user",
+  });
+
+  const notes = await notificationsFor("baduser");
+  assert.equal(notes.length, 1);
+  // The link uses the real issue number resolved from the suspension graph.
+  assert.match(
+    notes[0].text,
+    /\[Issue #1\]\(\/forums\/test-channel\/issues\/1\)/
+  );
+});
+
+test("no suspension block notification is created when the user has opted out", async () => {
+  await run(
+    `MATCH (u:User { username: 'baduser' }) SET u.notifyOnSuspensionBlocks = false`
+  );
+
+  await createSuspensionNotification({
+    UserModel: userModel(),
+    username: "baduser",
+    scopeName: "test-channel",
+    scopeType: "channel",
+    permission: "canCreateDiscussion",
+    relatedIssueId: "issue-1",
+    relatedIssueNumber: 1,
+    suspendedUntil: null,
+    suspendedIndefinitely: true,
+    actorType: "user",
+  });
+
+  const notes = await notificationsFor("baduser");
+  assert.equal(notes.length, 0);
+});


### PR DESCRIPTION
## What

Answers a real gap: there were **no integration tests** verifying that a suspension-block notification's issue link is valid (points at the real related issue). `getActiveSuspension` and `suspensionNotification` are both unit-tested, but with **mocked drivers** — so the chain that makes the link valid was never exercised against a real graph.

`tests/integration/suspensionNotificationLinks.test.ts` drives the two real DB-touching layers against live Neo4j, using a suspension created by the actual `suspendUser` resolver (so the suspension graph matches production):

1. **`getActiveSuspension` resolves `relatedIssueNumber`** from the real `(:Suspension)-[:HAS_CONTEXT]->(:Issue)` edge — previously only unit-mocked.
2. **The notification link is valid** — `createSuspensionNotification` persists a `Notification` whose markdown link `/forums/<channel>/issues/<n>` uses that real issue number.
3. **Opt-out is enforced** — with `notifyOnSuspensionBlocks = false`, no notification node is created.

## Scope note
Channel scope only. The server-scoped path (`/admin/issues/<n>`) depends on a cached `ServerConfig` + `SERVER_CONFIG_NAME` that's awkward to seed reliably in the shared testcontainer; its link format remains covered by the `suspensionNotification` unit tests.

This also closes the "blocked-action → notification" end-to-end gap flagged in the earlier coverage review (notification creation + opt-out suppression verified against a real DB).

## Testing
- `npm run tsc` — clean
- `npm run test:integration -- tests/integration/suspensionNotificationLinks.test.ts` — 3/3 pass against Neo4j
- `npm test` (unit) — 726/726 (integration file excluded from the unit run)
- `npx eslint` on the new file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)