### PR TITLE
[codex] Sort admin dashboard channel health rows

### DIFF
--- a/customResolvers/queries/getServerHealthDashboard.ts
+++ b/customResolvers/queries/getServerHealthDashboard.ts
@@ -12,9 +12,12 @@ type Args = {
   endDate?: string | null;
   channelUniqueNames?: string[] | null;
   limit?: number | null;
+  sortBy?: string | null;
+  sortDirection?: string | null;
 };
 
 type ChannelHealthRow = {
+  id: string;
   channelUniqueName: string;
   displayName: string | null;
   channelIconURL: string | null;
@@ -45,8 +48,50 @@ type AttentionItem = {
   value?: number | null;
 };
 
+type ChannelHealthSortKey =
+  | "channelUniqueName"
+  | "displayName"
+  | "discussionCount"
+  | "commentCount"
+  | "eventCount"
+  | "downloadCount"
+  | "voteCount"
+  | "uniqueContributorCount"
+  | "openIssueCount"
+  | "issueOpenedCount"
+  | "moderationActionCount"
+  | "archivedContentCount"
+  | "lockedContentCount"
+  | "oldestOpenIssueAgeDays"
+  | "issuesPerHundredContributions"
+  | "activityScore"
+  | "healthLabel";
+
+type SortDirection = "asc" | "desc";
+
 const DEFAULT_RANGE_DAYS = 30;
 const DEFAULT_CHANNEL_LIMIT = 25;
+const DEFAULT_CHANNEL_SORT_BY: ChannelHealthSortKey = "activityScore";
+const DEFAULT_CHANNEL_SORT_DIRECTION: SortDirection = "desc";
+const CHANNEL_HEALTH_SORT_KEYS = new Set<ChannelHealthSortKey>([
+  "channelUniqueName",
+  "displayName",
+  "discussionCount",
+  "commentCount",
+  "eventCount",
+  "downloadCount",
+  "voteCount",
+  "uniqueContributorCount",
+  "openIssueCount",
+  "issueOpenedCount",
+  "moderationActionCount",
+  "archivedContentCount",
+  "lockedContentCount",
+  "oldestOpenIssueAgeDays",
+  "issuesPerHundredContributions",
+  "activityScore",
+  "healthLabel",
+]);
 const SERVER_SCOPED_ISSUE_WHERE =
   "(coalesce(issue.flaggedServerRuleViolation, false) = true OR issue.channelUniqueName IS NULL)";
 
@@ -77,6 +122,50 @@ const parseDateArg = (value: string | null | undefined, fallback: DateTime) => {
   if (!value) return fallback;
   const parsed = DateTime.fromISO(value, { zone: "utc" });
   return parsed.isValid ? parsed : fallback;
+};
+
+const parseSortBy = (value: string | null | undefined): ChannelHealthSortKey => {
+  if (value && CHANNEL_HEALTH_SORT_KEYS.has(value as ChannelHealthSortKey)) {
+    return value as ChannelHealthSortKey;
+  }
+  return DEFAULT_CHANNEL_SORT_BY;
+};
+
+const parseSortDirection = (value: string | null | undefined): SortDirection => {
+  return value === "asc" || value === "desc"
+    ? value
+    : DEFAULT_CHANNEL_SORT_DIRECTION;
+};
+
+const compareChannelRows = (
+  a: ChannelHealthRow,
+  b: ChannelHealthRow,
+  sortBy: ChannelHealthSortKey,
+  sortDirection: SortDirection
+) => {
+  const aValue = a[sortBy];
+  const bValue = b[sortBy];
+  let comparison = 0;
+
+  if (typeof aValue === "string" || typeof bValue === "string") {
+    comparison = String(aValue || "").localeCompare(String(bValue || ""));
+  } else {
+    comparison = toNumber(aValue) - toNumber(bValue);
+  }
+
+  if (comparison !== 0) {
+    return sortDirection === "asc" ? comparison : -comparison;
+  }
+
+  comparison = b.activityScore - a.activityScore;
+  if (comparison === 0) {
+    comparison = b.openIssueCount - a.openIssueCount;
+  }
+  if (comparison === 0) {
+    comparison = a.channelUniqueName.localeCompare(b.channelUniqueName);
+  }
+
+  return comparison;
 };
 
 const getHealthLabel = (row: Omit<ChannelHealthRow, "healthLabel">): string => {
@@ -305,6 +394,7 @@ const channelHealthQuery = `
        oldestOpenIssueAgeDays,
        discussionCount + commentCount + eventCount AS contributionCount
   WITH {
+    id: c.uniqueName,
     channelUniqueName: c.uniqueName,
     displayName: c.displayName,
     channelIconURL: c.channelIconURL,
@@ -493,6 +583,8 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
     const startDate = start.toISODate() || now.toISODate();
     const endDate = end.toISODate() || now.toISODate();
     const limit = args.limit || DEFAULT_CHANNEL_LIMIT;
+    const sortBy = parseSortBy(args.sortBy);
+    const sortDirection = parseSortDirection(args.sortDirection);
     const channelUniqueNames = args.channelUniqueNames || [];
     const session = driver.session({ defaultAccessMode: "READ" });
 
@@ -512,8 +604,7 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
 
       const channelRecord = channelResult.records[0];
       const allChannelHealth = sanitize(channelRecord?.get("allChannelHealth") || []) as Array<Omit<ChannelHealthRow, "healthLabel">>;
-      const rawRows = allChannelHealth.slice(0, limit);
-      const channelHealth = rawRows.map((row) => {
+      const normalizedChannelHealth = allChannelHealth.map((row) => {
         const normalized = {
           ...row,
           oldestOpenIssueAgeDays: toNullableNumber(row.oldestOpenIssueAgeDays),
@@ -524,6 +615,9 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
           healthLabel: getHealthLabel(normalized),
         };
       });
+      const channelHealth = normalizedChannelHealth
+        .sort((a, b) => compareChannelRows(a, b, sortBy, sortDirection))
+        .slice(0, limit);
       const timeSeries = sanitize(timeSeriesResult.records[0]?.get("timeSeries") || []);
       const issueSummary = issueSummaryResult.records[0];
       const openIssueSummary = openIssueSummaryResult.records[0];

--- a/tests/integration/serverHealthDashboard.test.ts
+++ b/tests/integration/serverHealthDashboard.test.ts
@@ -126,6 +126,7 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
     (row: any) => row.channelUniqueName === "general"
   );
   assert.ok(general, `expected general row, got ${JSON.stringify(result.channelHealth)}`);
+  assert.equal(general.id, "general");
   assert.equal(general.uniqueContributorCount, 2);
   assert.equal(general.openIssueCount, 1);
   assert.equal(general.healthLabel, "Needs review");
@@ -192,4 +193,47 @@ test("getServerHealthDashboard filters channel rows without limiting summary tot
   assert.equal(result.channelHealth.length, 1);
   assert.equal(result.summary.discussionCount, 2);
   assert.equal(result.summary.activeChannelCount, 2);
+});
+
+test("getServerHealthDashboard sorts channel rows before applying the limit", async () => {
+  await run(
+    `
+    CREATE (active:Channel { uniqueName: 'active', createdAt: datetime() })
+    CREATE (stale:Channel { uniqueName: 'stale', createdAt: datetime() })
+    CREATE (u:User { username: 'alice' })
+    CREATE (d1:Discussion { id: 'd1', title: 'One', createdAt: datetime() })
+    CREATE (d2:Discussion { id: 'd2', title: 'Two', createdAt: datetime() })
+    CREATE (dc1:DiscussionChannel { id: 'dc1', discussionId: 'd1', channelUniqueName: 'active', createdAt: datetime() })
+    CREATE (dc2:DiscussionChannel { id: 'dc2', discussionId: 'd2', channelUniqueName: 'active', createdAt: datetime() })
+    CREATE (oldIssue:Issue {
+      id: 'old-issue',
+      issueNumber: 50,
+      channelUniqueName: 'stale',
+      title: 'Old stale issue',
+      isOpen: true,
+      flaggedServerRuleViolation: true,
+      createdAt: datetime() - duration({days: 45})
+    })
+    CREATE (u)-[:POSTED_DISCUSSION]->(d1)
+    CREATE (u)-[:POSTED_DISCUSSION]->(d2)
+    CREATE (dc1)-[:POSTED_IN_CHANNEL]->(active)
+    CREATE (dc1)-[:POSTED_IN_CHANNEL]->(d1)
+    CREATE (dc2)-[:POSTED_IN_CHANNEL]->(active)
+    CREATE (dc2)-[:POSTED_IN_CHANNEL]->(d2)
+    CREATE (stale)-[:HAS_ISSUE]->(oldIssue)
+    `
+  );
+
+  const result = await env.resolvers.Query.getServerHealthDashboard(null, {
+    startDate: "2000-01-01",
+    endDate: "2100-01-01",
+    limit: 1,
+    sortBy: "oldestOpenIssueAgeDays",
+    sortDirection: "desc",
+  });
+
+  assert.equal(result.channelHealth.length, 1);
+  assert.equal(result.channelHealth[0].channelUniqueName, "stale");
+  assert.equal(result.summary.discussionCount, 2);
+  assert.equal(result.summary.activeChannelCount, 1);
 });

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1894,6 +1894,7 @@ const typeDefinitions = gql`
   }
 
   type ChannelHealthRow @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    id: ID!
     channelUniqueName: String!
     displayName: String
     channelIconURL: String
@@ -2055,6 +2056,8 @@ const typeDefinitions = gql`
       endDate: String
       channelUniqueNames: [String!]
       limit: Int
+      sortBy: String
+      sortDirection: String
     ): ServerHealthDashboard!
     isOriginalPosterSuspended(issueId: String!): Boolean
     safetyCheck: SafetyCheckResponse


### PR DESCRIPTION
## Summary

Adds sortable channel health support to the server health dashboard resolver.

- Adds `sortBy` and `sortDirection` arguments to `getServerHealthDashboard`
- Adds stable `id` values to `ChannelHealthRow` so frontend GraphQL responses include row identifiers
- Sorts channel health rows before applying the limit, so admins can sort by stale issues, issue pressure, contributors, activity, and related metrics across the full result set
- Adds integration coverage for sorting before limiting and for the new row id

## Validation

- `npm run tsc`
- `node --loader ts-node/esm --test --test-concurrency=1 tests/integration/serverHealthDashboard.test.ts`