### PR TITLE
[codex] support registry sources from GitHub releases

### DIFF
--- a/customResolvers/mutations/enableServerPlugin.ts
+++ b/customResolvers/mutations/enableServerPlugin.ts
@@ -51,6 +51,12 @@ const getResolver = (input: Input) => {
             uiSchema
             documentationPath
             readmeMarkdown
+            registryUrl
+            releaseNotesUrl
+            sourceRepoUrl
+            sourceCommit
+            minServerVersion
+            apiVersion
           }
         }`
       })
@@ -174,7 +180,13 @@ const getResolver = (input: Input) => {
         settingsDefaults: pluginVersion.settingsDefaults || null,
         uiSchema: pluginVersion.uiSchema || null,
         documentationPath: pluginVersion.documentationPath || null,
-        readmeMarkdown: pluginVersion.readmeMarkdown || null
+        readmeMarkdown: pluginVersion.readmeMarkdown || null,
+        registryUrl: pluginVersion.registryUrl || null,
+        releaseNotesUrl: pluginVersion.releaseNotesUrl || null,
+        sourceRepoUrl: pluginVersion.sourceRepoUrl || null,
+        sourceCommit: pluginVersion.sourceCommit || null,
+        minServerVersion: pluginVersion.minServerVersion || null,
+        apiVersion: pluginVersion.apiVersion || null
       }
 
     } catch (error: unknown) {

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -25,6 +25,15 @@ type Args = {
   version: string
 }
 
+const buildReleaseMetadataPayload = (registryVersion: RegistryVersion) => ({
+  registryUrl: registryVersion.registryUrl || null,
+  releaseNotesUrl: registryVersion.releaseNotesUrl || null,
+  sourceRepoUrl: registryVersion.sourceRepoUrl || null,
+  sourceCommit: registryVersion.sourceCommit || null,
+  minServerVersion: registryVersion.minServerVersion || null,
+  apiVersion: registryVersion.apiVersion || null
+})
+
 const getResolver = (input: Input) => {
   const { Plugin, PluginVersion, ServerConfig } = input
 
@@ -81,6 +90,12 @@ const getResolver = (input: Input) => {
           repoUrl
           tarballGsUri
           integritySha256
+          registryUrl
+          releaseNotesUrl
+          sourceRepoUrl
+          sourceCommit
+          minServerVersion
+          apiVersion
           entryPath
           Plugin {
             id
@@ -222,6 +237,7 @@ const getResolver = (input: Input) => {
       const manifestJson = artifacts.manifest ? JSON.stringify(artifacts.manifest) : null
       const documentationPath = artifacts.readmePath ?? manifest.documentation?.readmePath ?? null
       const readmeMarkdown = artifacts.readmeMarkdown ?? null
+      const releaseMetadataPayload = buildReleaseMetadataPayload(registryVersion)
 
       if (!pluginVersion) {
         logger.info(`Creating new plugin version: ${pluginSlug}@${version}`)
@@ -232,6 +248,7 @@ const getResolver = (input: Input) => {
               repoUrl: String(registryVersion.tarballUrl),
               tarballGsUri: String(registryVersion.tarballUrl),
               integritySha256: String(registryVersion.integritySha256),
+              ...releaseMetadataPayload,
               entryPath: artifacts.entryPath || 'index.js',
               manifest: manifestJson,
               settingsDefaults,
@@ -254,6 +271,7 @@ const getResolver = (input: Input) => {
             repoUrl: String(registryVersion.tarballUrl),
             tarballGsUri: String(registryVersion.tarballUrl),
             integritySha256: String(registryVersion.integritySha256),
+            ...releaseMetadataPayload,
             entryPath: artifacts.entryPath || pluginVersion.entryPath || 'index.js',
             manifest: manifestJson,
             settingsDefaults,

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto'
-import { Storage } from '@google-cloud/storage'
 import type {
   PluginModel,
   PluginVersionModel,
@@ -13,20 +12,7 @@ import type { GraphQLResolveInfo } from 'graphql'
 import { parseManifestFromTarball } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
-
-type RegistryPlugin = {
-  id: string
-  versions: {
-    version: string
-    tarballUrl: string
-    integritySha256: string
-  }[]
-}
-
-type PluginRegistry = {
-  updatedAt: string
-  plugins: RegistryPlugin[]
-}
+import { downloadBytes, fetchMergedPluginRegistry, type RegistryVersion } from '../../services/plugin/registryService.js'
 
 type Input = {
   Plugin: PluginModel
@@ -58,37 +44,10 @@ const getResolver = (input: Input) => {
         throw new Error('No plugin registries configured')
       }
 
-      const registryUrl = serverConfigs[0].pluginRegistries?.[0]
-      if (!registryUrl) {
-        throw new Error('No plugin registry URL configured')
-      }
-      logger.info('Using plugin registry URL:', registryUrl)
-
-      // 2. Fetch and find plugin version in registry
-      let registryData: PluginRegistry
-      try {
-        if (registryUrl.startsWith('gs://')) {
-          const storage = new Storage()
-          const gsPath = registryUrl.replace('gs://', '')
-          const [bucketName, ...pathParts] = gsPath.split('/')
-          const filePath = pathParts.join('/')
-          
-          const bucket = storage.bucket(bucketName)
-          const file = bucket.file(filePath)
-          
-          const [contents] = await file.download()
-          registryData = JSON.parse(contents.toString())
-        } else {
-          const response = await fetch(registryUrl)
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-          }
-          registryData = await response.json()
-        }
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`Failed to fetch plugin registry: ${message}`)
-      }
+      const registryUrls = (serverConfigs[0].pluginRegistries || [])
+        .filter((url): url is string => typeof url === 'string' && url.trim().length > 0)
+      logger.info('Using plugin registry URLs:', registryUrls)
+      const registryData = await fetchMergedPluginRegistry(registryUrls)
 
       // First, resolve the plugin node using either the Neo4j ID or the plugin slug
       const pluginCandidates = await Plugin.find({
@@ -130,7 +89,7 @@ const getResolver = (input: Input) => {
         }`
       })
 
-      let registryVersion: { version: string; tarballUrl: string; integritySha256: string }
+      let registryVersion: RegistryVersion
 
       // Always get the version data from the registry for integrity verification
       const registryPlugin = registryData.plugins.find(p => p.id === pluginSlug)
@@ -161,25 +120,7 @@ const getResolver = (input: Input) => {
       // 3. Download and verify tarball integrity
       logger.info(`Downloading tarball from: ${registryVersion.tarballUrl}`)
       
-      let tarballBytes: Buffer
-      if (registryVersion.tarballUrl.startsWith('gs://')) {
-        const storage = new Storage()
-        const gsPath = registryVersion.tarballUrl.replace('gs://', '')
-        const [bucketName, ...pathParts] = gsPath.split('/')
-        const filePath = pathParts.join('/')
-        
-        const bucket = storage.bucket(bucketName)
-        const file = bucket.file(filePath)
-        
-        const [contents] = await file.download()
-        tarballBytes = contents
-      } else {
-        const response = await fetch(registryVersion.tarballUrl)
-        if (!response.ok) {
-          throw new Error(`Failed to download tarball: HTTP ${response.status}`)
-        }
-        tarballBytes = Buffer.from(await response.arrayBuffer())
-      }
+      const tarballBytes = await downloadBytes(registryVersion.tarballUrl)
 
       // 4. Verify integrity
       const actualSha256 = crypto.createHash('sha256').update(tarballBytes).digest('hex')

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -13,6 +13,7 @@ import { parseManifestFromTarball } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
 import { downloadBytes, fetchMergedPluginRegistry, type RegistryVersion } from '../../services/plugin/registryService.js'
+import { getPluginVersionCompatibility } from '../../services/plugin/compatibility.js'
 
 type Input = {
   Plugin: PluginModel
@@ -122,12 +123,18 @@ const getResolver = (input: Input) => {
         logger.info(`Found existing version in database: ${pluginSlug}@${version}`)
         // Use database URL but always use registry hash for verification
         registryVersion = {
+          ...registryVersionData,
           version: dbVersion.version,
           tarballUrl: dbVersion.repoUrl || registryVersionData.tarballUrl,
           integritySha256: registryVersionData.integritySha256 // Always use registry hash
         }
       } else {
         registryVersion = registryVersionData
+      }
+
+      const compatibility = getPluginVersionCompatibility(registryVersion)
+      if (!compatibility.compatible) {
+        throw new Error(compatibility.message)
       }
 
       logger.info('Using version data:', JSON.stringify(registryVersion, null, 2))

--- a/customResolvers/mutations/refreshPlugins.ts
+++ b/customResolvers/mutations/refreshPlugins.ts
@@ -11,13 +11,22 @@ import type { GraphQLResolveInfo } from 'graphql'
 import { getManifestArtifacts } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
-import { fetchMergedPluginRegistry } from '../../services/plugin/registryService.js'
+import { fetchMergedPluginRegistry, type RegistryVersion } from '../../services/plugin/registryService.js'
 
 type Input = {
   Plugin: PluginModel
   PluginVersion: PluginVersionModel
   ServerConfig: ServerConfigModel
 }
+
+const buildReleaseMetadataPayload = (registryVersion: RegistryVersion) => ({
+  registryUrl: registryVersion.registryUrl || null,
+  releaseNotesUrl: registryVersion.releaseNotesUrl || null,
+  sourceRepoUrl: registryVersion.sourceRepoUrl || null,
+  sourceCommit: registryVersion.sourceCommit || null,
+  minServerVersion: registryVersion.minServerVersion || null,
+  apiVersion: registryVersion.apiVersion || null
+})
 
 
 const getResolver = (input: Input) => {
@@ -244,6 +253,7 @@ for (const registryPlugin of registryData.plugins) {
       const settingsDefaults = settingsDefaultsRaw ? JSON.stringify(settingsDefaultsRaw) : null
       const uiSchema = uiSchemaRaw ? JSON.stringify(uiSchemaRaw) : null
       const manifestJson = artifacts.manifest ? JSON.stringify(artifacts.manifest) : null
+      const releaseMetadataPayload = buildReleaseMetadataPayload(registryVersion)
 
       if (existingVersions.length === 0) {
         logger.info(
@@ -256,6 +266,7 @@ for (const registryPlugin of registryData.plugins) {
               repoUrl: registryVersion.tarballUrl,
               tarballGsUri: registryVersion.tarballUrl,
               integritySha256: registryVersion.integritySha256,
+              ...releaseMetadataPayload,
               entryPath: artifacts.entryPath || 'index.js',
               manifest: manifestJson,
               settingsDefaults,
@@ -281,6 +292,7 @@ for (const registryPlugin of registryData.plugins) {
           update: ({
             tarballGsUri: registryVersion.tarballUrl,
             integritySha256: registryVersion.integritySha256,
+            ...releaseMetadataPayload,
             entryPath: artifacts.entryPath || 'index.js',
             manifest: manifestJson,
             settingsDefaults,
@@ -332,6 +344,12 @@ for (const registryPlugin of registryData.plugins) {
                 repoUrl
                 tarballGsUri
                 integritySha256
+                registryUrl
+                releaseNotesUrl
+                sourceRepoUrl
+                sourceCommit
+                minServerVersion
+                apiVersion
                 entryPath
                 manifest
                 settingsDefaults

--- a/customResolvers/mutations/refreshPlugins.ts
+++ b/customResolvers/mutations/refreshPlugins.ts
@@ -7,25 +7,11 @@ import type {
   PluginVersionCreateInput,
   PluginVersionUpdateInput
 } from '../../ogm_types.js'
-import { Storage } from '@google-cloud/storage'
 import type { GraphQLResolveInfo } from 'graphql'
 import { getManifestArtifacts } from './shared/pluginManifest.js'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
-
-type RegistryPlugin = {
-  id: string
-  versions: {
-    version: string
-    tarballUrl: string
-    integritySha256: string
-  }[]
-}
-
-type PluginRegistry = {
-  updatedAt: string
-  plugins: RegistryPlugin[]
-}
+import { fetchMergedPluginRegistry } from '../../services/plugin/registryService.js'
 
 type Input = {
   Plugin: PluginModel
@@ -53,45 +39,10 @@ const getResolver = (input: Input) => {
         throw new Error('No plugin registries configured')
       }
 
-      const registryUrl = serverConfigs[0].pluginRegistries?.[0]
-      if (!registryUrl) {
-        throw new Error('No plugin registry URL configured')
-      }
-      
-      logger.info(`Fetching plugin registry from: ${registryUrl}`)
-
-      // Fetch registry data
-      let registryData: PluginRegistry
-      try {
-        if (registryUrl.startsWith('gs://')) {
-          // For Google Cloud Storage URLs, use authenticated GCS client
-          const storage = new Storage()
-          const gsPath = registryUrl.replace('gs://', '')
-          const [bucketName, ...pathParts] = gsPath.split('/')
-          const filePath = pathParts.join('/')
-          
-          logger.info(`Downloading from GCS bucket: ${bucketName}, file: ${filePath}`)
-          
-          const bucket = storage.bucket(bucketName)
-          const file = bucket.file(filePath)
-          
-          const [contents] = await file.download()
-          registryData = JSON.parse(contents.toString())
-        } else {
-          // For regular HTTP/HTTPS URLs
-          const response = await fetch(registryUrl)
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-          }
-          registryData = await response.json()
-        }
-      } catch (error: unknown) {
-        logger.error('Failed to fetch plugin registry:', error)
-        const message = error instanceof Error ? error.message : String(error)
-        throw new Error(
-          `Failed to fetch plugin registry: ${message}`
-        )
-      }
+      const registryUrls = (serverConfigs[0].pluginRegistries || [])
+        .filter((url): url is string => typeof url === 'string' && url.trim().length > 0)
+      logger.info(`Fetching plugin registries from: ${registryUrls.join(', ')}`)
+      const registryData = await fetchMergedPluginRegistry(registryUrls)
 
       logger.info(`Registry updated at: ${registryData.updatedAt}`)
       logger.info(`Found ${registryData.plugins.length} plugins in registry`)

--- a/customResolvers/queries/getInstalledPlugins.ts
+++ b/customResolvers/queries/getInstalledPlugins.ts
@@ -1,27 +1,13 @@
-import { Storage } from '@google-cloud/storage'
 import type { GraphQLResolveInfo } from 'graphql'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
 import type {
   ServerConfigModel
 } from '../../ogm_types.js'
+import { compareVersions, fetchMergedPluginRegistry, findLatestVersion } from '../../services/plugin/registryService.js'
 
 type Input = {
   ServerConfig: ServerConfigModel
-}
-
-type RegistryPlugin = {
-  id: string
-  versions: {
-    version: string
-    tarballUrl: string
-    integritySha256: string
-  }[]
-}
-
-type PluginRegistry = {
-  updatedAt: string
-  plugins: RegistryPlugin[]
 }
 
 type PluginEdge = {
@@ -50,44 +36,6 @@ type PluginEdge = {
     }
     [key: string]: unknown
   }
-}
-
-/**
- * Compare two semver-style version strings.
- * Returns: negative if a < b, positive if a > b, 0 if equal
- */
-function compareVersions(a: string, b: string): number {
-  const parseVersion = (v: string) => {
-    // Remove 'v' prefix if present
-    const clean = v.replace(/^v/, '')
-    const parts = clean.split('.').map(p => {
-      const num = parseInt(p, 10)
-      return isNaN(num) ? 0 : num
-    })
-    // Pad to 3 parts (major.minor.patch)
-    while (parts.length < 3) parts.push(0)
-    return parts
-  }
-
-  const aParts = parseVersion(a)
-  const bParts = parseVersion(b)
-
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aVal = aParts[i] || 0
-    const bVal = bParts[i] || 0
-    if (aVal !== bVal) return aVal - bVal
-  }
-  return 0
-}
-
-/**
- * Find the latest version from an array of version strings
- */
-function findLatestVersion(versions: string[]): string | null {
-  if (!versions.length) return null
-  return versions.reduce((latest, current) =>
-    compareVersions(current, latest) > 0 ? current : latest
-  )
 }
 
 const getResolver = (input: Input) => {
@@ -152,40 +100,20 @@ const getResolver = (input: Input) => {
       }
 
       // Try to fetch registry for version comparison
-      let registryData: PluginRegistry | null = null
-      const registryUrl = serverConfig.pluginRegistries?.[0]
-
-      if (registryUrl) {
+      let registryVersionsMap = new Map<string, string[]>()
+      const registryUrls = serverConfig.pluginRegistries || []
+      if (registryUrls.length) {
         try {
-          if (registryUrl.startsWith('gs://')) {
-            const storage = new Storage()
-            const gsPath = registryUrl.replace('gs://', '')
-            const [bucketName, ...pathParts] = gsPath.split('/')
-            const filePath = pathParts.join('/')
-
-            const bucket = storage.bucket(bucketName)
-            const file = bucket.file(filePath)
-
-            const [contents] = await file.download()
-            registryData = JSON.parse(contents.toString())
-          } else {
-            const response = await fetch(registryUrl)
-            if (response.ok) {
-              registryData = await response.json()
-            }
-          }
+          const registryData = await fetchMergedPluginRegistry(registryUrls)
+          registryVersionsMap = new Map(
+            registryData.plugins.map((plugin) => [
+              plugin.id,
+              plugin.versions.map((version) => version.version)
+            ])
+          )
         } catch (error) {
           // Registry fetch failed - continue without version comparison
           logger.warn('Failed to fetch plugin registry for version comparison:', error instanceof Error ? error.message : String(error))
-        }
-      }
-
-      // Build a map of plugin ID -> available versions from registry
-      const registryVersionsMap = new Map<string, string[]>()
-      if (registryData?.plugins) {
-        for (const plugin of registryData.plugins) {
-          const versions = plugin.versions.map(v => v.version)
-          registryVersionsMap.set(plugin.id, versions)
         }
       }
 

--- a/customResolvers/queries/getInstalledPlugins.ts
+++ b/customResolvers/queries/getInstalledPlugins.ts
@@ -22,6 +22,12 @@ type PluginEdge = {
     uiSchema?: string | Record<string, unknown> | null
     documentationPath?: string | null
     readmeMarkdown?: string | null
+    registryUrl?: string | null
+    releaseNotesUrl?: string | null
+    sourceRepoUrl?: string | null
+    sourceCommit?: string | null
+    minServerVersion?: string | null
+    apiVersion?: string | null
     Plugin?: {
       id?: string
       name?: string
@@ -61,6 +67,12 @@ const getResolver = (input: Input) => {
                 repoUrl
                 tarballGsUri
                 integritySha256
+                registryUrl
+                releaseNotesUrl
+                sourceRepoUrl
+                sourceCommit
+                minServerVersion
+                apiVersion
                 entryPath
                 manifest
                 settingsDefaults
@@ -158,6 +170,12 @@ const getResolver = (input: Input) => {
           uiSchema: node.uiSchema ? (typeof node.uiSchema === 'string' ? JSON.parse(node.uiSchema) : node.uiSchema) : null,
           documentationPath: node.documentationPath || null,
           readmeMarkdown: node.readmeMarkdown || null,
+          registryUrl: node.registryUrl || null,
+          releaseNotesUrl: node.releaseNotesUrl || null,
+          sourceRepoUrl: node.sourceRepoUrl || null,
+          sourceCommit: node.sourceCommit || null,
+          minServerVersion: node.minServerVersion || null,
+          apiVersion: node.apiVersion || null,
           hasUpdate,
           latestVersion,
           availableVersions: availableVersions.sort((a, b) => compareVersions(b, a)) // sorted newest first

--- a/services/plugin/compatibility.test.ts
+++ b/services/plugin/compatibility.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getPluginVersionCompatibility } from './compatibility.js'
+
+test('getPluginVersionCompatibility allows versions without compatibility metadata', () => {
+  assert.deepEqual(getPluginVersionCompatibility({}), { compatible: true })
+})
+
+test('getPluginVersionCompatibility rejects versions requiring a newer server', () => {
+  const result = getPluginVersionCompatibility(
+    { minServerVersion: '2.0.0' },
+    { currentServerVersion: '1.0.0' }
+  )
+
+  assert.equal(result.compatible, false)
+  if (!result.compatible) {
+    assert.equal(result.code, 'PLUGIN_VERSION_REQUIRES_NEWER_SERVER')
+    assert.match(result.message, /Requires server >= 2\.0\.0/)
+  }
+})
+
+test('getPluginVersionCompatibility rejects unsupported plugin API versions', () => {
+  const result = getPluginVersionCompatibility(
+    { apiVersion: '2' },
+    { supportedPluginApiVersion: '1' }
+  )
+
+  assert.equal(result.compatible, false)
+  if (!result.compatible) {
+    assert.equal(result.code, 'PLUGIN_API_VERSION_UNSUPPORTED')
+    assert.match(result.message, /Requires plugin API 2/)
+  }
+})
+
+test('getPluginVersionCompatibility accepts matching compatibility metadata', () => {
+  assert.deepEqual(
+    getPluginVersionCompatibility(
+      { minServerVersion: '1.0.0', apiVersion: '1' },
+      { currentServerVersion: '1.0.0', supportedPluginApiVersion: '1' }
+    ),
+    { compatible: true }
+  )
+})

--- a/services/plugin/compatibility.ts
+++ b/services/plugin/compatibility.ts
@@ -1,0 +1,39 @@
+import { compareVersions, type RegistryVersion } from './registryService.js'
+import { CURRENT_SERVER_VERSION, SUPPORTED_PLUGIN_API_VERSION } from './constants.js'
+
+export type PluginCompatibilityResult =
+  | { compatible: true }
+  | {
+      compatible: false
+      code: 'PLUGIN_VERSION_REQUIRES_NEWER_SERVER' | 'PLUGIN_API_VERSION_UNSUPPORTED'
+      message: string
+    }
+
+export function getPluginVersionCompatibility(
+  version: Pick<RegistryVersion, 'minServerVersion' | 'apiVersion'>,
+  options: {
+    currentServerVersion?: string
+    supportedPluginApiVersion?: string
+  } = {}
+): PluginCompatibilityResult {
+  const currentServerVersion = options.currentServerVersion || CURRENT_SERVER_VERSION
+  const supportedPluginApiVersion = options.supportedPluginApiVersion || SUPPORTED_PLUGIN_API_VERSION
+
+  if (version.minServerVersion && compareVersions(currentServerVersion, version.minServerVersion) < 0) {
+    return {
+      compatible: false,
+      code: 'PLUGIN_VERSION_REQUIRES_NEWER_SERVER',
+      message: `PLUGIN_VERSION_REQUIRES_NEWER_SERVER: Requires server >= ${version.minServerVersion}; current server is ${currentServerVersion}`
+    }
+  }
+
+  if (version.apiVersion && version.apiVersion !== supportedPluginApiVersion) {
+    return {
+      compatible: false,
+      code: 'PLUGIN_API_VERSION_UNSUPPORTED',
+      message: `PLUGIN_API_VERSION_UNSUPPORTED: Requires plugin API ${version.apiVersion}; supported API is ${supportedPluginApiVersion}`
+    }
+  }
+
+  return { compatible: true }
+}

--- a/services/plugin/constants.ts
+++ b/services/plugin/constants.ts
@@ -14,3 +14,6 @@ export const COMMENT_EVENTS = new Set([
 export const CHANNEL_EVENTS = new Set([
   'discussionChannel.created',
 ])
+
+export const CURRENT_SERVER_VERSION = '1.0.0'
+export const SUPPORTED_PLUGIN_API_VERSION = '1'

--- a/services/plugin/registryService.test.ts
+++ b/services/plugin/registryService.test.ts
@@ -13,18 +13,32 @@ afterEach(() => {
   globalThis.fetch = originalFetch
 })
 
-const installFetchMock = (registries: Record<string, unknown>) => {
+const installFetchMock = (registries: Record<string, any>) => {
   globalThis.fetch = (async (url: any) => {
     const key = String(url)
     if (!(key in registries)) {
       throw new Error(`Unexpected fetch: ${key}`)
     }
 
+    const response = registries[key]
+    const ok = response.ok ?? true
+    const status = response.status ?? 200
+    const statusText = response.statusText ?? 'OK'
+    const jsonValue = response.json ?? response
+
     return {
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => registries[key]
+      ok,
+      status,
+      statusText,
+      json: async () => {
+        if (response.json !== undefined) return response.json
+        if (response.text !== undefined) return JSON.parse(response.text)
+        return response
+      },
+      text: async () => {
+        if (response.text !== undefined) return response.text
+        return JSON.stringify(jsonValue)
+      }
     }
   }) as any
 }
@@ -137,6 +151,62 @@ test('fetchMergedPluginRegistry rejects conflicting plugin version entries', asy
     ]),
     /Conflicting registry entry for alpha@1\.0\.0/
   )
+})
+
+test('fetchMergedPluginRegistry can synthesize a registry from a GitHub repo release feed', async () => {
+  installFetchMock({
+    'https://api.github.com/repos/gennit-project/multiforum-plugin-hello-world/releases?per_page=100': {
+      json: [
+        {
+          tag_name: 'v0.2.2',
+          html_url: 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/tag/v0.2.2',
+          target_commitish: 'main',
+          assets: [
+            {
+              name: 'plugin.json',
+              browser_download_url: 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/plugin.json'
+            },
+            {
+              name: 'hello-world-0.2.2.tgz',
+              browser_download_url: 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/hello-world-0.2.2.tgz'
+            },
+            {
+              name: 'hello-world-0.2.2.tgz.sha256',
+              browser_download_url: 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/hello-world-0.2.2.tgz.sha256'
+            }
+          ]
+        }
+      ]
+    },
+    'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/plugin.json': {
+      json: {
+        id: 'hello-world',
+        version: '0.2.2',
+        source: {
+          repoUrl: 'https://github.com/gennit-project/multiforum-plugin-hello-world'
+        },
+        compatibility: {
+          minServerVersion: '1.0.0',
+          apiVersion: '1'
+        }
+      }
+    },
+    'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/hello-world-0.2.2.tgz.sha256': {
+      text: 'abc123  hello-world-0.2.2.tgz\n'
+    }
+  })
+
+  const registry = await fetchMergedPluginRegistry([
+    'https://github.com/gennit-project/multiforum-plugin-hello-world'
+  ])
+
+  assert.deepEqual(registry.plugins.map((plugin) => plugin.id), ['hello-world'])
+  const version = registry.plugins[0]?.versions[0]
+  assert.equal(version?.version, '0.2.2')
+  assert.equal(version?.tarballUrl, 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/download/v0.2.2/hello-world-0.2.2.tgz')
+  assert.equal(version?.integritySha256, 'abc123')
+  assert.equal(version?.releaseNotesUrl, 'https://github.com/gennit-project/multiforum-plugin-hello-world/releases/tag/v0.2.2')
+  assert.equal(version?.sourceRepoUrl, 'https://github.com/gennit-project/multiforum-plugin-hello-world')
 })
 
 test('version helpers sort releases ahead of prereleases', () => {

--- a/services/plugin/registryService.test.ts
+++ b/services/plugin/registryService.test.ts
@@ -53,7 +53,12 @@ test('fetchMergedPluginRegistry merges multiple registry URLs and sorts versions
             {
               version: '1.1.0',
               tarballUrl: 'https://registry-b.test/alpha-1.1.0.tgz',
-              integritySha256: 'bbb'
+              integritySha256: 'bbb',
+              releaseNotesUrl: 'https://registry-b.test/alpha/releases/1.1.0',
+              sourceRepoUrl: 'https://github.com/example/alpha',
+              sourceCommit: 'abcdef123456',
+              minServerVersion: '0.8.0',
+              apiVersion: '1'
             }
           ]
         },
@@ -84,6 +89,13 @@ test('fetchMergedPluginRegistry merges multiple registry URLs and sorts versions
     registry.plugins.find((plugin) => plugin.id === 'alpha')?.versions.map((version) => version.version),
     ['1.1.0', '1.0.0']
   )
+  const latestAlpha = registry.plugins.find((plugin) => plugin.id === 'alpha')?.versions[0]
+  assert.equal(latestAlpha?.registryUrl, 'https://registry-b.test/registry.json')
+  assert.equal(latestAlpha?.releaseNotesUrl, 'https://registry-b.test/alpha/releases/1.1.0')
+  assert.equal(latestAlpha?.sourceRepoUrl, 'https://github.com/example/alpha')
+  assert.equal(latestAlpha?.sourceCommit, 'abcdef123456')
+  assert.equal(latestAlpha?.minServerVersion, '0.8.0')
+  assert.equal(latestAlpha?.apiVersion, '1')
 })
 
 test('fetchMergedPluginRegistry rejects conflicting plugin version entries', async () => {

--- a/services/plugin/registryService.test.ts
+++ b/services/plugin/registryService.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import test, { afterEach } from 'node:test'
+import {
+  compareVersions,
+  fetchMergedPluginRegistry,
+  findLatestVersion,
+  sortVersionsDescending
+} from './registryService.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const installFetchMock = (registries: Record<string, unknown>) => {
+  globalThis.fetch = (async (url: any) => {
+    const key = String(url)
+    if (!(key in registries)) {
+      throw new Error(`Unexpected fetch: ${key}`)
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => registries[key]
+    }
+  }) as any
+}
+
+test('fetchMergedPluginRegistry merges multiple registry URLs and sorts versions', async () => {
+  installFetchMock({
+    'https://registry-a.test/registry.json': {
+      plugins: [
+        {
+          id: 'alpha',
+          versions: [
+            {
+              version: '1.0.0',
+              tarballUrl: 'https://registry-a.test/alpha-1.0.0.tgz',
+              integritySha256: 'aaa'
+            }
+          ]
+        }
+      ]
+    },
+    'https://registry-b.test/registry.json': {
+      plugins: [
+        {
+          id: 'alpha',
+          versions: [
+            {
+              version: '1.1.0',
+              tarballUrl: 'https://registry-b.test/alpha-1.1.0.tgz',
+              integritySha256: 'bbb'
+            }
+          ]
+        },
+        {
+          id: 'beta',
+          versions: [
+            {
+              version: '0.1.0',
+              tarballUrl: 'https://registry-b.test/beta-0.1.0.tgz',
+              integritySha256: 'ccc'
+            }
+          ]
+        }
+      ]
+    }
+  })
+
+  const registry = await fetchMergedPluginRegistry([
+    'https://registry-a.test/registry.json',
+    'https://registry-b.test/registry.json'
+  ])
+
+  assert.deepEqual(
+    registry.plugins.map((plugin) => plugin.id),
+    ['alpha', 'beta']
+  )
+  assert.deepEqual(
+    registry.plugins.find((plugin) => plugin.id === 'alpha')?.versions.map((version) => version.version),
+    ['1.1.0', '1.0.0']
+  )
+})
+
+test('fetchMergedPluginRegistry rejects conflicting plugin version entries', async () => {
+  installFetchMock({
+    'https://registry-a.test/registry.json': {
+      plugins: [
+        {
+          id: 'alpha',
+          versions: [
+            {
+              version: '1.0.0',
+              tarballUrl: 'https://registry-a.test/alpha-1.0.0.tgz',
+              integritySha256: 'aaa'
+            }
+          ]
+        }
+      ]
+    },
+    'https://registry-b.test/registry.json': {
+      plugins: [
+        {
+          id: 'alpha',
+          versions: [
+            {
+              version: '1.0.0',
+              tarballUrl: 'https://registry-b.test/alpha-1.0.0.tgz',
+              integritySha256: 'bbb'
+            }
+          ]
+        }
+      ]
+    }
+  })
+
+  await assert.rejects(
+    fetchMergedPluginRegistry([
+      'https://registry-a.test/registry.json',
+      'https://registry-b.test/registry.json'
+    ]),
+    /Conflicting registry entry for alpha@1\.0\.0/
+  )
+})
+
+test('version helpers sort releases ahead of prereleases', () => {
+  assert.equal(compareVersions('1.0.0', '1.0.0-beta.1') > 0, true)
+  assert.equal(findLatestVersion(['v1.0.0', '1.1.0-beta.1', '1.0.1']), '1.1.0-beta.1')
+  assert.deepEqual(
+    sortVersionsDescending([
+      { version: '0.2.0' },
+      { version: '0.10.0' },
+      { version: '0.10.0-beta.1' }
+    ]).map((version) => version.version),
+    ['0.10.0', '0.10.0-beta.1', '0.2.0']
+  )
+})

--- a/services/plugin/registryService.ts
+++ b/services/plugin/registryService.ts
@@ -5,6 +5,11 @@ export type RegistryVersion = {
   tarballUrl: string
   integritySha256: string
   registryUrl?: string
+  releaseNotesUrl?: string
+  sourceRepoUrl?: string
+  sourceCommit?: string
+  minServerVersion?: string
+  apiVersion?: string
 }
 
 export type RegistryPlugin = {

--- a/services/plugin/registryService.ts
+++ b/services/plugin/registryService.ts
@@ -22,6 +22,18 @@ export type PluginRegistry = {
   plugins: RegistryPlugin[]
 }
 
+type GitHubReleaseAsset = {
+  name?: string
+  browser_download_url?: string
+}
+
+type GitHubRelease = {
+  tag_name?: string
+  html_url?: string
+  target_commitish?: string
+  assets?: GitHubReleaseAsset[]
+}
+
 const storage = new Storage()
 
 export async function fetchJsonFromUrl<T>(url: string): Promise<T> {
@@ -41,6 +53,125 @@ export async function fetchJsonFromUrl<T>(url: string): Promise<T> {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`)
   }
   return await response.json() as T
+}
+
+const isGitHubRepoUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'github.com') return false
+    const parts = parsed.pathname.split('/').filter(Boolean)
+    return parts.length >= 2 && !parts[0].startsWith('.')
+  } catch {
+    return false
+  }
+}
+
+const normalizeGitHubRepoUrl = (url: string): string => {
+  const parsed = new URL(url)
+  const parts = parsed.pathname.split('/').filter(Boolean)
+  const owner = parts[0]
+  const repo = parts[1].replace(/\.git$/, '')
+  return `https://github.com/${owner}/${repo}`
+}
+
+const githubApiHeaders = (): HeadersInit => {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+  return token
+    ? {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28'
+      }
+    : {
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28'
+      }
+}
+
+const fetchGitHubJson = async <T>(url: string): Promise<T> => {
+  const response = await fetch(url, { headers: githubApiHeaders() })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+  return await response.json() as T
+}
+
+const fetchGitHubText = async (url: string): Promise<string> => {
+  const response = await fetch(url, { headers: githubApiHeaders() })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+  return await response.text()
+}
+
+const githubReleaseRegistryFromRepoUrl = async (repoUrl: string): Promise<PluginRegistry> => {
+  const normalizedRepoUrl = normalizeGitHubRepoUrl(repoUrl)
+  const parsed = new URL(normalizedRepoUrl)
+  const [owner, repo] = parsed.pathname.split('/').filter(Boolean)
+  const releasesUrl = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`
+  const releases = await fetchGitHubJson<GitHubRelease[]>(releasesUrl)
+
+  const pluginVersionsById = new Map<string, RegistryVersion[]>()
+
+  for (const release of releases || []) {
+    const assets = release.assets || []
+    const manifestAsset = assets.find((asset) => asset.name === 'plugin.json' && asset.browser_download_url)
+    const tarballAsset = assets.find((asset) => asset.name?.endsWith('.tgz') && asset.browser_download_url)
+    const checksumAsset = assets.find((asset) => asset.name?.endsWith('.tgz.sha256') && asset.browser_download_url)
+
+    if (!manifestAsset?.browser_download_url || !tarballAsset?.browser_download_url || !checksumAsset?.browser_download_url) {
+      continue
+    }
+
+    const manifest = JSON.parse(await fetchGitHubText(manifestAsset.browser_download_url)) as {
+      id?: string
+      version?: string
+      source?: {
+        repoUrl?: string
+        releaseNotesUrl?: string
+        commit?: string
+      }
+      compatibility?: {
+        minServerVersion?: string
+        apiVersion?: string
+      }
+    }
+
+    if (!manifest.id || !manifest.version) {
+      continue
+    }
+
+    const integritySha256 = (await fetchGitHubText(checksumAsset.browser_download_url)).split(/\s+/)[0]?.trim()
+    if (!integritySha256) {
+      continue
+    }
+
+    const version: RegistryVersion = {
+      version: manifest.version,
+      tarballUrl: tarballAsset.browser_download_url,
+      integritySha256,
+      registryUrl: normalizedRepoUrl,
+      releaseNotesUrl: release.html_url || manifest.source?.releaseNotesUrl || `${normalizedRepoUrl}/releases/tag/v${manifest.version}`,
+      sourceRepoUrl: manifest.source?.repoUrl || normalizedRepoUrl,
+      sourceCommit: manifest.source?.commit || release.target_commitish || '',
+      minServerVersion: manifest.compatibility?.minServerVersion || '',
+      apiVersion: manifest.compatibility?.apiVersion || ''
+    }
+
+    const versions = pluginVersionsById.get(manifest.id) || []
+    versions.push(version)
+    pluginVersionsById.set(manifest.id, versions)
+  }
+
+  return {
+    updatedAt: new Date().toISOString(),
+    plugins: Array.from(pluginVersionsById.entries())
+      .map(([id, versions]) => ({
+        id,
+        versions: sortVersionsDescending(versions)
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id))
+  }
 }
 
 export async function downloadBytes(url: string): Promise<Buffer> {
@@ -108,7 +239,11 @@ export async function fetchMergedPluginRegistry(registryUrls: string[]): Promise
   for (const registryUrl of trimmedRegistryUrls) {
     let registry: PluginRegistry
     try {
-      registry = await fetchJsonFromUrl<PluginRegistry>(registryUrl)
+      if (isGitHubRepoUrl(registryUrl)) {
+        registry = await githubReleaseRegistryFromRepoUrl(registryUrl)
+      } else {
+        registry = await fetchJsonFromUrl<PluginRegistry>(registryUrl)
+      }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to fetch plugin registry ${registryUrl}: ${message}`)

--- a/services/plugin/registryService.ts
+++ b/services/plugin/registryService.ts
@@ -1,0 +1,143 @@
+import { Storage } from '@google-cloud/storage'
+
+export type RegistryVersion = {
+  version: string
+  tarballUrl: string
+  integritySha256: string
+  registryUrl?: string
+}
+
+export type RegistryPlugin = {
+  id: string
+  versions: RegistryVersion[]
+}
+
+export type PluginRegistry = {
+  updatedAt?: string
+  plugins: RegistryPlugin[]
+}
+
+const storage = new Storage()
+
+export async function fetchJsonFromUrl<T>(url: string): Promise<T> {
+  if (url.startsWith('gs://')) {
+    const gsPath = url.replace('gs://', '')
+    const [bucketName, ...pathParts] = gsPath.split('/')
+    const filePath = pathParts.join('/')
+
+    const bucket = storage.bucket(bucketName)
+    const file = bucket.file(filePath)
+    const [contents] = await file.download()
+    return JSON.parse(contents.toString()) as T
+  }
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+  return await response.json() as T
+}
+
+export async function downloadBytes(url: string): Promise<Buffer> {
+  if (url.startsWith('gs://')) {
+    const gsPath = url.replace('gs://', '')
+    const [bucketName, ...pathParts] = gsPath.split('/')
+    const filePath = pathParts.join('/')
+
+    const bucket = storage.bucket(bucketName)
+    const file = bucket.file(filePath)
+    const [contents] = await file.download()
+    return contents
+  }
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to download tarball: HTTP ${response.status}`)
+  }
+  return Buffer.from(await response.arrayBuffer())
+}
+
+export function compareVersions(a: string, b: string): number {
+  const normalize = (version: string) => version.replace(/^v/i, '')
+  const parse = (version: string) => {
+    const [core, prerelease] = normalize(version).split('-', 2)
+    const parts = core.split('.').map((part) => {
+      const parsed = Number.parseInt(part, 10)
+      return Number.isFinite(parsed) ? parsed : 0
+    })
+    while (parts.length < 3) parts.push(0)
+    return { parts, prerelease: prerelease || '' }
+  }
+
+  const parsedA = parse(a)
+  const parsedB = parse(b)
+
+  for (let i = 0; i < Math.max(parsedA.parts.length, parsedB.parts.length); i += 1) {
+    const aPart = parsedA.parts[i] || 0
+    const bPart = parsedB.parts[i] || 0
+    if (aPart !== bPart) return aPart - bPart
+  }
+
+  if (parsedA.prerelease && !parsedB.prerelease) return -1
+  if (!parsedA.prerelease && parsedB.prerelease) return 1
+  return parsedA.prerelease.localeCompare(parsedB.prerelease)
+}
+
+export function sortVersionsDescending<T extends { version: string }>(versions: T[]): T[] {
+  return [...versions].sort((a, b) => compareVersions(b.version, a.version))
+}
+
+export function findLatestVersion(versions: string[]): string | null {
+  if (!versions.length) return null
+  return sortVersionsDescending(versions.map((version) => ({ version })))[0]?.version ?? null
+}
+
+export async function fetchMergedPluginRegistry(registryUrls: string[]): Promise<PluginRegistry> {
+  const trimmedRegistryUrls = registryUrls.map((url) => url.trim()).filter(Boolean)
+  if (!trimmedRegistryUrls.length) {
+    throw new Error('No plugin registries configured')
+  }
+
+  const mergedPlugins = new Map<string, RegistryPlugin>()
+
+  for (const registryUrl of trimmedRegistryUrls) {
+    let registry: PluginRegistry
+    try {
+      registry = await fetchJsonFromUrl<PluginRegistry>(registryUrl)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to fetch plugin registry ${registryUrl}: ${message}`)
+    }
+
+    for (const plugin of registry.plugins || []) {
+      if (!plugin?.id) continue
+      const current = mergedPlugins.get(plugin.id) || { id: plugin.id, versions: [] }
+      const versionsByNumber = new Map(current.versions.map((version) => [version.version, version]))
+
+      for (const version of plugin.versions || []) {
+        if (!version?.version || !version.tarballUrl || !version.integritySha256) continue
+        const normalizedVersion = { ...version, registryUrl }
+        const existing = versionsByNumber.get(version.version)
+
+        if (existing && (
+          existing.tarballUrl !== version.tarballUrl ||
+          existing.integritySha256 !== version.integritySha256
+        )) {
+          throw new Error(
+            `Conflicting registry entry for ${plugin.id}@${version.version} between ${existing.registryUrl || 'unknown registry'} and ${registryUrl}`
+          )
+        }
+
+        versionsByNumber.set(version.version, normalizedVersion)
+      }
+
+      current.versions = sortVersionsDescending(Array.from(versionsByNumber.values()))
+      mergedPlugins.set(plugin.id, current)
+    }
+  }
+
+  return {
+    updatedAt: new Date().toISOString(),
+    plugins: Array.from(mergedPlugins.values()).sort((a, b) => a.id.localeCompare(b.id))
+  }
+}

--- a/tests/integration/refreshPlugins.test.ts
+++ b/tests/integration/refreshPlugins.test.ts
@@ -1,11 +1,13 @@
 // Integration test for refreshPlugins against live Neo4j. This resolver reaches
-// out to a plugin registry over HTTP and downloads each plugin's tarball to read
-// its manifest, so we mock global fetch: the registry URL returns registry JSON,
-// and each tarball URL returns a real gzipped tar containing plugin.json. The DB
-// writes (Plugin / PluginVersion nodes) run against the live container.
+// out to a plugin source over HTTP and now synthesizes registry entries from the
+// GitHub Releases API, so we mock global fetch: the repo URL resolves to release
+// metadata, the plugin.json asset provides the manifest, and the tarball/checksum
+// assets are downloaded and verified against a real gzipped tar containing plugin.json.
+// The DB writes (Plugin / PluginVersion nodes) run against the live container.
 
 import test, { before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import tar from "tar-stream";
 import { gzipSync } from "zlib";
 import {
@@ -19,8 +21,11 @@ import {
 let env: ImageModEnv;
 const originalFetch = globalThis.fetch;
 
-const REGISTRY_URL = "https://registry.test/registry.json";
-const TARBALL_URL = "https://registry.test/test-plugin-1.0.0.tgz";
+const REPO_URL = "https://github.com/gennit-project/test-plugin";
+const RELEASES_API_URL = "https://api.github.com/repos/gennit-project/test-plugin/releases?per_page=100";
+const TARBALL_URL = "https://github.com/gennit-project/test-plugin/releases/download/v1.0.0/test-plugin-1.0.0.tgz";
+const MANIFEST_URL = "https://github.com/gennit-project/test-plugin/releases/download/v1.0.0/plugin.json";
+const CHECKSUM_URL = "https://github.com/gennit-project/test-plugin/releases/download/v1.0.0/test-plugin-1.0.0.tgz.sha256";
 
 const buildTarball = (manifest: object): Promise<Buffer> =>
   new Promise((resolve, reject) => {
@@ -36,28 +41,53 @@ const buildTarball = (manifest: object): Promise<Buffer> =>
   });
 
 let tarball: Buffer;
-
-const registryJson = {
-  updatedAt: "2026-01-01T00:00:00Z",
-  plugins: [
-    {
-      id: "test-plugin",
-      versions: [
-        {
-          version: "1.0.0",
-          tarballUrl: TARBALL_URL,
-          integritySha256: "deadbeef",
-        },
-      ],
-    },
-  ],
-};
+let tarballSha256: string;
 
 const installFetchMock = () => {
   globalThis.fetch = (async (url: any) => {
     const u = String(url);
-    if (u === REGISTRY_URL) {
-      return { ok: true, status: 200, json: async () => registryJson };
+    if (u === RELEASES_API_URL) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ([
+          {
+            tag_name: "v1.0.0",
+            html_url: "https://github.com/gennit-project/test-plugin/releases/tag/v1.0.0",
+            target_commitish: "main",
+            assets: [
+              { name: "plugin.json", browser_download_url: MANIFEST_URL },
+              { name: "test-plugin-1.0.0.tgz", browser_download_url: TARBALL_URL },
+              { name: "test-plugin-1.0.0.tgz.sha256", browser_download_url: CHECKSUM_URL },
+            ],
+          },
+        ]),
+      };
+    }
+    if (u === MANIFEST_URL) {
+      const manifest = {
+        id: "test-plugin",
+        version: "1.0.0",
+        name: "Test Plugin",
+        description: "A test plugin",
+        entry: "index.js",
+        metadata: { author: { name: "Alice" }, tags: ["util"] },
+        source: { repoUrl: REPO_URL },
+        compatibility: { minServerVersion: "1.0.0", apiVersion: "1" },
+      };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => manifest,
+        text: async () => JSON.stringify(manifest),
+      };
+    }
+    if (u === CHECKSUM_URL) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => `${tarballSha256}  test-plugin-1.0.0.tgz\n`,
+      };
     }
     if (u === TARBALL_URL) {
       return {
@@ -84,6 +114,7 @@ before(async () => {
     entry: "index.js",
     metadata: { author: { name: "Alice" }, tags: ["util"] },
   });
+  tarballSha256 = crypto.createHash("sha256").update(tarball).digest("hex");
 }, { timeout: 240000 });
 
 after(async () => {
@@ -102,7 +133,7 @@ const refreshPlugins = () =>
 test("creates Plugin + PluginVersion from the registry and tarball manifest", async () => {
   await run(
     `CREATE (:ServerConfig { serverName: 'test-server', pluginRegistries: [$url] })`,
-    { url: REGISTRY_URL }
+    { url: REPO_URL }
   );
 
   await refreshPlugins();

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1584,6 +1584,12 @@ const typeDefinitions = gql`
     repoUrl: String!
     tarballGsUri: String
     integritySha256: String
+    registryUrl: String
+    releaseNotesUrl: String
+    sourceRepoUrl: String
+    sourceCommit: String
+    minServerVersion: String
+    apiVersion: String
     entryPath: String!
     manifest: JSON
     settingsDefaults: JSON
@@ -1733,6 +1739,12 @@ const typeDefinitions = gql`
     uiSchema: JSON
     documentationPath: String
     readmeMarkdown: String
+    registryUrl: String
+    releaseNotesUrl: String
+    sourceRepoUrl: String
+    sourceCommit: String
+    minServerVersion: String
+    apiVersion: String
     hasUpdate: Boolean
     latestVersion: String
     availableVersions: [String!]


### PR DESCRIPTION
Backend changes for the standalone plugin release flow.\n\n- synthesize registry entries from GitHub repo release assets\n- refresh plugins from repo URLs instead of only prebuilt registry JSON\n- keep compatibility metadata and integrity verification in the refresh path\n\nChecks:\n- tsc --noEmit\n- services/plugin/registryService.test.ts\n- tests/integration/refreshPlugins.test.ts