### PR TITLE
Fix createEventSeries end-to-end: input collision + repeatPattern node (#108)

### DIFF
--- a/customResolvers/mutations/createEventSeriesWithChannelConnections.test.ts
+++ b/customResolvers/mutations/createEventSeriesWithChannelConnections.test.ts
@@ -189,10 +189,10 @@ test("createEventSeriesWithChannelConnections handles repeat pattern", async () 
   assert.equal(typedResult.repeatPattern.endType, "AFTER_COUNT");
   assert.equal(typedResult.repeatPattern.endCount, 4);
 
-  // Verify repeat pattern was passed to create
+  // Verify repeat pattern was passed to create as a nested RepeatPattern node.
   const createInput = createCalls[0].input[0];
-  assert.equal(createInput.repeatPattern.type, "WEEKLY");
-  assert.deepEqual(createInput.repeatPattern.daysOfWeek, [3]);
+  assert.equal(createInput.repeatPattern.create.node.type, "WEEKLY");
+  assert.deepEqual(createInput.repeatPattern.create.node.daysOfWeek, [3]);
 });
 
 test("createEventSeriesWithChannelConnections connects tags", async () => {

--- a/customResolvers/mutations/createEventSeriesWithChannelConnections.ts
+++ b/customResolvers/mutations/createEventSeriesWithChannelConnections.ts
@@ -220,15 +220,20 @@ const getResolver = (input: Input) => {
         eventSeriesCreateInput.location = locationPoint;
       }
 
-      // Add repeat pattern if provided
+      // Add repeat pattern if provided. RepeatPattern is its own node linked via
+      // HAS_REPEAT_PATTERN, so create it nested rather than as a property.
       if (seriesInput.repeatPattern) {
         eventSeriesCreateInput.repeatPattern = {
-          type: seriesInput.repeatPattern.type,
-          count: seriesInput.repeatPattern.count,
-          daysOfWeek: seriesInput.repeatPattern.daysOfWeek,
-          endType: seriesInput.repeatPattern.endType,
-          endCount: seriesInput.repeatPattern.endCount,
-          endDate: seriesInput.repeatPattern.endDate,
+          create: {
+            node: {
+              type: seriesInput.repeatPattern.type,
+              count: seriesInput.repeatPattern.count,
+              daysOfWeek: seriesInput.repeatPattern.daysOfWeek,
+              endType: seriesInput.repeatPattern.endType,
+              endCount: seriesInput.repeatPattern.endCount,
+              endDate: seriesInput.repeatPattern.endDate,
+            },
+          },
         };
       }
 

--- a/tests/integration/createEventSeries.test.ts
+++ b/tests/integration/createEventSeries.test.ts
@@ -1,0 +1,129 @@
+// Integration tests for createEventSeriesWithChannelConnections against a live
+// Neo4j container. This resolver was previously broken end-to-end against the
+// real OGM (input-name collision + an unpersistable repeatPattern object field
+// — see #108); these tests prove the fix: it now creates the EventSeries, its
+// indexed occurrences, their channel links, and the repeat-pattern node.
+
+import test, { before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await run(
+    `CREATE (:Channel { uniqueName: 'cats', createdAt: datetime() })
+     CREATE (:User { username: 'poster' })`
+  );
+});
+
+const seriesInput = (overrides: Record<string, unknown> = {}) => ({
+  title: "Weekly Meetup",
+  description: "Every Wednesday",
+  channelConnections: ["cats"],
+  tags: ["social"],
+  occurrences: [
+    { startTime: "2030-01-02T18:00:00.000Z", endTime: "2030-01-02T20:00:00.000Z" },
+    { startTime: "2030-01-09T18:00:00.000Z", endTime: "2030-01-09T20:00:00.000Z" },
+    { startTime: "2030-01-16T18:00:00.000Z", endTime: "2030-01-16T20:00:00.000Z" },
+  ],
+  repeatPattern: {
+    type: "WEEKLY",
+    count: 1,
+    daysOfWeek: [3],
+    endType: "AFTER_COUNT",
+    endCount: 3,
+    endDate: null,
+  },
+  ...overrides,
+});
+
+const createSeries = (overrides: Record<string, unknown> = {}, poster = "poster") =>
+  env.resolvers.Mutation.createEventSeriesWithChannelConnections(
+    null,
+    { input: seriesInput(overrides) },
+    { user: { username: poster } }
+  );
+
+test("createEventSeries returns the series with one occurrence per date, indexed in order", async () => {
+  const series = await createSeries();
+
+  assert.deepEqual(
+    {
+      title: series.title,
+      count: series.Occurrences.length,
+      indexes: series.Occurrences.map(
+        (o: { occurrenceIndex: number }) => o.occurrenceIndex
+      ).sort(),
+    },
+    { title: "Weekly Meetup", count: 3, indexes: [0, 1, 2] }
+  );
+});
+
+test("createEventSeries persists the series and its occurrences in the graph", async () => {
+  await createSeries();
+
+  const rows = await run(
+    `MATCH (s:EventSeries)-[:HAS_OCCURRENCE]->(e:Event)
+     RETURN e.occurrenceIndex AS idx ORDER BY idx`
+  );
+  assert.deepEqual(rows.map((r) => Number(r.idx)), [0, 1, 2]);
+});
+
+test("createEventSeries links every occurrence to the requested channel via an EventChannel", async () => {
+  await createSeries();
+
+  const ecs = await run(
+    `MATCH (e:Event)<-[:POSTED_IN_CHANNEL]-(ec:EventChannel { channelUniqueName: 'cats' })
+     RETURN count(ec) AS n`
+  );
+  assert.equal(Number(ecs[0].n), 3);
+});
+
+test("createEventSeries creates a linked RepeatPattern node", async () => {
+  await createSeries();
+
+  const rows = await run(
+    `MATCH (:EventSeries)-[:HAS_REPEAT_PATTERN]->(rp:RepeatPattern)
+     RETURN rp.type AS type, rp.endCount AS endCount, rp.daysOfWeek AS daysOfWeek`
+  );
+  assert.deepEqual(
+    {
+      type: rows[0]?.type,
+      endCount: rows[0] ? Number(rows[0].endCount) : null,
+      daysOfWeek: rows[0]?.daysOfWeek?.map((d: unknown) => Number(d)),
+    },
+    { type: "WEEKLY", endCount: 3, daysOfWeek: [3] }
+  );
+});
+
+test("createEventSeries links the poster to the series", async () => {
+  await createSeries();
+
+  const rows = await run(
+    `MATCH (s:EventSeries)<-[:POSTED_BY]-(u:User) RETURN u.username AS poster`
+  );
+  assert.equal(rows[0]?.poster, "poster");
+});
+
+test("createEventSeries rejects a series with no channel connections", async () => {
+  await assert.rejects(
+    createSeries({ channelConnections: [] }),
+    /channel connection is required/i
+  );
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -675,7 +675,10 @@ const typeDefinitions = gql`
     until: DateTime
   }
 
+  # A repeat pattern is its own node (Neo4j can't store a nested object as a
+  # property), linked to its EventSeries via HAS_REPEAT_PATTERN.
   type RepeatPattern {
+    id: ID! @id
     type: RepeatPatternType!
     count: Int
     daysOfWeek: [Int]
@@ -717,6 +720,7 @@ const typeDefinitions = gql`
     createdAt: DateTime! @timestamp(operations: [CREATE])
     updatedAt: DateTime @timestamp(operations: [UPDATE])
     repeatPattern: RepeatPattern
+      @relationship(type: "HAS_REPEAT_PATTERN", direction: OUT)
     Poster: User @relationship(type: "POSTED_BY", direction: IN)
     Tags: [Tag!]! @relationship(type: "HAS_TAG", direction: OUT)
     Occurrences: [Event!]! @relationship(type: "HAS_OCCURRENCE", direction: OUT)
@@ -958,7 +962,11 @@ const typeDefinitions = gql`
     channelConnections: [String!]!
   }
 
-  input EventSeriesCreateInput {
+  # Must NOT be named EventSeriesCreateInput — that collides with the OGM's
+  # auto-generated node-create input for the EventSeries @node type (the two
+  # merge, injecting this required channelConnections into the OGM input and
+  # breaking EventSeries.create() in the resolver).
+  input CreateEventSeriesInput {
     title: String!
     description: String
     locationName: String
@@ -1082,7 +1090,7 @@ const typeDefinitions = gql`
       input: [EventCreateInputWithChannels!]!
     ): [Event!]!
     createEventSeriesWithChannelConnections(
-      input: EventSeriesCreateInput!
+      input: CreateEventSeriesInput!
     ): EventSeries
     updateEventWithChannelConnections(
       where: EventWhere!


### PR DESCRIPTION
Closes #108.

`createEventSeriesWithChannelConnections` had only mocked-OGM unit tests and nothing called it until the frontend wiring (multiforum-nuxt#229), so it had never run against a real Neo4j. Two schema problems made it fail:

## 1. Input-name collision
`type EventSeries` is an `@node`, so the OGM auto-generates `EventSeriesCreateInput`. typeDefs **also** declared a custom `input EventSeriesCreateInput` (the mutation arg); the two merged, forcing a required `channelConnections` onto the OGM node-create input.
→ Renamed the custom input to **`CreateEventSeriesInput`** (mutation arg updated).

## 2. `repeatPattern` not persistable
`EventSeries.repeatPattern: RepeatPattern` was an object-typed field with no `@relationship` — Neo4j can't store a nested object as a node property.
→ Modeled **`RepeatPattern` as its own `@node`** linked via `HAS_REPEAT_PATTERN`, and create it nested in the resolver. **Read selections (`repeatPattern { ... }`) are unchanged**, so query sites don't change.

## Tests
- New live-Neo4j integration test (`tests/integration/createEventSeries.test.ts`, 6/6) — create now persists the series, its indexed occurrences, channel links, the `RepeatPattern` node, and the poster, and rejects a no-channel series.
- Updated the existing unit test for the nested create shape (9/9).
- `npm run tsc` clean.

## ⚠️ Coordinated frontend change required
The public mutation input type is renamed (`EventSeriesCreateInput` → `CreateEventSeriesInput`). The frontend mutation doc (`graphQLData/event/mutations.js`) and multiforum-nuxt#229's type import must rename in lockstep — I'm handling that on the #229 branch so they deploy together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)