### PR TITLE
Add upload storage metadata auditing

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -79,6 +79,7 @@ import installPluginVersion from "./mutations/installPluginVersion.js";
 import triggerDownloadableFilePluginRuns from "./mutations/triggerDownloadableFilePluginRuns.js";
 import trackDownload from "./mutations/trackDownload.js";
 import updateDownloadableFileSupportSettings from "./mutations/updateDownloadableFileSupportSettings.js";
+import createDownloadableFilesWithUploadMetadata from "./mutations/createDownloadableFilesWithUploadMetadata.js";
 import enableServerPlugin from "./mutations/enableServerPlugin.js";
 import setServerPluginSecret from "./mutations/setServerPluginSecret.js";
 import updatePluginPipelines from "./mutations/updatePluginPipelines.js";
@@ -497,6 +498,10 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     updateDownloadableFileSupportSettings: updateDownloadableFileSupportSettings({
       driver
     }),
+    createDownloadableFiles: createDownloadableFilesWithUploadMetadata({
+      DownloadableFile,
+      driver
+    }),
     enableServerPlugin: enableServerPlugin({
       Plugin,
       PluginVersion,
@@ -516,11 +521,13 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     }),
     createImageWithUploader: createImageWithUploader({
       Image,
-      User
+      User,
+      driver
     }),
     createImages: createImagesWithUploader({
       Image,
-      User
+      User,
+      driver
     }),
     createAlbums: createAlbumsWithOwner({
       Album,

--- a/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.test.ts
+++ b/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import type { Driver } from "neo4j-driver";
+import createDownloadableFilesWithUploadMetadata from "./createDownloadableFilesWithUploadMetadata.js";
+import type { GraphQLContext } from "../../types/context.js";
+
+process.env.PLAYWRIGHT_MOCK_AUTH = "true";
+
+class DownloadableFileModelStub {
+  createCalls: any[] = [];
+
+  constructor(private createImpl: (args: any) => any) {}
+
+  async create(args: any) {
+    this.createCalls.push(args);
+    return this.createImpl(args);
+  }
+}
+
+const buildDriver = (recordData?: Record<string, unknown>) => {
+  const calls = {
+    sessions: [] as string[],
+    run: [] as Array<{ query: string; params: Record<string, unknown> }>,
+    close: 0,
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => {
+      calls.sessions.push(defaultAccessMode);
+      return {
+        run: async (query: string, params: Record<string, unknown>) => {
+          calls.run.push({ query, params });
+          return {
+            records: recordData
+              ? [
+                  {
+                    get: (key: string) => recordData[key],
+                  },
+                ]
+              : [],
+          };
+        },
+        close: async () => {
+          calls.close += 1;
+        },
+      };
+    },
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const createMockContext = (username: string) =>
+  ({
+    req: {
+      headers: {
+        authorization: `Bearer ${jwt.sign(
+          { email: `${username}@example.com`, username },
+          "test-secret"
+        )}`,
+      },
+    },
+    ogm: {
+      model: (name: string) => {
+        if (name === "User") {
+          return {
+            find: async () => [
+              {
+                ModerationProfile: {
+                  displayName: `mod-${username}`,
+                },
+              },
+            ],
+          };
+        }
+        throw new Error("No model lookup expected");
+      },
+    },
+  }) as unknown as GraphQLContext;
+
+test("createDownloadableFiles copies verified upload metadata into the file", async () => {
+  const { driver, calls } = buildDriver({
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/model.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/model.stl",
+    uploadedAt: "2026-07-01T12:00:00.000000000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: "203.0.113.10",
+  });
+  const DownloadableFile = new DownloadableFileModelStub((args) => ({
+    downloadableFiles: [
+      {
+        id: "file-1",
+        ...args.input[0],
+      },
+    ],
+  }));
+  const resolver = createDownloadableFilesWithUploadMetadata({
+    DownloadableFile: DownloadableFile as any,
+    driver,
+  });
+
+  const result = await resolver(
+    null,
+    {
+      input: [
+        {
+          fileName: "model.stl",
+          kind: "STL",
+          url: "https://storage.googleapis.com/bucket/uploads/alice/model.stl",
+          storageObjectName: "uploads/alice/model.stl",
+        } as any,
+      ],
+    },
+    createMockContext("alice")
+  );
+
+  assert.deepEqual(
+    {
+      fileMetadata: DownloadableFile.createCalls[0].input[0],
+      claimedByType: calls.run[1].params.claimedByType,
+      claimedById: calls.run[1].params.claimedById,
+      resultId: result.downloadableFiles[0].id,
+    },
+    {
+      fileMetadata: {
+        fileName: "model.stl",
+        kind: "STL",
+        url: "https://storage.googleapis.com/bucket/uploads/alice/model.stl",
+        storageObjectName: "uploads/alice/model.stl",
+        storageBucket: "bucket",
+        storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/model.stl",
+        uploadedAt: "2026-07-01T12:00:00.000000000Z",
+        uploadedByUsername: "alice",
+        uploadedByIp: "203.0.113.10",
+      },
+      claimedByType: "DownloadableFile",
+      claimedById: "file-1",
+      resultId: "file-1",
+    }
+  );
+});
+
+test("createDownloadableFiles rejects an unverified storage object", async () => {
+  const { driver } = buildDriver();
+  const DownloadableFile = new DownloadableFileModelStub(() => ({
+    downloadableFiles: [],
+  }));
+  const resolver = createDownloadableFilesWithUploadMetadata({
+    DownloadableFile: DownloadableFile as any,
+    driver,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        input: [
+          {
+            fileName: "model.stl",
+            kind: "STL",
+            url: "https://storage.googleapis.com/bucket/uploads/alice/model.stl",
+            storageObjectName: "uploads/alice/model.stl",
+          } as any,
+        ],
+      },
+      createMockContext("alice")
+    ),
+    /Upload metadata not found/
+  );
+});

--- a/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.ts
+++ b/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.ts
@@ -1,0 +1,135 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { logger } from "../../logger.js";
+import type {
+  DownloadableFileCreateInput,
+  DownloadableFileModel,
+} from "../../ogm_types.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  claimUploadAuditMetadata,
+  getUnclaimedUploadAuditMetadata,
+  type StorageUploadMetadata,
+} from "../../services/uploadStorageMetadata.js";
+
+type Args = {
+  input: DownloadableFileCreateInput[];
+};
+
+type Input = {
+  DownloadableFile: DownloadableFileModel;
+  driver: Driver;
+};
+
+const selectionSet = `
+  {
+    downloadableFiles {
+      id
+      fileName
+      kind
+      size
+      url
+      storageBucket
+      storageObjectName
+      storageUrl
+      uploadedAt
+      uploadedByUsername
+      uploadedByIp
+      createdAt
+      priceModel
+      priceCents
+      priceCurrency
+      downloadCountTotal
+      downloadCountUnique
+      attributionOverride
+      supportPatreonUrl
+      supportBuyMeACoffeeUrl
+      supportKoFiUrl
+      supportPayPalMeUrl
+      scanStatus
+      scanCheckedAt
+    }
+  }
+`;
+
+const createDownloadableFilesWithUploadMetadata = ({
+  DownloadableFile,
+  driver,
+}: Input) => {
+  return async (_parent: unknown, args: Args, context: GraphQLContext) => {
+    context.user = await setUserDataOnContext({ context });
+    const username = context.user?.username;
+
+    if (!username) {
+      throw new GraphQLError("You must be logged in to upload files.");
+    }
+
+    const uploadMetadataByIndex = await Promise.all(
+      (args.input || []).map(async (fileInput) => {
+        const storageObjectName = (fileInput as { storageObjectName?: string })?.storageObjectName;
+        if (!storageObjectName) {
+          return null;
+        }
+
+        const uploadMetadata = await getUnclaimedUploadAuditMetadata({
+          driver,
+          storageObjectName,
+          username,
+        });
+
+        if (!uploadMetadata) {
+          throw new GraphQLError("Upload metadata not found for one or more files.");
+        }
+
+        return uploadMetadata;
+      })
+    );
+
+    const sanitizedInputs = (args.input || []).map((fileInput, index) => {
+      const uploadMetadata = uploadMetadataByIndex[index] as StorageUploadMetadata | null;
+
+      return {
+        ...fileInput,
+        storageBucket: uploadMetadata?.storageBucket,
+        storageObjectName: uploadMetadata?.storageObjectName,
+        storageUrl: uploadMetadata?.storageUrl,
+        uploadedAt: uploadMetadata?.uploadedAt,
+        uploadedByUsername: uploadMetadata?.uploadedByUsername,
+        uploadedByIp: uploadMetadata?.uploadedByIp,
+      };
+    });
+
+    try {
+      const response = await DownloadableFile.create({
+        input: sanitizedInputs as unknown as DownloadableFileCreateInput[],
+        selectionSet,
+      });
+
+      await Promise.all(
+        response.downloadableFiles.map((file, index) => {
+          const uploadMetadata = uploadMetadataByIndex[index];
+          if (!uploadMetadata?.storageObjectName) {
+            return Promise.resolve(null);
+          }
+
+          return claimUploadAuditMetadata({
+            driver,
+            storageObjectName: uploadMetadata.storageObjectName,
+            username,
+            claimedByType: "DownloadableFile",
+            claimedById: file.id,
+          });
+        })
+      );
+
+      return response;
+    } catch (error: unknown) {
+      logger.error("Error creating downloadable files:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new GraphQLError(`Failed to create downloadable files: ${message}`);
+    }
+  };
+};
+
+export default createDownloadableFilesWithUploadMetadata;

--- a/customResolvers/mutations/createImageWithUploader.ts
+++ b/customResolvers/mutations/createImageWithUploader.ts
@@ -1,9 +1,14 @@
 import { GraphQLError, type GraphQLResolveInfo } from 'graphql';
+import type { Driver } from 'neo4j-driver';
 import { setUserDataOnContext } from '../../rules/permission/userDataHelperFunctions.js';
 import { ERROR_MESSAGES } from '../../rules/errorMessages.js';
 import type { GraphQLContext } from '../../types/context.js';
 import type { ImageModel, UserModel } from '../../ogm_types.js';
 import { logger } from "../../logger.js";
+import {
+  claimUploadAuditMetadata,
+  getUnclaimedUploadAuditMetadata,
+} from "../../services/uploadStorageMetadata.js";
 
 // Input type for image creation (excluding Uploader since we set it automatically)
 type ImageInput = {
@@ -15,6 +20,7 @@ type ImageInput = {
   hasSensitiveContent?: boolean;
   hasSpoiler?: boolean;
   albumId?: string;
+  storageObjectName?: string;
 };
 
 type Args = {
@@ -24,12 +30,19 @@ type Args = {
 type Input = {
   Image: ImageModel;
   User: UserModel;
+  driver?: Driver;
 };
 
 const selectionSet = `
   {
     id
     url
+    storageBucket
+    storageObjectName
+    storageUrl
+    uploadedAt
+    uploadedByUsername
+    uploadedByIp
     alt
     caption
     longDescription
@@ -48,7 +61,7 @@ const selectionSet = `
 `;
 
 const getResolver = (input: Input) => {
-  const { Image, User } = input;
+  const { Image, User, driver } = input;
 
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { input: imageInput } = args;
@@ -74,9 +87,29 @@ const getResolver = (input: Input) => {
       throw new GraphQLError(ERROR_MESSAGES.image.noUploader);
     }
 
+    const uploadMetadata = imageInput.storageObjectName
+      ? await getUnclaimedUploadAuditMetadata({
+          driver: driver || (() => {
+            throw new GraphQLError("Upload metadata lookup is not configured.");
+          })(),
+          storageObjectName: imageInput.storageObjectName,
+          username,
+        })
+      : null;
+
+    if (imageInput.storageObjectName && !uploadMetadata) {
+      throw new GraphQLError("Upload metadata not found for this image.");
+    }
+
     // Build the create input with the Uploader relationship
     const createInput: any = {
       url: imageInput.url,
+      storageBucket: uploadMetadata?.storageBucket,
+      storageObjectName: uploadMetadata?.storageObjectName,
+      storageUrl: uploadMetadata?.storageUrl,
+      uploadedAt: uploadMetadata?.uploadedAt,
+      uploadedByUsername: uploadMetadata?.uploadedByUsername,
+      uploadedByIp: uploadMetadata?.uploadedByIp,
       alt: imageInput.alt,
       caption: imageInput.caption,
       longDescription: imageInput.longDescription,
@@ -118,6 +151,18 @@ const getResolver = (input: Input) => {
 
       if (!createdImage) {
         throw new GraphQLError('Failed to create image.');
+      }
+
+      if (uploadMetadata?.storageObjectName) {
+        await claimUploadAuditMetadata({
+          driver: driver || (() => {
+            throw new GraphQLError("Upload metadata claim is not configured.");
+          })(),
+          storageObjectName: uploadMetadata.storageObjectName,
+          username,
+          claimedByType: "Image",
+          claimedById: createdImage.id,
+        });
       }
 
       return createdImage;

--- a/customResolvers/mutations/createImagesWithUploader.ts
+++ b/customResolvers/mutations/createImagesWithUploader.ts
@@ -1,8 +1,14 @@
 import { GraphQLError, type GraphQLResolveInfo } from "graphql";
+import type { Driver } from "neo4j-driver";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { ImageCreateInput, ImageModel, UserModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import {
+  claimUploadAuditMetadata,
+  getUnclaimedUploadAuditMetadata,
+  type StorageUploadMetadata,
+} from "../../services/uploadStorageMetadata.js";
 
 type Args = {
   input: ImageCreateInput[];
@@ -11,12 +17,19 @@ type Args = {
 type Input = {
   Image: ImageModel;
   User: UserModel;
+  driver?: Driver;
 };
 
 const selectionSet = `
   {
     id
     url
+    storageBucket
+    storageObjectName
+    storageUrl
+    uploadedAt
+    uploadedByUsername
+    uploadedByIp
     alt
     caption
     longDescription
@@ -35,7 +48,7 @@ const selectionSet = `
 `;
 
 const getResolver = (input: Input) => {
-  const { Image, User } = input;
+  const { Image, User, driver } = input;
 
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { input: imageInputs } = args;
@@ -59,10 +72,40 @@ const getResolver = (input: Input) => {
       throw new GraphQLError("Could not find the original uploader of this image.");
     }
 
-    const sanitizedInputs = (imageInputs || []).map((imageInput) => {
+    const uploadMetadataByIndex = await Promise.all(
+      (imageInputs || []).map(async (imageInput) => {
+        const storageObjectName = (imageInput as { storageObjectName?: string })?.storageObjectName;
+        if (!storageObjectName) {
+          return null;
+        }
+
+        const uploadMetadata = await getUnclaimedUploadAuditMetadata({
+          driver: driver || (() => {
+            throw new GraphQLError("Upload metadata lookup is not configured.");
+          })(),
+          storageObjectName,
+          username,
+        });
+
+        if (!uploadMetadata) {
+          throw new GraphQLError("Upload metadata not found for one or more images.");
+        }
+
+        return uploadMetadata;
+      })
+    );
+
+    const sanitizedInputs = (imageInputs || []).map((imageInput, index) => {
       const { Uploader, ...rest } = imageInput || ({} as ImageCreateInput);
+      const uploadMetadata = uploadMetadataByIndex[index] as StorageUploadMetadata | null;
       return {
         ...rest,
+        storageBucket: uploadMetadata?.storageBucket,
+        storageObjectName: uploadMetadata?.storageObjectName,
+        storageUrl: uploadMetadata?.storageUrl,
+        uploadedAt: uploadMetadata?.uploadedAt,
+        uploadedByUsername: uploadMetadata?.uploadedByUsername,
+        uploadedByIp: uploadMetadata?.uploadedByIp,
         Uploader: {
           connect: {
             where: {
@@ -80,6 +123,25 @@ const getResolver = (input: Input) => {
         input: sanitizedInputs as unknown as ImageCreateInput[],
         selectionSet: `{ images ${selectionSet} }`,
       });
+
+      await Promise.all(
+        response.images.map((image, index) => {
+          const uploadMetadata = uploadMetadataByIndex[index];
+          if (!uploadMetadata?.storageObjectName) {
+            return Promise.resolve(null);
+          }
+
+          return claimUploadAuditMetadata({
+            driver: driver || (() => {
+              throw new GraphQLError("Upload metadata claim is not configured.");
+            })(),
+            storageObjectName: uploadMetadata.storageObjectName,
+            username,
+            claimedByType: "Image",
+            claimedById: image.id,
+          });
+        })
+      );
 
       return response;
     } catch (error: unknown) {

--- a/customResolvers/mutations/createSignedStorageURL.ts
+++ b/customResolvers/mutations/createSignedStorageURL.ts
@@ -1,6 +1,14 @@
 import { Storage, GetSignedUrlConfig } from "@google-cloud/storage";
-import type { Ogm } from "../../types/context.js";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext, Ogm } from "../../types/context.js";
 import { logger } from "../../logger.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import {
+  buildStorageObjectName,
+  buildStorageUrl,
+  createUploadAuditRecord,
+  getRequesterIp,
+} from "../../services/uploadStorageMetadata.js";
 
 type Args = {
   filename: string;
@@ -12,18 +20,14 @@ interface ValidationContext {
   ogm: Ogm;
 }
 
+type ResolverContext = ValidationContext & {
+  driver: Driver;
+} & Pick<GraphQLContext, "req" | "user">;
+
 type ChannelUploadPreferences = {
   uniqueName?: string | null;
   imageUploadsEnabled?: boolean | null;
   allowedFileTypes?: string[] | null;
-};
-
-const isUrlEncoded = (filename: string): boolean => {
-  try {
-    return filename === encodeURIComponent(decodeURIComponent(filename));
-  } catch (e) {
-    return false;
-  }
 };
 
 /**
@@ -153,11 +157,18 @@ export const validateFile = async (
 };
 
 const createSignedStorageURL = () => {
-  return async (parent: unknown, args: Args, ctx: ValidationContext) => {
+  return async (parent: unknown, args: Args, ctx: ResolverContext) => {
     let { filename, contentType, channelConnections = [] } = args;
 
-    if (!isUrlEncoded(filename)) {
-      throw new Error("Filename is not properly URL encoded");
+    if (!filename?.trim()) {
+      throw new Error("Filename is required");
+    }
+
+    ctx.user = await setUserDataOnContext({ context: ctx });
+    const username = ctx.user?.username;
+
+    if (!username) {
+      throw new Error("You must be logged in to upload files");
     }
 
     // Validate file against server and channel configurations
@@ -170,6 +181,16 @@ const createSignedStorageURL = () => {
       throw new Error("GCS_BUCKET_NAME environment variable not set");
     }
 
+    const uploadedAt = new Date().toISOString();
+    const storageObjectName = buildStorageObjectName({
+      username,
+      originalFilename: filename,
+    });
+    const storageUrl = buildStorageUrl({
+      storageBucket: bucketName,
+      storageObjectName,
+    });
+
     const options: GetSignedUrlConfig = {
       version: "v4",
       action: "write",
@@ -180,7 +201,7 @@ const createSignedStorageURL = () => {
     // Generate the Signed URL
     const [url] = await storage
       .bucket(bucketName)
-      .file(filename)
+      .file(storageObjectName)
       .getSignedUrl(options);
 
     if (!url) {
@@ -188,8 +209,26 @@ const createSignedStorageURL = () => {
       return { url: "" };
     }
 
+    await createUploadAuditRecord({
+      driver: ctx.driver,
+      storageBucket: bucketName,
+      storageObjectName,
+      storageUrl,
+      originalFilename: filename,
+      contentType,
+      uploadedAt,
+      uploadedByUsername: username,
+      uploadedByIp: getRequesterIp(ctx),
+    });
+
     // Return the Signed URL
-    return { url };
+    return {
+      url,
+      storageBucket: bucketName,
+      storageObjectName,
+      storageUrl,
+      uploadedAt,
+    };
   };
 };
 

--- a/permissions.ts
+++ b/permissions.ts
@@ -40,6 +40,7 @@ const {
   updateCommentInputIsValid,
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
+  updateImageInputIsValid,
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,
@@ -270,7 +271,7 @@ const permissionList = shield({
       // canArchiveImage mod permission here, since updateImages carries no
       // channel argument and images aren't channel-scoped; server admins are
       // covered because the seeded admin bundle grants that mod capability.
-      updateImages: and(isAuthenticated, or(isImageUploader, canArchiveAndUnarchiveImage)),
+      updateImages: and(isAuthenticated, updateImageInputIsValid, or(isImageUploader, canArchiveAndUnarchiveImage)),
       createImages: deny, // Use createImageWithUploader instead to ensure Uploader is set
       createImageWithUploader: and(isAuthenticated, canUploadFile),
 

--- a/rules/rules.ts
+++ b/rules/rules.ts
@@ -54,6 +54,7 @@ import {
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
 } from "./validation/downloadableFileIsValid.js";
+import { updateImageInputIsValid } from "./validation/imageIsValid.js";
 import { updateUserInputIsValid } from "./validation/userIsValid.js";
 import {
   serverRoleInputDoesNotEscalate,
@@ -134,6 +135,7 @@ const ruleList = {
   updateEventInputIsValid,
   createDownloadableFileInputIsValid,
   updateDownloadableFileInputIsValid,
+  updateImageInputIsValid,
   updateUserInputIsValid,
   serverRoleInputDoesNotEscalate,
   modServerRoleInputDoesNotEscalate,

--- a/rules/validation/downloadableFileIsValid.ts
+++ b/rules/validation/downloadableFileIsValid.ts
@@ -3,6 +3,10 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLRequest, Ogm } from "../../types/context.js";
 import { logger } from "../../logger.js";
 import {
+  getAttemptedUploadAuditFields,
+  uploadAuditFieldsError,
+} from "./uploadAuditFields.js";
+import {
   DownloadableFileCreateInput,
   DownloadableFileUpdateInput,
 } from "../../src/generated/graphql.js";
@@ -180,6 +184,13 @@ export const updateDownloadableFileInputIsValid = rule({ cache: "contextual" })(
   async (parent: unknown, args: UpdateDownloadableFileArgs, ctx: ValidationContext, info: GraphQLResolveInfo) => {
     if (!args.update) {
       return "Missing update input in args.";
+    }
+
+    const attemptedUploadAuditFields = getAttemptedUploadAuditFields(
+      args.update as Record<string, unknown>
+    );
+    if (attemptedUploadAuditFields.length > 0) {
+      return uploadAuditFieldsError(attemptedUploadAuditFields);
     }
 
     // For update operations, we need to find the existing file and its channel connections

--- a/rules/validation/imageIsValid.ts
+++ b/rules/validation/imageIsValid.ts
@@ -1,0 +1,28 @@
+import { rule } from "graphql-shield";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  getAttemptedUploadAuditFields,
+  uploadAuditFieldsError,
+} from "./uploadAuditFields.js";
+
+type UpdateImageArgs = {
+  update?: Record<string, unknown> | null;
+};
+
+export const updateImageInputIsValid = rule({ cache: "contextual" })(
+  async (
+    _parent: unknown,
+    args: UpdateImageArgs,
+    _ctx: GraphQLContext,
+    _info: GraphQLResolveInfo
+  ) => {
+    const attemptedUploadAuditFields = getAttemptedUploadAuditFields(args.update);
+
+    if (attemptedUploadAuditFields.length > 0) {
+      return uploadAuditFieldsError(attemptedUploadAuditFields);
+    }
+
+    return true;
+  }
+);

--- a/rules/validation/uploadAuditFields.ts
+++ b/rules/validation/uploadAuditFields.ts
@@ -1,0 +1,23 @@
+const uploadAuditFieldNames = [
+  "storageBucket",
+  "storageObjectName",
+  "storageUrl",
+  "uploadedAt",
+  "uploadedByUsername",
+  "uploadedByIp",
+] as const;
+
+export const getAttemptedUploadAuditFields = (
+  input: Record<string, unknown> | null | undefined
+): string[] => {
+  if (!input) {
+    return [];
+  }
+
+  return uploadAuditFieldNames.filter((fieldName) =>
+    Object.prototype.hasOwnProperty.call(input, fieldName)
+  );
+};
+
+export const uploadAuditFieldsError = (attempted: string[]) =>
+  `Upload audit fields cannot be modified (${attempted.join(", ")})`;

--- a/services/uploadStorageMetadata.test.ts
+++ b/services/uploadStorageMetadata.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import {
+  buildStorageObjectName,
+  buildStorageUrl,
+  claimUploadAuditMetadata,
+  createUploadAuditRecord,
+  getRequesterIp,
+  getUnclaimedUploadAuditMetadata,
+} from "./uploadStorageMetadata.js";
+
+const buildDriver = (recordData?: Record<string, unknown>) => {
+  const calls = {
+    sessions: [] as string[],
+    run: [] as Array<{ query: string; params: Record<string, unknown> }>,
+    close: 0,
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => {
+      calls.sessions.push(defaultAccessMode);
+      return {
+        run: async (query: string, params: Record<string, unknown>) => {
+          calls.run.push({ query, params });
+
+          return {
+            records: recordData
+              ? [
+                  {
+                    get: (key: string) => recordData[key],
+                  },
+                ]
+              : [],
+          };
+        },
+        close: async () => {
+          calls.close += 1;
+        },
+      };
+    },
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+test("buildStorageObjectName includes a sanitized username segment", () => {
+  const objectName = buildStorageObjectName({
+    username: "alice/example",
+    originalFilename: "My Model.stl",
+    now: new Date("2026-07-01T12:00:00.000Z"),
+    id: "fixed-id",
+  });
+
+  assert.equal(
+    objectName,
+    "uploads/alice_example/2026-07-01T12-00-00-000Z-fixed-id-My_Model.stl"
+  );
+});
+
+test("buildStorageUrl encodes bucket and object name safely", () => {
+  const storageUrl = buildStorageUrl({
+    storageBucket: "my bucket",
+    storageObjectName: "uploads/alice/a file.stl",
+  });
+
+  assert.equal(
+    storageUrl,
+    "https://storage.googleapis.com/my%20bucket/uploads/alice/a%20file.stl"
+  );
+});
+
+test("getRequesterIp prefers the first forwarded IP", () => {
+  const ip = getRequesterIp({
+    req: {
+      headers: {
+        "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      },
+    } as any,
+  });
+
+  assert.equal(ip, "203.0.113.10");
+});
+
+test("createUploadAuditRecord writes server-owned audit metadata", async () => {
+  const { driver, calls } = buildDriver();
+
+  await createUploadAuditRecord({
+    driver,
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/file.stl",
+    originalFilename: "file.stl",
+    contentType: "model/stl",
+    uploadedAt: "2026-07-01T12:00:00.000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: "203.0.113.10",
+  });
+
+  assert.deepEqual(calls.run[0].params, {
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/file.stl",
+    originalFilename: "file.stl",
+    contentType: "model/stl",
+    uploadedAt: "2026-07-01T12:00:00.000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: "203.0.113.10",
+  });
+});
+
+test("getUnclaimedUploadAuditMetadata returns matching metadata", async () => {
+  const { driver } = buildDriver({
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/file.stl",
+    uploadedAt: "2026-07-01T12:00:00.000000000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: "203.0.113.10",
+  });
+
+  const metadata = await getUnclaimedUploadAuditMetadata({
+    driver,
+    storageObjectName: "uploads/alice/file.stl",
+    username: "alice",
+  });
+
+  assert.deepEqual(metadata, {
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/file.stl",
+    uploadedAt: "2026-07-01T12:00:00.000000000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: "203.0.113.10",
+  });
+});
+
+test("claimUploadAuditMetadata records the claiming entity", async () => {
+  const { driver, calls } = buildDriver({
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storageUrl: "https://storage.googleapis.com/bucket/uploads/alice/file.stl",
+    uploadedAt: "2026-07-01T12:00:00.000000000Z",
+    uploadedByUsername: "alice",
+    uploadedByIp: null,
+  });
+
+  await claimUploadAuditMetadata({
+    driver,
+    storageObjectName: "uploads/alice/file.stl",
+    username: "alice",
+    claimedByType: "DownloadableFile",
+    claimedById: "file-1",
+  });
+
+  assert.deepEqual(
+    {
+      storageObjectName: calls.run[0].params.storageObjectName,
+      username: calls.run[0].params.username,
+      claimedByType: calls.run[0].params.claimedByType,
+      claimedById: calls.run[0].params.claimedById,
+    },
+    {
+      storageObjectName: "uploads/alice/file.stl",
+      username: "alice",
+      claimedByType: "DownloadableFile",
+      claimedById: "file-1",
+    }
+  );
+});

--- a/services/uploadStorageMetadata.ts
+++ b/services/uploadStorageMetadata.ts
@@ -1,0 +1,256 @@
+import { randomUUID } from "node:crypto";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../types/context.js";
+
+export type StorageUploadMetadata = {
+  storageBucket: string;
+  storageObjectName: string;
+  storageUrl: string;
+  uploadedAt: string;
+  uploadedByUsername: string;
+  uploadedByIp: string | null;
+};
+
+type BuildStorageObjectNameInput = {
+  username: string;
+  originalFilename: string;
+  now?: Date;
+  id?: string;
+};
+
+type CreateUploadAuditInput = StorageUploadMetadata & {
+  driver: Driver;
+  originalFilename: string;
+  contentType: string;
+};
+
+type ClaimUploadAuditInput = {
+  driver: Driver;
+  storageObjectName?: string | null;
+  username: string;
+  claimedByType: "Image" | "DownloadableFile";
+  claimedById: string;
+};
+
+type GetUploadAuditMetadataInput = {
+  driver: Driver;
+  storageObjectName?: string | null;
+  username: string;
+};
+
+const sanitizePathSegment = (value: string): string => {
+  const sanitized = value
+    .trim()
+    .replace(/[/\\]/g, "_")
+    .replace(/\s+/g, "_")
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return sanitized || "upload";
+};
+
+const safelyDecodeURIComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const getRequesterIp = (context: Pick<GraphQLContext, "req">): string | null => {
+  const forwardedFor = context.req?.headers?.["x-forwarded-for"];
+  const firstForwardedIp = Array.isArray(forwardedFor)
+    ? forwardedFor[0]
+    : forwardedFor?.split(",")[0];
+
+  return (
+    firstForwardedIp?.trim() ||
+    context.req?.ip ||
+    context.req?.socket?.remoteAddress ||
+    null
+  );
+};
+
+export const buildStorageObjectName = ({
+  username,
+  originalFilename,
+  now = new Date(),
+  id = randomUUID(),
+}: BuildStorageObjectNameInput): string => {
+  const safeUsername = sanitizePathSegment(username);
+  const safeFilename = sanitizePathSegment(safelyDecodeURIComponent(originalFilename));
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+
+  return `uploads/${safeUsername}/${timestamp}-${id}-${safeFilename}`;
+};
+
+export const buildStorageUrl = ({
+  storageBucket,
+  storageObjectName,
+}: {
+  storageBucket: string;
+  storageObjectName: string;
+}): string => {
+  const encodedObjectName = storageObjectName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `https://storage.googleapis.com/${encodeURIComponent(storageBucket)}/${encodedObjectName}`;
+};
+
+export const createUploadAuditRecord = async ({
+  driver,
+  storageBucket,
+  storageObjectName,
+  storageUrl,
+  originalFilename,
+  contentType,
+  uploadedAt,
+  uploadedByUsername,
+  uploadedByIp,
+}: CreateUploadAuditInput): Promise<void> => {
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+
+  try {
+    await session.run(
+      `
+      CREATE (:UploadedFileAudit {
+        id: randomUUID(),
+        storageBucket: $storageBucket,
+        storageObjectName: $storageObjectName,
+        storageUrl: $storageUrl,
+        originalFilename: $originalFilename,
+        contentType: $contentType,
+        uploadedAt: datetime($uploadedAt),
+        uploadedByUsername: $uploadedByUsername,
+        uploadedByIp: $uploadedByIp
+      })
+      `,
+      {
+        storageBucket,
+        storageObjectName,
+        storageUrl,
+        originalFilename,
+        contentType,
+        uploadedAt,
+        uploadedByUsername,
+        uploadedByIp,
+      }
+    );
+  } finally {
+    await session.close();
+  }
+};
+
+export const getUnclaimedUploadAuditMetadata = async ({
+  driver,
+  storageObjectName,
+  username,
+}: GetUploadAuditMetadataInput): Promise<StorageUploadMetadata | null> => {
+  if (!storageObjectName) {
+    return null;
+  }
+
+  const session = driver.session({ defaultAccessMode: "READ" });
+
+  try {
+    const result = await session.run(
+      `
+      MATCH (audit:UploadedFileAudit {
+        storageObjectName: $storageObjectName,
+        uploadedByUsername: $username
+      })
+      WHERE audit.claimedAt IS NULL
+      RETURN
+        audit.storageBucket AS storageBucket,
+        audit.storageObjectName AS storageObjectName,
+        audit.storageUrl AS storageUrl,
+        toString(audit.uploadedAt) AS uploadedAt,
+        audit.uploadedByUsername AS uploadedByUsername,
+        audit.uploadedByIp AS uploadedByIp
+      `,
+      {
+        storageObjectName,
+        username,
+      }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return {
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+      storageUrl: record.get("storageUrl"),
+      uploadedAt: record.get("uploadedAt"),
+      uploadedByUsername: record.get("uploadedByUsername"),
+      uploadedByIp: record.get("uploadedByIp"),
+    };
+  } finally {
+    await session.close();
+  }
+};
+
+export const claimUploadAuditMetadata = async ({
+  driver,
+  storageObjectName,
+  username,
+  claimedByType,
+  claimedById,
+}: ClaimUploadAuditInput): Promise<StorageUploadMetadata | null> => {
+  if (!storageObjectName) {
+    return null;
+  }
+
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+
+  try {
+    const result = await session.run(
+      `
+      MATCH (audit:UploadedFileAudit {
+        storageObjectName: $storageObjectName,
+        uploadedByUsername: $username
+      })
+      WHERE audit.claimedAt IS NULL
+      SET
+        audit.claimedAt = datetime($claimedAt),
+        audit.claimedByType = $claimedByType,
+        audit.claimedById = $claimedById
+      RETURN
+        audit.storageBucket AS storageBucket,
+        audit.storageObjectName AS storageObjectName,
+        audit.storageUrl AS storageUrl,
+        toString(audit.uploadedAt) AS uploadedAt,
+        audit.uploadedByUsername AS uploadedByUsername,
+        audit.uploadedByIp AS uploadedByIp
+      `,
+      {
+        storageObjectName,
+        username,
+        claimedAt: new Date().toISOString(),
+        claimedByType,
+        claimedById,
+      }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return {
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+      storageUrl: record.get("storageUrl"),
+      uploadedAt: record.get("uploadedAt"),
+      uploadedByUsername: record.get("uploadedByUsername"),
+      uploadedByIp: record.get("uploadedByIp"),
+    };
+  } finally {
+    await session.close();
+  }
+};

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -73,6 +73,12 @@ const typeDefinitions = gql`
   type Image {
     id: ID! @id
     url: String
+    storageBucket: String
+    storageObjectName: String
+    storageUrl: String
+    uploadedAt: DateTime
+    uploadedByUsername: String
+    uploadedByIp: String
     alt: String
     caption: String
     longDescription: String
@@ -391,6 +397,12 @@ const typeDefinitions = gql`
     kind:     FileKind!
     size:     Int
     url:      String!
+    storageBucket: String
+    storageObjectName: String
+    storageUrl: String
+    uploadedAt: DateTime
+    uploadedByUsername: String
+    uploadedByIp: String
     createdAt: DateTime! @timestamp(operations: [CREATE])
 
     # commerce fields
@@ -945,6 +957,10 @@ const typeDefinitions = gql`
 
   type SignedURL {
     url: String
+    storageBucket: String
+    storageObjectName: String
+    storageUrl: String
+    uploadedAt: DateTime
   }
 
   type DropDataResponse {


### PR DESCRIPTION
## Summary
- Generate canonical GCS object names server-side with the uploader username in the path.
- Return explicit storage metadata from `createSignedStorageURL` and store a backend-only `UploadedFileAudit` node via Cypher.
- Copy verified audit metadata onto `Image` and `DownloadableFile` records at creation time, and block later audit-field edits through generic update mutations.

## Validation
- `npm run codegen`
- `npm run tsc`
- `node --loader ts-node/esm --test services/uploadStorageMetadata.test.ts customResolvers/mutations/createDownloadableFilesWithUploadMetadata.test.ts customResolvers/mutations/createSignedStorageURL.test.ts customResolvers/mutations/createImageWithUploader.test.ts rules/validation/downloadableFileIsValid.test.ts`
- `npm test`