### PR TITLE
Add sitewide issue list resolver

### DIFF
--- a/customResolvers/cypher/cypherQueries.ts
+++ b/customResolvers/cypher/cypherQueries.ts
@@ -17,6 +17,7 @@ export const getCommentsQuery = fs.readFileSync(path.resolve(__dirname, './getCo
 export const getNewCommentsQuery = fs.readFileSync(path.resolve(__dirname, './getNewCommentsQuery.cypher'), 'utf8');
 export const getDiscussionChannelsQuery = fs.readFileSync(path.resolve(__dirname, './getDiscussionChannelsQuery.cypher'), 'utf8');
 export const getSiteWideDiscussionsQuery = fs.readFileSync(path.resolve(__dirname, './getSiteWideDiscussionsQuery.cypher'), 'utf8');
+export const getSiteWideIssuesQuery = fs.readFileSync(path.resolve(__dirname, './getSiteWideIssuesQuery.cypher'), 'utf8');
 export const getSiteWideWikiPagesQuery = fs.readFileSync(path.resolve(__dirname, './getSiteWideWikiPagesQuery.cypher'), 'utf8');
 export const getCommentRepliesQuery = fs.readFileSync(path.resolve(__dirname, './getCommentRepliesQuery.cypher'), 'utf8');
 export const getEventCommentsQuery = fs.readFileSync(path.resolve(__dirname, './getEventCommentsQuery.cypher'), 'utf8');

--- a/customResolvers/cypher/getSiteWideIssuesQuery.cypher
+++ b/customResolvers/cypher/getSiteWideIssuesQuery.cypher
@@ -1,0 +1,51 @@
+MATCH (issue:Issue)
+WHERE issue.isOpen = $isOpen
+AND ($searchInput = "" OR coalesce(issue.title, "") =~ $titleRegex OR coalesce(issue.body, "") =~ $bodyRegex)
+AND (size($selectedChannels) = 0 OR issue.channelUniqueName IN $selectedChannels)
+AND ($showOnlyServerRuleViolations = false OR coalesce(issue.flaggedServerRuleViolation, false) = true)
+AND ($startDate IS NULL OR datetime(issue.createdAt) >= datetime($startDate))
+AND ($endDate IS NULL OR datetime(issue.createdAt) <= datetime($endDate))
+WITH count(issue) AS totalCount
+
+MATCH (issue:Issue)
+WHERE issue.isOpen = $isOpen
+AND ($searchInput = "" OR coalesce(issue.title, "") =~ $titleRegex OR coalesce(issue.body, "") =~ $bodyRegex)
+AND (size($selectedChannels) = 0 OR issue.channelUniqueName IN $selectedChannels)
+AND ($showOnlyServerRuleViolations = false OR coalesce(issue.flaggedServerRuleViolation, false) = true)
+AND ($startDate IS NULL OR datetime(issue.createdAt) >= datetime($startDate))
+AND ($endDate IS NULL OR datetime(issue.createdAt) <= datetime($endDate))
+OPTIONAL MATCH (issue)<-[:HAS_ISSUE]-(channel:Channel)
+OPTIONAL MATCH (issue)<-[:AUTHORED_ISSUE]-(authorUser:User)
+OPTIONAL MATCH (issue)<-[:AUTHORED_ISSUE]-(authorMod:ModerationProfile)
+OPTIONAL MATCH (issue)-[:ACTIVITY_ON_ISSUE]->(reportAction:ModerationAction {actionType: "report"})
+WITH issue, channel, authorUser, authorMod, count(reportAction) AS reportCount, totalCount
+ORDER BY
+  CASE WHEN $sort = "mostReports" THEN reportCount END DESC,
+  CASE WHEN $sort = "oldest" THEN datetime(issue.createdAt).epochMillis END ASC,
+  CASE WHEN $sort <> "oldest" THEN datetime(issue.createdAt).epochMillis END DESC,
+  issue.issueNumber DESC
+SKIP $offset
+LIMIT $limit
+RETURN {
+  id: issue.id,
+  issueNumber: issue.issueNumber,
+  title: issue.title,
+  body: issue.body,
+  isOpen: issue.isOpen,
+  createdAt: toString(issue.createdAt),
+  updatedAt: toString(issue.updatedAt),
+  relatedCommentId: issue.relatedCommentId,
+  relatedDiscussionId: issue.relatedDiscussionId,
+  relatedEventId: issue.relatedEventId,
+  relatedImageId: issue.relatedImageId,
+  relatedWikiPageId: issue.relatedWikiPageId,
+  relatedWikiRevisionId: issue.relatedWikiRevisionId,
+  relatedUsername: issue.relatedUsername,
+  flaggedServerRuleViolation: issue.flaggedServerRuleViolation,
+  locked: issue.locked,
+  lockReason: issue.lockReason,
+  channelUniqueName: issue.channelUniqueName,
+  channelIconURL: channel.channelIconURL,
+  authorName: coalesce(authorMod.displayName, authorUser.username, issue.authorName),
+  reportCount: reportCount
+} AS issue, totalCount

--- a/customResolvers/queries/getSiteWideIssueList.test.ts
+++ b/customResolvers/queries/getSiteWideIssueList.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLResolveInfo } from "graphql";
+import neo4j, { type Driver, type Integer } from "neo4j-driver";
+import { getSiteWideIssuesQuery } from "../cypher/cypherQueries.js";
+import type { GraphQLContext } from "../../types/context.js";
+import getSiteWideIssueListResolver from "./getSiteWideIssueList.js";
+
+type SessionRunCall = {
+  query: string;
+  params: Record<string, unknown>;
+};
+
+const createMockDriver = (mockRecords: Array<Record<string, unknown>> = []) => {
+  const runCalls: SessionRunCall[] = [];
+
+  return {
+    runCalls,
+    session: () => ({
+      run: async (query: string, params: Record<string, unknown>) => {
+        runCalls.push({ query, params });
+        return {
+          records: mockRecords.map((record) => ({
+            get: (key: string) => record[key],
+          })),
+        };
+      },
+      close: async () => {},
+    }),
+  } as unknown as Driver & { runCalls: SessionRunCall[] };
+};
+
+const createMockContext = () =>
+  ({
+    req: {
+      headers: {},
+    },
+  }) as unknown as GraphQLContext;
+
+const mockInfo = null as unknown as GraphQLResolveInfo;
+
+const baseArgs = {
+  searchInput: "",
+  selectedChannels: [],
+  startDate: null,
+  endDate: null,
+  showOnlyServerRuleViolations: true,
+  isOpen: true,
+  options: {
+    offset: 0,
+    limit: null,
+    sort: "newest",
+  },
+};
+
+test("getSiteWideIssueList passes the default params to the query", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(null, baseArgs, createMockContext(), mockInfo);
+
+  assert.equal(driver.runCalls.length, 1);
+  assert.equal(driver.runCalls[0].params.searchInput, "");
+  assert.equal(driver.runCalls[0].params.sort, "newest");
+  assert.equal(driver.runCalls[0].params.isOpen, true);
+  assert.deepEqual(driver.runCalls[0].params.selectedChannels, []);
+  assert.equal(neo4j.isInt(driver.runCalls[0].params.offset), true);
+  assert.equal((driver.runCalls[0].params.offset as Integer).toNumber(), 0);
+  assert.equal(neo4j.isInt(driver.runCalls[0].params.limit), true);
+  assert.equal(
+    (driver.runCalls[0].params.limit as Integer).toNumber(),
+    1_000_000_000
+  );
+});
+
+test("getSiteWideIssueList normalizes date filters to full-day UTC bounds", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    {
+      ...baseArgs,
+      startDate: "2026-05-01",
+      endDate: "2026-07-01",
+    },
+    createMockContext(),
+    mockInfo
+  );
+
+  assert.equal(driver.runCalls[0].params.startDate, "2026-05-01T00:00:00.000Z");
+  assert.equal(driver.runCalls[0].params.endDate, "2026-07-01T23:59:59.999Z");
+});
+
+test("getSiteWideIssueList passes selected channels and rule-violation filter", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    {
+      ...baseArgs,
+      selectedChannels: ["cats", "dogs"],
+      showOnlyServerRuleViolations: false,
+    },
+    createMockContext(),
+    mockInfo
+  );
+
+  assert.deepEqual(driver.runCalls[0].params.selectedChannels, ["cats", "dogs"]);
+  assert.equal(driver.runCalls[0].params.showOnlyServerRuleViolations, false);
+});
+
+test("getSiteWideIssueList passes sort options through", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    {
+      ...baseArgs,
+      options: {
+        offset: 3,
+        limit: 25,
+        sort: "mostReports",
+      },
+    },
+    createMockContext(),
+    mockInfo
+  );
+
+  assert.equal(driver.runCalls[0].params.sort, "mostReports");
+  assert.equal((driver.runCalls[0].params.offset as Integer).toNumber(), 3);
+  assert.equal((driver.runCalls[0].params.limit as Integer).toNumber(), 25);
+});
+
+test("getSiteWideIssueList falls back to newest for unknown sort", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    {
+      ...baseArgs,
+      options: {
+        ...baseArgs.options,
+        sort: "weird",
+      },
+    } as any,
+    createMockContext(),
+    mockInfo
+  );
+
+  assert.equal(driver.runCalls[0].params.sort, "newest");
+});
+
+test("getSiteWideIssueList returns issues and aggregate count", async () => {
+  const driver = createMockDriver([
+    {
+      issue: { id: "i1", title: "First", reportCount: 3 },
+      totalCount: 2,
+    },
+    {
+      issue: { id: "i2", title: "Second", reportCount: 1 },
+      totalCount: 2,
+    },
+  ]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  const result = await resolver(null, baseArgs, createMockContext(), mockInfo);
+
+  assert.equal(result.aggregateIssueCount, 2);
+  assert.deepEqual(result.issues, [
+    { id: "i1", title: "First", reportCount: 3 },
+    { id: "i2", title: "Second", reportCount: 1 },
+  ]);
+});
+
+test("getSiteWideIssueList query uses bound pagination params", () => {
+  assert.match(getSiteWideIssuesQuery, /SKIP \$offset/);
+  assert.match(getSiteWideIssuesQuery, /LIMIT \$limit/);
+});
+
+test("getSiteWideIssueList query stringifies datetime fields", () => {
+  assert.match(getSiteWideIssuesQuery, /createdAt: toString\(issue\.createdAt\)/);
+  assert.match(getSiteWideIssuesQuery, /updatedAt: toString\(issue\.updatedAt\)/);
+});

--- a/customResolvers/queries/getSiteWideIssueList.ts
+++ b/customResolvers/queries/getSiteWideIssueList.ts
@@ -1,0 +1,124 @@
+import type { GraphQLResolveInfo } from "graphql";
+import neo4j, { type Driver, type Record as Neo4jRecord } from "neo4j-driver";
+import { DateTime } from "luxon";
+import { getSiteWideIssuesQuery } from "../cypher/cypherQueries.js";
+import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
+
+type Input = {
+  driver: Driver;
+};
+
+type Args = {
+  searchInput?: string;
+  selectedChannels?: string[];
+  startDate?: string | null;
+  endDate?: string | null;
+  showOnlyServerRuleViolations?: boolean;
+  isOpen: boolean;
+  options?: {
+    offset?: number | null;
+    limit?: number | null;
+    sort?: string | null;
+  };
+};
+
+const VALID_SORTS = new Set(["newest", "oldest", "mostReports"]);
+const DEFAULT_LIMIT = 1_000_000_000;
+
+const sanitize = (value: unknown): unknown => {
+  if (neo4j.isInt(value)) return value.toNumber();
+  if (Array.isArray(value)) return value.map(sanitize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitize(entry)])
+    );
+  }
+  return value;
+};
+
+const normalizeDateStart = (value: string | null | undefined) => {
+  if (!value) return null;
+  const parsed = DateTime.fromISO(value, { zone: "utc" });
+  return parsed.isValid ? parsed.startOf("day").toISO() : null;
+};
+
+const normalizeDateEnd = (value: string | null | undefined) => {
+  if (!value) return null;
+  const parsed = DateTime.fromISO(value, { zone: "utc" });
+  return parsed.isValid ? parsed.endOf("day").toISO() : null;
+};
+
+const normalizePaginationValue = (
+  value: number | null | undefined,
+  fallback: number
+) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return neo4j.int(fallback);
+  }
+  return neo4j.int(Math.max(0, Math.trunc(value)));
+};
+
+const getResolver = (input: Input) => {
+  const { driver } = input;
+
+  return async (
+    parent: unknown,
+    args: Args,
+    context: GraphQLContext,
+    info: GraphQLResolveInfo
+  ) => {
+    const searchInput = args.searchInput ?? "";
+    const selectedChannels = args.selectedChannels ?? [];
+    const showOnlyServerRuleViolations =
+      args.showOnlyServerRuleViolations ?? true;
+    const offset = normalizePaginationValue(args.options?.offset, 0);
+    const limit = normalizePaginationValue(args.options?.limit, DEFAULT_LIMIT);
+    const sort = VALID_SORTS.has(args.options?.sort || "")
+      ? args.options?.sort || "newest"
+      : "newest";
+
+    const session = driver.session();
+    const titleRegex = `(?i).*${searchInput}.*`;
+    const bodyRegex = `(?i).*${searchInput}.*`;
+    const startDate = normalizeDateStart(args.startDate);
+    const endDate = normalizeDateEnd(args.endDate);
+
+    try {
+      const issueResult = await session.run(getSiteWideIssuesQuery, {
+        searchInput,
+        titleRegex,
+        bodyRegex,
+        selectedChannels,
+        showOnlyServerRuleViolations,
+        startDate,
+        endDate,
+        isOpen: args.isOpen,
+        offset,
+        limit,
+        sort,
+      });
+
+      const firstRecord = issueResult.records[0];
+      const aggregateIssueCount = firstRecord
+        ? sanitize(firstRecord.get("totalCount"))
+        : 0;
+      const issues = issueResult.records.map((record: Neo4jRecord) =>
+        sanitize(record.get("issue"))
+      );
+
+      return {
+        aggregateIssueCount,
+        issues,
+      };
+    } catch (error: unknown) {
+      logger.error("Error getting site wide issues:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to fetch site wide issues. ${message}`);
+    } finally {
+      session.close();
+    }
+  };
+};
+
+export default getResolver;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -21,6 +21,7 @@ import getPipelineRuns from "./queries/getPipelineRuns.js";
 import publicCollectionsContaining from "./queries/publicCollectionsContaining.js";
 import getOwnEmail from "./queries/getOwnEmail.js";
 import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
+import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -43,6 +44,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
   return {
     getSiteWideDiscussionList: getSiteWideDiscussionList({
       Discussion,
+      driver,
+    }),
+    getSiteWideIssueList: getSiteWideIssueList({
       driver,
     }),
     getSiteWideWikiList: getSiteWideWikiList({

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1398,6 +1398,18 @@ const typeDefinitions = gql`
     timeFrame: TimeFrame
   }
 
+  enum IssueSortType {
+    newest
+    oldest
+    mostReports
+  }
+
+  input IssueListOptions {
+    offset: Int
+    limit: Int
+    sort: IssueSortType
+  }
+
   input WikiListOptions {
     offset: Int
     limit: Int
@@ -1426,6 +1438,35 @@ const typeDefinitions = gql`
   type SiteWideWikiListFormat {
     aggregateWikiPageCount: Int!
     wikiPages: [WikiPage!]!
+  }
+
+  type SiteWideIssueListItem {
+    id: ID!
+    issueNumber: Int!
+    title: String
+    body: String
+    isOpen: Boolean!
+    createdAt: DateTime!
+    updatedAt: DateTime
+    relatedCommentId: ID
+    relatedDiscussionId: ID
+    relatedEventId: ID
+    relatedImageId: ID
+    relatedWikiPageId: ID
+    relatedWikiRevisionId: ID
+    relatedUsername: String
+    flaggedServerRuleViolation: Boolean
+    locked: Boolean
+    lockReason: String
+    channelUniqueName: String
+    channelIconURL: String
+    authorName: String
+    reportCount: Int!
+  }
+
+  type SiteWideIssueListFormat {
+    aggregateIssueCount: Int!
+    issues: [SiteWideIssueListItem!]!
   }
 
   type DiscussionChannelListItem {
@@ -2010,6 +2051,15 @@ const typeDefinitions = gql`
       options: DiscussionListOptions
       loggedInUsername: String
     ): SiteWideDiscussionListFormat
+    getSiteWideIssueList(
+      searchInput: String
+      selectedChannels: [String]
+      startDate: String
+      endDate: String
+      showOnlyServerRuleViolations: Boolean
+      isOpen: Boolean!
+      options: IssueListOptions
+    ): SiteWideIssueListFormat
     getSiteWideWikiList(
       searchInput: String
       selectedChannels: [String]


### PR DESCRIPTION
## Summary
- add a custom sitewide issue list query and resolver for admin issues
- support backend sorting by newest, oldest, and most reports
- fix pagination integer handling and datetime serialization for the custom issue list response

## Testing
- npm run build
- verified the local GraphQL getSiteWideIssueList query returns rows on http://localhost:4000/graphql