### PR TITLE
Add shared storage deletion utility

### DIFF
--- a/services/storageDeletion.test.ts
+++ b/services/storageDeletion.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  deleteStoredObject,
+  type StorageClient,
+} from "./storageDeletion.js";
+
+const buildStorageClient = () => {
+  const calls = {
+    bucket: [] as string[],
+    file: [] as string[],
+    delete: [] as Array<{ ignoreNotFound?: boolean } | undefined>,
+  };
+
+  const storage: StorageClient = {
+    bucket: (storageBucket: string) => {
+      calls.bucket.push(storageBucket);
+      return {
+        file: (storageObjectName: string) => {
+          calls.file.push(storageObjectName);
+          return {
+            delete: async (options?: { ignoreNotFound?: boolean }) => {
+              calls.delete.push(options);
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { storage, calls };
+};
+
+test("deleteStoredObject deletes the stored object and ignores missing GCS objects", async () => {
+  const { storage, calls } = buildStorageClient();
+
+  const result = await deleteStoredObject({
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storage,
+  });
+
+  assert.deepEqual(
+    {
+      result,
+      calls,
+    },
+    {
+      result: {
+        status: "deleted",
+        storageBucket: "bucket",
+        storageObjectName: "uploads/alice/file.stl",
+      },
+      calls: {
+        bucket: ["bucket"],
+        file: ["uploads/alice/file.stl"],
+        delete: [{ ignoreNotFound: true }],
+      },
+    }
+  );
+});
+
+test("deleteStoredObject skips deletion when storage metadata is missing", async () => {
+  const { storage, calls } = buildStorageClient();
+
+  const result = await deleteStoredObject({
+    storageBucket: "bucket",
+    storageObjectName: null,
+    storage,
+  });
+
+  assert.deepEqual(
+    {
+      result,
+      calls,
+    },
+    {
+      result: {
+        status: "skipped",
+        reason: "missing-storage-metadata",
+        storageBucket: "bucket",
+        storageObjectName: undefined,
+      },
+      calls: {
+        bucket: [],
+        file: [],
+        delete: [],
+      },
+    }
+  );
+});
+
+test("deleteStoredObject propagates storage client errors", async () => {
+  const storage: StorageClient = {
+    bucket: () => ({
+      file: () => ({
+        delete: async () => {
+          throw new Error("storage unavailable");
+        },
+      }),
+    }),
+  };
+
+  await assert.rejects(
+    deleteStoredObject({
+      storageBucket: "bucket",
+      storageObjectName: "uploads/alice/file.stl",
+      storage,
+    }),
+    /storage unavailable/
+  );
+});

--- a/services/storageDeletion.ts
+++ b/services/storageDeletion.ts
@@ -1,0 +1,58 @@
+import { Storage } from "@google-cloud/storage";
+
+export type StoredObjectMetadata = {
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+};
+
+export type StorageDeletionStatus = "deleted" | "skipped";
+
+export type StorageDeletionResult = {
+  status: StorageDeletionStatus;
+  storageBucket?: string;
+  storageObjectName?: string;
+  reason?: "missing-storage-metadata";
+};
+
+export type StorageFileClient = {
+  delete: (options?: { ignoreNotFound?: boolean }) => Promise<unknown>;
+};
+
+export type StorageBucketClient = {
+  file: (storageObjectName: string) => StorageFileClient;
+};
+
+export type StorageClient = {
+  bucket: (storageBucket: string) => StorageBucketClient;
+};
+
+type DeleteStoredObjectInput = StoredObjectMetadata & {
+  storage?: StorageClient;
+};
+
+export const deleteStoredObject = async ({
+  storageBucket,
+  storageObjectName,
+  storage,
+}: DeleteStoredObjectInput): Promise<StorageDeletionResult> => {
+  if (!storageBucket || !storageObjectName) {
+    return {
+      status: "skipped",
+      reason: "missing-storage-metadata",
+      storageBucket: storageBucket || undefined,
+      storageObjectName: storageObjectName || undefined,
+    };
+  }
+
+  const storageClient = storage || new Storage();
+  await storageClient
+    .bucket(storageBucket)
+    .file(storageObjectName)
+    .delete({ ignoreNotFound: true });
+
+  return {
+    status: "deleted",
+    storageBucket,
+    storageObjectName,
+  };
+};


### PR DESCRIPTION
## Summary
- add a shared deleteStoredObject utility for GCS-backed uploads
- skip deletion safely when storage metadata is absent
- delete with ignoreNotFound so stale/missing objects do not make cleanup non-idempotent
- add unit coverage with an injected storage client

## Stack
- Depends on upload metadata PR: https://github.com/gennit-project/multiforum-backend/pull/116

## Validation
- node --loader ts-node/esm --test services/storageDeletion.test.ts
- npm run tsc

## Next
- Wire this utility into permanent-delete mutations for Image and DownloadableFile with OP/mod permission checks.