### PR TITLE
[codex] Auto-save downloads to a private collection

### DIFF
--- a/customResolvers/mutations/trackDownload.test.ts
+++ b/customResolvers/mutations/trackDownload.test.ts
@@ -2,10 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { Driver } from 'neo4j-driver'
 import type { GraphQLContext } from '../../types/context.js'
-import trackDownload from './trackDownload.js'
+import trackDownload, {
+  AUTO_SAVED_DOWNLOADS_COLLECTION_DESCRIPTION,
+  AUTO_SAVED_DOWNLOADS_COLLECTION_NAME
+} from './trackDownload.js'
 
 type RunCall = [string, {
   username?: string
+  downloadsCollectionName?: string
+  downloadsCollectionDescription?: string
   downloadableFileId: string
   discussionId: string
 }]
@@ -114,6 +119,51 @@ test('trackDownload updates counters and saves the download discussion', async (
   assert.match(calls.run[0][0], /downloadCountTotal/)
   assert.match(calls.run[0][0], /downloadCountUnique/)
   assert.match(calls.run[0][0], /OWNS_DOWNLOAD/)
+  assert.match(calls.run[0][0], /CREATED_BY/)
+  assert.match(calls.run[0][0], /CONTAINS_DOWNLOAD/)
+  assert.match(calls.run[0][0], /itemOrder/)
+  assert.equal(
+    calls.run[0][1].downloadsCollectionName,
+    AUTO_SAVED_DOWNLOADS_COLLECTION_NAME
+  )
+  assert.equal(
+    calls.run[0][1].downloadsCollectionDescription,
+    AUTO_SAVED_DOWNLOADS_COLLECTION_DESCRIPTION
+  )
+})
+
+test('trackDownload only appends to the downloads collection when the discussion is not already present', async () => {
+  const { driver, calls } = buildDriver()
+  const resolver = trackDownload({ driver })
+
+  await resolver(
+    null,
+    { downloadableFileId: 'file-1', discussionId: 'discussion-1' },
+    { user: { username: 'alice' } } as unknown as GraphQLContext
+  )
+
+  assert.match(calls.run[0][0], /existingCollectionDownload IS NULL/)
+  assert.match(calls.run[0][0], /FOREACH/)
+  assert.match(calls.run[0][0], /coalesce\(downloadsCollection.itemOrder, \[\]\) \+ \[\$discussionId\]/)
+})
+
+test('trackDownload treats a different authenticated user as a separate downloader', async () => {
+  const { driver, calls } = buildDriver()
+  const resolver = trackDownload({ driver })
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: 'file-1', discussionId: 'discussion-1' },
+    { user: { username: 'bob' } } as unknown as GraphQLContext
+  )
+
+  assert.equal(result, true)
+  assert.equal(calls.run[0][1].username, 'bob')
+  assert.match(calls.run[0][0], /existingDownload IS NULL AS isUnique/)
+  assert.match(
+    calls.run[0][0],
+    /downloadCountUnique = coalesce\(file.downloadCountUnique, 0\) \+ CASE WHEN isUnique THEN 1 ELSE 0 END/
+  )
 })
 
 test('trackDownload throws when the file does not belong to the discussion', async () => {

--- a/customResolvers/mutations/trackDownload.ts
+++ b/customResolvers/mutations/trackDownload.ts
@@ -20,6 +20,10 @@ type Input = {
 
 type Neo4jCount = number | { toNumber: () => number } | null | undefined
 
+export const AUTO_SAVED_DOWNLOADS_COLLECTION_NAME = 'Downloaded Items'
+export const AUTO_SAVED_DOWNLOADS_COLLECTION_DESCRIPTION =
+  'Items appear here automatically when you download them.'
+
 const toNumber = (value: Neo4jCount) => {
   if (typeof value === 'number') {
     return value
@@ -93,11 +97,28 @@ const trackDownload = ({
         MATCH (user:User {username: $username})
         MATCH (discussion:Discussion {id: $discussionId})-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile {id: $downloadableFileId})
         OPTIONAL MATCH (user)-[existingDownload:DOWNLOADED_FILE]->(file)
-        WITH user, discussion, file, existingDownload IS NULL AS isUnique
+        MERGE (user)<-[:CREATED_BY]-(downloadsCollection:Collection {
+          name: $downloadsCollectionName,
+          collectionType: 'DOWNLOADS'
+        })
+          ON CREATE SET
+            downloadsCollection.id = randomUUID(),
+            downloadsCollection.description = $downloadsCollectionDescription,
+            downloadsCollection.visibility = 'PRIVATE',
+            downloadsCollection.itemOrder = [],
+            downloadsCollection.createdAt = datetime(),
+            downloadsCollection.updatedAt = datetime()
+        WITH user, discussion, file, downloadsCollection, existingDownload IS NULL AS isUnique
         MERGE (user)-[download:DOWNLOADED_FILE]->(file)
           ON CREATE SET download.createdAt = datetime()
+        OPTIONAL MATCH (downloadsCollection)-[existingCollectionDownload:CONTAINS_DOWNLOAD]->(discussion)
+        FOREACH (_ IN CASE WHEN existingCollectionDownload IS NULL THEN [1] ELSE [] END |
+          MERGE (downloadsCollection)-[:CONTAINS_DOWNLOAD]->(discussion)
+          SET downloadsCollection.itemOrder = coalesce(downloadsCollection.itemOrder, []) + [$discussionId]
+        )
         SET
           download.lastDownloadedAt = datetime(),
+          downloadsCollection.updatedAt = datetime(),
           file.downloadCountTotal = coalesce(file.downloadCountTotal, 0) + 1,
           file.downloadCountUnique = coalesce(file.downloadCountUnique, 0) + CASE WHEN isUnique THEN 1 ELSE 0 END
         MERGE (user)-[:OWNS_DOWNLOAD]->(discussion)
@@ -105,6 +126,9 @@ const trackDownload = ({
         `,
         {
           username,
+          downloadsCollectionName: AUTO_SAVED_DOWNLOADS_COLLECTION_NAME,
+          downloadsCollectionDescription:
+            AUTO_SAVED_DOWNLOADS_COLLECTION_DESCRIPTION,
           downloadableFileId,
           discussionId
         }


### PR DESCRIPTION
## What changed
- extended `trackDownload` so authenticated downloads also create or reuse a private `Downloaded Items` collection
- upserted the downloaded discussion into that collection without duplicating membership or `itemOrder`
- kept the existing unique/total download tracking behavior intact
- added resolver tests covering anonymous downloads, authenticated downloads, repeat collection membership protection, and multi-user uniqueness behavior

## Why
The roadmap's first downloads slice requires downloaded items to appear in a durable private library collection while keeping download-activity tracking separate from collection membership.

## User impact
Authenticated users now build a real private downloads collection as they download files, which the frontend can surface in Library.

## Validation
- `TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test customResolvers/mutations/trackDownload.test.ts`

## Notes
- This PR intentionally keeps the legacy `OWNS_DOWNLOAD` relationship for compatibility while adding the new collection-backed library path.