### PR TITLE
[codex] Default collection visibility safely

### DIFF
--- a/customResolvers/mutations/utils/ownershipSanitizers.test.ts
+++ b/customResolvers/mutations/utils/ownershipSanitizers.test.ts
@@ -6,6 +6,7 @@ import {
   sanitizeImagesFieldInput,
   sanitizeAlbumCreateNode,
   sanitizeAlbumUpdateNode,
+  sanitizeCollectionCreateInput,
 } from "./ownershipSanitizers.js";
 
 // sanitizeAlbumCreateInput tests
@@ -308,4 +309,42 @@ test("sanitizeAlbumUpdateNode preserves non-ownership fields", () => {
   assert.deepEqual(result?.imageOrder, ["1", "2", "3"]);
   // Arbitrary client field preserved by the spread but not on AlbumUpdateInput.
   assert.equal((result as Record<string, unknown>).customField, "preserved");
+});
+
+test("sanitizeCollectionCreateInput defaults visibility to PRIVATE", () => {
+  const result = sanitizeCollectionCreateInput(
+    {
+      name: "Reading List",
+      collectionType: "DISCUSSIONS",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      itemOrder: [],
+    },
+    "owner-user"
+  );
+
+  assert.equal(result.visibility, "PRIVATE");
+  assert.deepEqual(result.CreatedBy, {
+    connect: { where: { node: { username: "owner-user" } } },
+  });
+});
+
+test("sanitizeCollectionCreateInput preserves explicit visibility overrides", () => {
+  const result = sanitizeCollectionCreateInput(
+    {
+      name: "Shared List",
+      collectionType: "DISCUSSIONS",
+      visibility: "PUBLIC",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      itemOrder: [],
+      CreatedBy: {
+        connect: { where: { node: { username: "spoofed-user" } } },
+      },
+    },
+    "owner-user"
+  );
+
+  assert.equal(result.visibility, "PUBLIC");
+  assert.deepEqual(result.CreatedBy, {
+    connect: { where: { node: { username: "owner-user" } } },
+  });
 });

--- a/customResolvers/mutations/utils/ownershipSanitizers.ts
+++ b/customResolvers/mutations/utils/ownershipSanitizers.ts
@@ -6,6 +6,7 @@ import type {
   ImageUploaderFieldInput,
   CollectionCreateInput,
   CollectionCreatedByFieldInput,
+  CollectionVisibility,
 } from "../../../ogm_types.js";
 
 const buildOwnerConnect = (username: string): AlbumOwnerFieldInput => ({
@@ -120,6 +121,9 @@ export const sanitizeCollectionCreateInput = (
 
   return {
     ...rest,
+    visibility:
+      ((rest as Partial<CollectionCreateInput>).visibility as CollectionVisibility | undefined) ??
+      "PRIVATE",
     CreatedBy: buildCreatedByConnect(username),
   } as CollectionCreateInput;
 };


### PR DESCRIPTION
## What changed
- default collection creation visibility to `PRIVATE` in the ownership sanitizer when the client omits visibility
- preserve explicit client visibility choices, including `PUBLIC`
- keep ownership sanitization behavior unchanged: `CreatedBy` is still forced to the authenticated user
- add tests for default-private behavior and explicit visibility overrides

## Why
The frontend should default new collections to private, but the backend should also fail closed if another creation path omits visibility.

## Frontend pair
- pairs with `gennit-project/multiforum-nuxt` branch `codex/collections-private-frontend`

## Validation
- `node --experimental-specifier-resolution=node --loader ts-node/esm --test customResolvers/mutations/utils/ownershipSanitizers.test.ts`