### PR TITLE
Validate channel preference flag values (#105)

### DIFF
--- a/rules/validation/channelIsValid.test.ts
+++ b/rules/validation/channelIsValid.test.ts
@@ -108,3 +108,85 @@ test("rejects malformed rules JSON", () => {
     "The rules must be a valid JSON array."
   );
 });
+
+// --- preference flags (#105) ---
+
+test("accepts boolean preference flags", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      eventsEnabled: false,
+      wikiEnabled: true,
+      isEditMode: false,
+    }),
+    true
+  );
+});
+
+test("accepts null/undefined preference flags", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      eventsEnabled: null,
+      isEditMode: false,
+    }),
+    true
+  );
+});
+
+test("rejects a non-boolean preference flag", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      // @ts-expect-error - deliberately invalid value
+      eventsEnabled: "yes",
+      isEditMode: false,
+    }),
+    "eventsEnabled must be true or false."
+  );
+});
+
+test("accepts a valid allowedFileTypes array", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      allowedFileTypes: ["pdf", ".png", "STL"],
+      isEditMode: false,
+    }),
+    true
+  );
+});
+
+test("rejects allowedFileTypes that is not an array", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      // @ts-expect-error - deliberately invalid value
+      allowedFileTypes: "pdf",
+      isEditMode: false,
+    }),
+    "allowedFileTypes must be an array."
+  );
+});
+
+test("rejects an empty-string file type", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      allowedFileTypes: ["pdf", "  "],
+      isEditMode: false,
+    }),
+    "Each allowed file type must be a non-empty string."
+  );
+});
+
+test("rejects a malformed file type", () => {
+  assert.equal(
+    validateChannelInput({
+      uniqueName: "cats",
+      allowedFileTypes: ["pdf/exe"],
+      isEditMode: false,
+    }),
+    '"pdf/exe" is not a valid file type.'
+  );
+});

--- a/rules/validation/channelIsValid.ts
+++ b/rules/validation/channelIsValid.ts
@@ -23,7 +23,34 @@ type ChannelInput = {
   displayName?: string | null;
   rules?: string;
   isEditMode?: boolean | null;
+  // Preference flags
+  eventsEnabled?: boolean | null;
+  wikiEnabled?: boolean | null;
+  feedbackEnabled?: boolean | null;
+  downloadsEnabled?: boolean | null;
+  emojiEnabled?: boolean | null;
+  imageUploadsEnabled?: boolean | null;
+  markdownImagesEnabled?: boolean | null;
+  markAsAnsweredEnabled?: boolean | null;
+  allowedFileTypes?: Array<string | null> | null;
 };
+
+// The Channel preference flags, all GraphQL Booleans. GraphQL already rejects
+// non-booleans on the API path, so this is a defensive guard for the exported
+// validator.
+const BOOLEAN_FLAGS: Array<keyof ChannelInput> = [
+  "eventsEnabled",
+  "wikiEnabled",
+  "feedbackEnabled",
+  "downloadsEnabled",
+  "emojiEnabled",
+  "imageUploadsEnabled",
+  "markdownImagesEnabled",
+  "markAsAnsweredEnabled",
+];
+
+// A file type is an extension token: letters/digits, optionally a leading dot.
+const FILE_TYPE_PATTERN = /^\.?[A-Za-z0-9]+$/;
 
 export const validateChannelInput = (input: ChannelInput): true | string => {
   const { uniqueName, description, displayName, isEditMode } = input;
@@ -68,6 +95,32 @@ export const validateChannelInput = (input: ChannelInput): true | string => {
       return "The rules must be a valid JSON array.";
     }
   }
+
+  // Preference flags must be booleans when present.
+  for (const flag of BOOLEAN_FLAGS) {
+    const value = input[flag];
+    if (value !== undefined && value !== null && typeof value !== "boolean") {
+      return `${flag} must be true or false.`;
+    }
+  }
+
+  // allowedFileTypes, when present, must be an array of non-empty extension
+  // tokens (whether a given type is permitted server-wide is enforced at upload
+  // time; here we only validate the shape).
+  if (input.allowedFileTypes !== undefined && input.allowedFileTypes !== null) {
+    if (!Array.isArray(input.allowedFileTypes)) {
+      return "allowedFileTypes must be an array.";
+    }
+    for (const fileType of input.allowedFileTypes) {
+      if (typeof fileType !== "string" || fileType.trim() === "") {
+        return "Each allowed file type must be a non-empty string.";
+      }
+      if (!FILE_TYPE_PATTERN.test(fileType.trim())) {
+        return `"${fileType}" is not a valid file type.`;
+      }
+    }
+  }
+
   logger.info("channel input is valid");
 
   return true;


### PR DESCRIPTION
Closes #105.

## Change
`validateChannelInput` (`rules/validation/channelIsValid.ts`) previously checked `uniqueName` / `description` / `displayName` / `rules` but not the preference flags. It now validates:

- **Boolean flags** — `eventsEnabled`, `wikiEnabled`, `feedbackEnabled`, `downloadsEnabled`, `emojiEnabled`, `imageUploadsEnabled`, `markdownImagesEnabled`, `markAsAnsweredEnabled` must be booleans when present. (Defensive — GraphQL already enforces the `Boolean` type on the API path; this guards the exported validator.)
- **`allowedFileTypes`** — when present, must be an array of non-empty extension tokens (`letters/digits`, optional leading dot). Whether a given type is permitted server-wide is still enforced at upload time (`downloadableFileIsValid`); this only validates the shape.

## Tests
7 new unit tests in `channelIsValid.test.ts` (valid/null flags, non-boolean flag, valid/non-array/empty/malformed file types). Full file 20/20; `npm run tsc` clean.

Priority: low (defensive), as scoped in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)