### PR TITLE
Add permanent upload deletion mutations

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -56,6 +56,8 @@ import unarchiveEvent from "./mutations/unarchiveEvent.js";
 import archiveImage from "./mutations/archiveImage.js";
 import unarchiveImage from "./mutations/unarchiveImage.js";
 import permanentlyRemoveImage from "./mutations/permanentlyRemoveImage.js";
+import permanentlyDeleteImage from "./mutations/permanentlyDeleteImage.js";
+import permanentlyDeleteDownloadableFile from "./mutations/permanentlyDeleteDownloadableFile.js";
 import createIssue from "./mutations/createIssue.js";
 import suspendUser from "./mutations/suspendUser.js";
 import suspendMod from "./mutations/suspendMod.js";
@@ -348,6 +350,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     permanentlyRemoveImage: permanentlyRemoveImage({
       Issue,
       Image,
+      driver
+    }),
+    permanentlyDeleteImage: permanentlyDeleteImage({
+      driver
+    }),
+    permanentlyDeleteDownloadableFile: permanentlyDeleteDownloadableFile({
       driver
     }),
     lockChannel: lockChannel({

--- a/customResolvers/mutations/permanentlyDeleteDownloadableFile.ts
+++ b/customResolvers/mutations/permanentlyDeleteDownloadableFile.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getStoredUploadDeleteResolver from "./permanentlyDeleteStoredUpload.js";
+
+const permanentlyDeleteDownloadableFile = ({ driver }: { driver: Driver }) =>
+  getStoredUploadDeleteResolver({
+    driver,
+    mediaType: "DownloadableFile",
+  });
+
+export default permanentlyDeleteDownloadableFile;

--- a/customResolvers/mutations/permanentlyDeleteImage.ts
+++ b/customResolvers/mutations/permanentlyDeleteImage.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getStoredUploadDeleteResolver from "./permanentlyDeleteStoredUpload.js";
+
+const permanentlyDeleteImage = ({ driver }: { driver: Driver }) =>
+  getStoredUploadDeleteResolver({
+    driver,
+    mediaType: "Image",
+  });
+
+export default permanentlyDeleteImage;

--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import getResolver from "./permanentlyDeleteStoredUpload.js";
+
+type TargetRecord = {
+  id?: string;
+  permanentlyRemoved?: boolean;
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+  uploadedByUsername?: string | null;
+  uploaderUsername?: string | null;
+  discussionAuthorUsernames?: string[];
+};
+
+const buildRecord = (values: Record<string, unknown>) => ({
+  keys: Object.keys(values),
+  get: (key: string) => values[key],
+});
+
+const buildDriver = ({
+  target,
+}: {
+  target: TargetRecord | null;
+}) => {
+  const calls = {
+    sessions: [] as string[],
+    writes: [] as Record<string, unknown>[],
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => {
+      calls.sessions.push(defaultAccessMode);
+      return {
+        run: async (query: string, params: Record<string, unknown>) => {
+          if (defaultAccessMode === "READ") {
+            return {
+              records: target
+                ? [
+                    buildRecord({
+                      id: target.id || "target-1",
+                      permanentlyRemoved: target.permanentlyRemoved || false,
+                      storageBucket:
+                        target.storageBucket === undefined
+                          ? "bucket"
+                          : target.storageBucket,
+                      storageObjectName:
+                        target.storageObjectName === undefined
+                          ? "uploads/alice/file.stl"
+                          : target.storageObjectName,
+                      uploadedByUsername:
+                        target.uploadedByUsername === undefined
+                          ? "alice"
+                          : target.uploadedByUsername,
+                      uploaderUsername: target.uploaderUsername || null,
+                      discussionAuthorUsernames:
+                        target.discussionAuthorUsernames || [],
+                    }),
+                  ]
+                : [],
+            };
+          }
+
+          calls.writes.push({ query, params });
+          return {
+            records: [
+              buildRecord({
+                id: params.id,
+                url: "https://storage.example/file.stl",
+                fileName: "file.stl",
+                kind: "STL",
+                size: 100,
+                storageBucket: "bucket",
+                storageObjectName: "uploads/alice/file.stl",
+                storageUrl: "https://storage.example/file.stl",
+                permanentlyRemoved: true,
+                permanentlyRemovedAt: "2026-07-01T12:00:00.000Z",
+              }),
+            ],
+          };
+        },
+        close: async () => undefined,
+      };
+    },
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const contextFor = (username: string, modProfileName?: string): GraphQLContext =>
+  ({
+    user: {
+      username,
+      data: modProfileName
+        ? {
+            ModerationProfile: {
+              displayName: modProfileName,
+            },
+          }
+        : null,
+    },
+  }) as unknown as GraphQLContext;
+
+test("permanentlyDeleteImage lets an uploader delete their own image and storage object", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: null,
+      uploaderUsername: "alice",
+    },
+  });
+  const deleted: Record<string, unknown>[] = [];
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async (input) => {
+      deleted.push(input);
+      return { status: "deleted" };
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  const result = await resolver(
+    null,
+    { imageId: "image-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      deleted,
+      writeCount: calls.writes.length,
+    },
+    {
+      permanentlyRemoved: true,
+      deleted: [
+        {
+          storageBucket: "bucket",
+          storageObjectName: "uploads/alice/file.stl",
+        },
+      ],
+      writeCount: 1,
+    }
+  );
+});
+
+test("permanentlyDeleteDownloadableFile lets a discussion author delete an older download without upload metadata", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: null,
+      storageBucket: null,
+      storageObjectName: null,
+      discussionAuthorUsernames: ["alice"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async (input) => ({
+      status: input.storageObjectName ? "deleted" : "skipped",
+      reason: input.storageObjectName ? undefined : "missing-storage-metadata",
+    }),
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      storageDeletion: result.storageDeletion,
+      writeCount: calls.writes.length,
+    },
+    {
+      permanentlyRemoved: true,
+      storageDeletion: {
+        status: "skipped",
+        reason: "missing-storage-metadata",
+      },
+      writeCount: 1,
+    }
+  );
+});
+
+test("permanentlyDeleteImage lets a server mod with permanent removal permission delete another user's upload", async () => {
+  const { driver } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => true,
+  });
+
+  const result = await resolver(
+    null,
+    { imageId: "image-1" },
+    contextFor("moderator", "Mod One")
+  );
+
+  assert.equal(result.permanentlyRemoved, true);
+});
+
+test("permanentlyDeleteImage rejects an unrelated non-mod user", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => new Error("no permission"),
+  });
+
+  await assert.rejects(
+    resolver(null, { imageId: "image-1" }, contextFor("mallory")),
+    /no permission/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteImage does not mark the DB removed when storage deletion fails", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => {
+      throw new Error("storage unavailable");
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  await assert.rejects(
+    resolver(null, { imageId: "image-1" }, contextFor("alice")),
+    /storage unavailable/
+  );
+  assert.deepEqual(calls.writes, []);
+});

--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
@@ -1,0 +1,292 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import {
+  deleteStoredObject,
+  type StoredObjectMetadata,
+  type StorageDeletionResult,
+} from "../../services/storageDeletion.js";
+
+type MediaType = "Image" | "DownloadableFile";
+
+type DeleteObject = typeof deleteStoredObject;
+type CheckServerModPermission = typeof hasServerModPermission;
+
+type PermanentlyDeleteStoredUploadInput = {
+  driver: Driver;
+  mediaType: MediaType;
+  deleteObject?: DeleteObject;
+  checkServerModPermission?: CheckServerModPermission;
+};
+
+type StoredUploadTarget = StoredObjectMetadata & {
+  id: string;
+  permanentlyRemoved: boolean;
+  uploadedByUsername: string | null;
+  discussionAuthorUsernames: string[];
+};
+
+type Args = {
+  imageId?: string;
+  downloadableFileId?: string;
+};
+
+const getTargetId = (mediaType: MediaType, args: Args): string => {
+  const id =
+    mediaType === "Image" ? args.imageId : args.downloadableFileId;
+
+  if (!id) {
+    throw new GraphQLError(
+      mediaType === "Image"
+        ? "Image ID is required"
+        : "Downloadable file ID is required"
+    );
+  }
+
+  return id;
+};
+
+const readStoredUploadTarget = async ({
+  driver,
+  mediaType,
+  id,
+}: {
+  driver: Driver;
+  mediaType: MediaType;
+  id: string;
+}): Promise<StoredUploadTarget | null> => {
+  const session = driver.session({ defaultAccessMode: "READ" });
+
+  try {
+    const result = await session.run(
+      mediaType === "Image"
+        ? `
+          MATCH (target:Image {id: $id})
+          OPTIONAL MATCH (uploader:User)-[:UPLOADED_IMAGE]->(target)
+          RETURN
+            target.id AS id,
+            coalesce(target.permanentlyRemoved, false) AS permanentlyRemoved,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.uploadedByUsername AS uploadedByUsername,
+            uploader.username AS uploaderUsername,
+            [] AS discussionAuthorUsernames
+          `
+        : `
+          MATCH (target:DownloadableFile {id: $id})
+          OPTIONAL MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(target)
+          OPTIONAL MATCH (author:User)-[:POSTED_DISCUSSION]->(discussion)
+          RETURN
+            target.id AS id,
+            coalesce(target.permanentlyRemoved, false) AS permanentlyRemoved,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.uploadedByUsername AS uploadedByUsername,
+            null AS uploaderUsername,
+            collect(DISTINCT author.username) AS discussionAuthorUsernames
+          `,
+      { id }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return {
+      id: record.get("id"),
+      permanentlyRemoved: Boolean(record.get("permanentlyRemoved")),
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+      uploadedByUsername:
+        record.get("uploadedByUsername") || record.get("uploaderUsername") || null,
+      discussionAuthorUsernames: record.get("discussionAuthorUsernames") || [],
+    };
+  } finally {
+    await session.close();
+  }
+};
+
+const assertCanDelete = async ({
+  context,
+  target,
+  checkServerModPermission,
+}: {
+  context: GraphQLContext;
+  target: StoredUploadTarget;
+  checkServerModPermission: CheckServerModPermission;
+}): Promise<void> => {
+  if (!context.user?.username) {
+    context.user = await setUserDataOnContext({ context });
+  }
+  const username = context.user?.username || null;
+
+  if (!username) {
+    throw new GraphQLError("User must be logged in");
+  }
+
+  if (
+    target.uploadedByUsername === username ||
+    target.discussionAuthorUsernames.includes(username)
+  ) {
+    return;
+  }
+
+  const serverModPermission = await checkServerModPermission(
+    "canPermanentlyRemoveImage",
+    context
+  );
+
+  if (serverModPermission === true) {
+    return;
+  }
+
+  throw new GraphQLError(
+    serverModPermission instanceof Error
+      ? serverModPermission.message
+      : "Not authorized to permanently delete this upload"
+  );
+};
+
+const markStoredUploadRemoved = async ({
+  driver,
+  mediaType,
+  id,
+  username,
+  modProfileName,
+}: {
+  driver: Driver;
+  mediaType: MediaType;
+  id: string;
+  username: string;
+  modProfileName?: string | null;
+}): Promise<Record<string, unknown>> => {
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+  const removedAt = new Date().toISOString();
+
+  try {
+    const result = await session.run(
+      mediaType === "Image"
+        ? `
+          MATCH (target:Image {id: $id})
+          SET target.permanentlyRemoved = true,
+              target.permanentlyRemovedAt = datetime($removedAt)
+          WITH target
+          OPTIONAL MATCH (removerUser:User {username: $username})
+          FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
+            MERGE (removerUser)-[:REMOVED_IMAGE]->(target)
+          )
+          WITH target
+          OPTIONAL MATCH (removerMod:ModerationProfile {displayName: $modProfileName})
+          FOREACH (_ IN CASE WHEN removerMod IS NULL THEN [] ELSE [1] END |
+            MERGE (removerMod)-[:REMOVED_IMAGE]->(target)
+          )
+          RETURN
+            target.id AS id,
+            target.url AS url,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.storageUrl AS storageUrl,
+            target.permanentlyRemoved AS permanentlyRemoved,
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+          `
+        : `
+          MATCH (target:DownloadableFile {id: $id})
+          SET target.permanentlyRemoved = true,
+              target.permanentlyRemovedAt = datetime($removedAt)
+          WITH target
+          OPTIONAL MATCH (removerUser:User {username: $username})
+          FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
+            MERGE (removerUser)-[:REMOVED_DOWNLOADABLE_FILE]->(target)
+          )
+          WITH target
+          OPTIONAL MATCH (removerMod:ModerationProfile {displayName: $modProfileName})
+          FOREACH (_ IN CASE WHEN removerMod IS NULL THEN [] ELSE [1] END |
+            MERGE (removerMod)-[:REMOVED_DOWNLOADABLE_FILE]->(target)
+          )
+          RETURN
+            target.id AS id,
+            target.fileName AS fileName,
+            target.kind AS kind,
+            target.size AS size,
+            target.url AS url,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.storageUrl AS storageUrl,
+            target.permanentlyRemoved AS permanentlyRemoved,
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+          `,
+      {
+        id,
+        removedAt,
+        username,
+        modProfileName: modProfileName || null,
+      }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      throw new GraphQLError("Upload not found");
+    }
+
+    return Object.fromEntries(record.keys.map((key) => [key, record.get(key)]));
+  } finally {
+    await session.close();
+  }
+};
+
+const getResolver = ({
+  driver,
+  mediaType,
+  deleteObject = deleteStoredObject,
+  checkServerModPermission = hasServerModPermission,
+}: PermanentlyDeleteStoredUploadInput) => {
+  return async (
+    parent: unknown,
+    args: Args,
+    context: GraphQLContext
+  ): Promise<Record<string, unknown> & { storageDeletion: StorageDeletionResult }> => {
+    const id = getTargetId(mediaType, args);
+    const target = await readStoredUploadTarget({ driver, mediaType, id });
+
+    if (!target) {
+      throw new GraphQLError(
+        mediaType === "Image" ? "Image not found" : "Downloadable file not found"
+      );
+    }
+
+    if (target.permanentlyRemoved) {
+      throw new GraphQLError("Upload has already been permanently deleted");
+    }
+
+    await assertCanDelete({
+      context,
+      target,
+      checkServerModPermission,
+    });
+
+    const storageDeletion = await deleteObject({
+      storageBucket: target.storageBucket,
+      storageObjectName: target.storageObjectName,
+    });
+
+    const username = context.user?.username || "";
+    const modProfileName = context.user?.data?.ModerationProfile?.displayName || null;
+    const removed = await markStoredUploadRemoved({
+      driver,
+      mediaType,
+      id,
+      username,
+      modProfileName,
+    });
+
+    return {
+      ...removed,
+      storageDeletion,
+    };
+  };
+};
+
+export default getResolver;

--- a/permissions.ts
+++ b/permissions.ts
@@ -304,6 +304,8 @@ const permissionList = shield({
       archiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       unarchiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       permanentlyRemoveImage: and(isAuthenticated, canPermanentlyRemoveImage),
+      permanentlyDeleteImage: and(isAuthenticated, allow),
+      permanentlyDeleteDownloadableFile: and(isAuthenticated, allow),
 
       subscribeToDiscussionChannel: and(isAuthenticated, allow),
       unsubscribeFromDiscussionChannel: and(isAuthenticated, allow),

--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -198,6 +198,14 @@ const authGatedImageMod: Array<{ name: string; op: string }> = [
     name: "permanentlyRemoveImage",
     op: `mutation { permanentlyRemoveImage(imageId: "i") { id } }`,
   },
+  {
+    name: "permanentlyDeleteImage",
+    op: `mutation { permanentlyDeleteImage(imageId: "i") { id } }`,
+  },
+  {
+    name: "permanentlyDeleteDownloadableFile",
+    op: `mutation { permanentlyDeleteDownloadableFile(downloadableFileId: "f") { id } }`,
+  },
 ];
 
 for (const { name, op } of authGatedImageMod) {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -404,6 +404,10 @@ const typeDefinitions = gql`
     uploadedByUsername: String
     uploadedByIp: String
     createdAt: DateTime! @timestamp(operations: [CREATE])
+    permanentlyRemoved: Boolean @default(value: false)
+    permanentlyRemovedAt: DateTime
+    PermanentlyRemovedByUser: User @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
+    PermanentlyRemovedByMod: ModerationProfile @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
 
     # commerce fields
     priceModel: PriceModel! @default(value: FREE)
@@ -1283,6 +1287,8 @@ const typeDefinitions = gql`
       imageId: ID!
       explanation: String
     ): Issue
+    permanentlyDeleteImage(imageId: ID!): Image
+    permanentlyDeleteDownloadableFile(downloadableFileId: ID!): DownloadableFile
     lockChannel(
       channelUniqueName: String!
       reason: String!


### PR DESCRIPTION
## Summary
- add permanent-delete mutations for uploaded images and downloadable files
- authorize uploaders, legacy discussion authors for downloads, and server mods with permanent removal permission
- delete the GCS object before marking the Neo4j node permanently removed
- add resolver tests and auth coverage for the new mutations

Stacked on #117.

## Validation
- npm run codegen
- npm run tsc
- node --loader ts-node/esm --test services/storageDeletion.test.ts customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
- node --loader ts-node/esm --test tests/auth/mutationAuth.test.ts

Note: full npm test was attempted but appeared to hang without a failure trace after the first download-list tests; I interrupted it and validated the changed surface area directly.