### PR TITLE
Add uploaded download management query

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -56,6 +56,8 @@ import unarchiveEvent from "./mutations/unarchiveEvent.js";
 import archiveImage from "./mutations/archiveImage.js";
 import unarchiveImage from "./mutations/unarchiveImage.js";
 import permanentlyRemoveImage from "./mutations/permanentlyRemoveImage.js";
+import permanentlyDeleteImage from "./mutations/permanentlyDeleteImage.js";
+import permanentlyDeleteDownloadableFile from "./mutations/permanentlyDeleteDownloadableFile.js";
 import createIssue from "./mutations/createIssue.js";
 import suspendUser from "./mutations/suspendUser.js";
 import suspendMod from "./mutations/suspendMod.js";
@@ -348,6 +350,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     permanentlyRemoveImage: permanentlyRemoveImage({
       Issue,
       Image,
+      driver
+    }),
+    permanentlyDeleteImage: permanentlyDeleteImage({
+      driver
+    }),
+    permanentlyDeleteDownloadableFile: permanentlyDeleteDownloadableFile({
       driver
     }),
     lockChannel: lockChannel({

--- a/customResolvers/mutations/permanentlyDeleteDownloadableFile.ts
+++ b/customResolvers/mutations/permanentlyDeleteDownloadableFile.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getStoredUploadDeleteResolver from "./permanentlyDeleteStoredUpload.js";
+
+const permanentlyDeleteDownloadableFile = ({ driver }: { driver: Driver }) =>
+  getStoredUploadDeleteResolver({
+    driver,
+    mediaType: "DownloadableFile",
+  });
+
+export default permanentlyDeleteDownloadableFile;

--- a/customResolvers/mutations/permanentlyDeleteImage.ts
+++ b/customResolvers/mutations/permanentlyDeleteImage.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getStoredUploadDeleteResolver from "./permanentlyDeleteStoredUpload.js";
+
+const permanentlyDeleteImage = ({ driver }: { driver: Driver }) =>
+  getStoredUploadDeleteResolver({
+    driver,
+    mediaType: "Image",
+  });
+
+export default permanentlyDeleteImage;

--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import getResolver from "./permanentlyDeleteStoredUpload.js";
+
+type TargetRecord = {
+  id?: string;
+  permanentlyRemoved?: boolean;
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+  uploadedByUsername?: string | null;
+  uploaderUsername?: string | null;
+  discussionAuthorUsernames?: string[];
+};
+
+const buildRecord = (values: Record<string, unknown>) => ({
+  keys: Object.keys(values),
+  get: (key: string) => values[key],
+});
+
+const buildDriver = ({
+  target,
+}: {
+  target: TargetRecord | null;
+}) => {
+  const calls = {
+    sessions: [] as string[],
+    writes: [] as Record<string, unknown>[],
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => {
+      calls.sessions.push(defaultAccessMode);
+      return {
+        run: async (query: string, params: Record<string, unknown>) => {
+          if (defaultAccessMode === "READ") {
+            return {
+              records: target
+                ? [
+                    buildRecord({
+                      id: target.id || "target-1",
+                      permanentlyRemoved: target.permanentlyRemoved || false,
+                      storageBucket:
+                        target.storageBucket === undefined
+                          ? "bucket"
+                          : target.storageBucket,
+                      storageObjectName:
+                        target.storageObjectName === undefined
+                          ? "uploads/alice/file.stl"
+                          : target.storageObjectName,
+                      uploadedByUsername:
+                        target.uploadedByUsername === undefined
+                          ? "alice"
+                          : target.uploadedByUsername,
+                      uploaderUsername: target.uploaderUsername || null,
+                      discussionAuthorUsernames:
+                        target.discussionAuthorUsernames || [],
+                    }),
+                  ]
+                : [],
+            };
+          }
+
+          calls.writes.push({ query, params });
+          return {
+            records: [
+              buildRecord({
+                id: params.id,
+                url: "https://storage.example/file.stl",
+                fileName: "file.stl",
+                kind: "STL",
+                size: 100,
+                storageBucket: "bucket",
+                storageObjectName: "uploads/alice/file.stl",
+                storageUrl: "https://storage.example/file.stl",
+                permanentlyRemoved: true,
+                permanentlyRemovedAt: "2026-07-01T12:00:00.000Z",
+              }),
+            ],
+          };
+        },
+        close: async () => undefined,
+      };
+    },
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const contextFor = (username: string, modProfileName?: string): GraphQLContext =>
+  ({
+    user: {
+      username,
+      data: modProfileName
+        ? {
+            ModerationProfile: {
+              displayName: modProfileName,
+            },
+          }
+        : null,
+    },
+  }) as unknown as GraphQLContext;
+
+test("permanentlyDeleteImage lets an uploader delete their own image and storage object", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: null,
+      uploaderUsername: "alice",
+    },
+  });
+  const deleted: Record<string, unknown>[] = [];
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async (input) => {
+      deleted.push(input);
+      return { status: "deleted" };
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  const result = await resolver(
+    null,
+    { imageId: "image-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      deleted,
+      writeCount: calls.writes.length,
+    },
+    {
+      permanentlyRemoved: true,
+      deleted: [
+        {
+          storageBucket: "bucket",
+          storageObjectName: "uploads/alice/file.stl",
+        },
+      ],
+      writeCount: 1,
+    }
+  );
+});
+
+test("permanentlyDeleteDownloadableFile lets a discussion author delete an older download without upload metadata", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: null,
+      storageBucket: null,
+      storageObjectName: null,
+      discussionAuthorUsernames: ["alice"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async (input) => ({
+      status: input.storageObjectName ? "deleted" : "skipped",
+      reason: input.storageObjectName ? undefined : "missing-storage-metadata",
+    }),
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      storageDeletion: result.storageDeletion,
+      writeCount: calls.writes.length,
+    },
+    {
+      permanentlyRemoved: true,
+      storageDeletion: {
+        status: "skipped",
+        reason: "missing-storage-metadata",
+      },
+      writeCount: 1,
+    }
+  );
+});
+
+test("permanentlyDeleteImage lets a server mod with permanent removal permission delete another user's upload", async () => {
+  const { driver } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => true,
+  });
+
+  const result = await resolver(
+    null,
+    { imageId: "image-1" },
+    contextFor("moderator", "Mod One")
+  );
+
+  assert.equal(result.permanentlyRemoved, true);
+});
+
+test("permanentlyDeleteImage rejects an unrelated non-mod user", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => new Error("no permission"),
+  });
+
+  await assert.rejects(
+    resolver(null, { imageId: "image-1" }, contextFor("mallory")),
+    /no permission/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteImage does not mark the DB removed when storage deletion fails", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "Image",
+    deleteObject: async () => {
+      throw new Error("storage unavailable");
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  await assert.rejects(
+    resolver(null, { imageId: "image-1" }, contextFor("alice")),
+    /storage unavailable/
+  );
+  assert.deepEqual(calls.writes, []);
+});

--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
@@ -1,0 +1,292 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import {
+  deleteStoredObject,
+  type StoredObjectMetadata,
+  type StorageDeletionResult,
+} from "../../services/storageDeletion.js";
+
+type MediaType = "Image" | "DownloadableFile";
+
+type DeleteObject = typeof deleteStoredObject;
+type CheckServerModPermission = typeof hasServerModPermission;
+
+type PermanentlyDeleteStoredUploadInput = {
+  driver: Driver;
+  mediaType: MediaType;
+  deleteObject?: DeleteObject;
+  checkServerModPermission?: CheckServerModPermission;
+};
+
+type StoredUploadTarget = StoredObjectMetadata & {
+  id: string;
+  permanentlyRemoved: boolean;
+  uploadedByUsername: string | null;
+  discussionAuthorUsernames: string[];
+};
+
+type Args = {
+  imageId?: string;
+  downloadableFileId?: string;
+};
+
+const getTargetId = (mediaType: MediaType, args: Args): string => {
+  const id =
+    mediaType === "Image" ? args.imageId : args.downloadableFileId;
+
+  if (!id) {
+    throw new GraphQLError(
+      mediaType === "Image"
+        ? "Image ID is required"
+        : "Downloadable file ID is required"
+    );
+  }
+
+  return id;
+};
+
+const readStoredUploadTarget = async ({
+  driver,
+  mediaType,
+  id,
+}: {
+  driver: Driver;
+  mediaType: MediaType;
+  id: string;
+}): Promise<StoredUploadTarget | null> => {
+  const session = driver.session({ defaultAccessMode: "READ" });
+
+  try {
+    const result = await session.run(
+      mediaType === "Image"
+        ? `
+          MATCH (target:Image {id: $id})
+          OPTIONAL MATCH (uploader:User)-[:UPLOADED_IMAGE]->(target)
+          RETURN
+            target.id AS id,
+            coalesce(target.permanentlyRemoved, false) AS permanentlyRemoved,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.uploadedByUsername AS uploadedByUsername,
+            uploader.username AS uploaderUsername,
+            [] AS discussionAuthorUsernames
+          `
+        : `
+          MATCH (target:DownloadableFile {id: $id})
+          OPTIONAL MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(target)
+          OPTIONAL MATCH (author:User)-[:POSTED_DISCUSSION]->(discussion)
+          RETURN
+            target.id AS id,
+            coalesce(target.permanentlyRemoved, false) AS permanentlyRemoved,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.uploadedByUsername AS uploadedByUsername,
+            null AS uploaderUsername,
+            collect(DISTINCT author.username) AS discussionAuthorUsernames
+          `,
+      { id }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return {
+      id: record.get("id"),
+      permanentlyRemoved: Boolean(record.get("permanentlyRemoved")),
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+      uploadedByUsername:
+        record.get("uploadedByUsername") || record.get("uploaderUsername") || null,
+      discussionAuthorUsernames: record.get("discussionAuthorUsernames") || [],
+    };
+  } finally {
+    await session.close();
+  }
+};
+
+const assertCanDelete = async ({
+  context,
+  target,
+  checkServerModPermission,
+}: {
+  context: GraphQLContext;
+  target: StoredUploadTarget;
+  checkServerModPermission: CheckServerModPermission;
+}): Promise<void> => {
+  if (!context.user?.username) {
+    context.user = await setUserDataOnContext({ context });
+  }
+  const username = context.user?.username || null;
+
+  if (!username) {
+    throw new GraphQLError("User must be logged in");
+  }
+
+  if (
+    target.uploadedByUsername === username ||
+    target.discussionAuthorUsernames.includes(username)
+  ) {
+    return;
+  }
+
+  const serverModPermission = await checkServerModPermission(
+    "canPermanentlyRemoveImage",
+    context
+  );
+
+  if (serverModPermission === true) {
+    return;
+  }
+
+  throw new GraphQLError(
+    serverModPermission instanceof Error
+      ? serverModPermission.message
+      : "Not authorized to permanently delete this upload"
+  );
+};
+
+const markStoredUploadRemoved = async ({
+  driver,
+  mediaType,
+  id,
+  username,
+  modProfileName,
+}: {
+  driver: Driver;
+  mediaType: MediaType;
+  id: string;
+  username: string;
+  modProfileName?: string | null;
+}): Promise<Record<string, unknown>> => {
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+  const removedAt = new Date().toISOString();
+
+  try {
+    const result = await session.run(
+      mediaType === "Image"
+        ? `
+          MATCH (target:Image {id: $id})
+          SET target.permanentlyRemoved = true,
+              target.permanentlyRemovedAt = datetime($removedAt)
+          WITH target
+          OPTIONAL MATCH (removerUser:User {username: $username})
+          FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
+            MERGE (removerUser)-[:REMOVED_IMAGE]->(target)
+          )
+          WITH target
+          OPTIONAL MATCH (removerMod:ModerationProfile {displayName: $modProfileName})
+          FOREACH (_ IN CASE WHEN removerMod IS NULL THEN [] ELSE [1] END |
+            MERGE (removerMod)-[:REMOVED_IMAGE]->(target)
+          )
+          RETURN
+            target.id AS id,
+            target.url AS url,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.storageUrl AS storageUrl,
+            target.permanentlyRemoved AS permanentlyRemoved,
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+          `
+        : `
+          MATCH (target:DownloadableFile {id: $id})
+          SET target.permanentlyRemoved = true,
+              target.permanentlyRemovedAt = datetime($removedAt)
+          WITH target
+          OPTIONAL MATCH (removerUser:User {username: $username})
+          FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
+            MERGE (removerUser)-[:REMOVED_DOWNLOADABLE_FILE]->(target)
+          )
+          WITH target
+          OPTIONAL MATCH (removerMod:ModerationProfile {displayName: $modProfileName})
+          FOREACH (_ IN CASE WHEN removerMod IS NULL THEN [] ELSE [1] END |
+            MERGE (removerMod)-[:REMOVED_DOWNLOADABLE_FILE]->(target)
+          )
+          RETURN
+            target.id AS id,
+            target.fileName AS fileName,
+            target.kind AS kind,
+            target.size AS size,
+            target.url AS url,
+            target.storageBucket AS storageBucket,
+            target.storageObjectName AS storageObjectName,
+            target.storageUrl AS storageUrl,
+            target.permanentlyRemoved AS permanentlyRemoved,
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+          `,
+      {
+        id,
+        removedAt,
+        username,
+        modProfileName: modProfileName || null,
+      }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      throw new GraphQLError("Upload not found");
+    }
+
+    return Object.fromEntries(record.keys.map((key) => [key, record.get(key)]));
+  } finally {
+    await session.close();
+  }
+};
+
+const getResolver = ({
+  driver,
+  mediaType,
+  deleteObject = deleteStoredObject,
+  checkServerModPermission = hasServerModPermission,
+}: PermanentlyDeleteStoredUploadInput) => {
+  return async (
+    parent: unknown,
+    args: Args,
+    context: GraphQLContext
+  ): Promise<Record<string, unknown> & { storageDeletion: StorageDeletionResult }> => {
+    const id = getTargetId(mediaType, args);
+    const target = await readStoredUploadTarget({ driver, mediaType, id });
+
+    if (!target) {
+      throw new GraphQLError(
+        mediaType === "Image" ? "Image not found" : "Downloadable file not found"
+      );
+    }
+
+    if (target.permanentlyRemoved) {
+      throw new GraphQLError("Upload has already been permanently deleted");
+    }
+
+    await assertCanDelete({
+      context,
+      target,
+      checkServerModPermission,
+    });
+
+    const storageDeletion = await deleteObject({
+      storageBucket: target.storageBucket,
+      storageObjectName: target.storageObjectName,
+    });
+
+    const username = context.user?.username || "";
+    const modProfileName = context.user?.data?.ModerationProfile?.displayName || null;
+    const removed = await markStoredUploadRemoved({
+      driver,
+      mediaType,
+      id,
+      username,
+      modProfileName,
+    });
+
+    return {
+      ...removed,
+      storageDeletion,
+    };
+  };
+};
+
+export default getResolver;

--- a/customResolvers/queries/getUploadedDownloadableFiles.test.ts
+++ b/customResolvers/queries/getUploadedDownloadableFiles.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import getUploadedDownloadableFiles from "./getUploadedDownloadableFiles.js";
+
+const buildRecord = (values: Record<string, unknown>) => ({
+  get: (key: string) => values[key],
+});
+
+const buildDriver = () => {
+  const calls = {
+    params: [] as Record<string, unknown>[],
+    closed: 0,
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => ({
+      run: async (query: string, params: Record<string, unknown>) => {
+        calls.params.push({ defaultAccessMode, query, ...params });
+        return {
+          records: [
+            buildRecord({
+              group: {
+                discussion: {
+                  id: "discussion-1",
+                  title: "Printable model",
+                  channelUniqueNames: ["models"],
+                },
+                files: [
+                  {
+                    id: "file-1",
+                    fileName: "model.stl",
+                    uploadedByUsername: "alice",
+                  },
+                ],
+              },
+            }),
+          ],
+        };
+      },
+      close: async () => {
+        calls.closed += 1;
+      },
+    }),
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const contextFor = (username?: string): GraphQLContext =>
+  ({
+    user: username ? { username } : null,
+  }) as unknown as GraphQLContext;
+
+test("getUploadedDownloadableFiles returns the caller's uploaded files grouped by discussion", async () => {
+  const { driver, calls } = buildDriver();
+  const resolver = getUploadedDownloadableFiles({ driver });
+
+  const result = await resolver(null, { username: "alice" }, contextFor("alice"));
+
+  assert.deepEqual(
+    {
+      result,
+      username: calls.params[0].username,
+      closed: calls.closed,
+    },
+    {
+      result: [
+        {
+          discussion: {
+            id: "discussion-1",
+            title: "Printable model",
+            channelUniqueNames: ["models"],
+          },
+          files: [
+            {
+              id: "file-1",
+              fileName: "model.stl",
+              uploadedByUsername: "alice",
+            },
+          ],
+        },
+      ],
+      username: "alice",
+      closed: 1,
+    }
+  );
+});
+
+test("getUploadedDownloadableFiles rejects another user's upload inventory", async () => {
+  const { driver } = buildDriver();
+  const resolver = getUploadedDownloadableFiles({ driver });
+
+  await assert.rejects(
+    resolver(null, { username: "alice" }, contextFor("mallory")),
+    /Not authorized/
+  );
+});

--- a/customResolvers/queries/getUploadedDownloadableFiles.ts
+++ b/customResolvers/queries/getUploadedDownloadableFiles.ts
@@ -1,0 +1,84 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+
+type GetUploadedDownloadableFilesInput = {
+  driver: Driver;
+};
+
+type Args = {
+  username: string;
+};
+
+type UploadedDownloadableFileRecord = {
+  discussion: {
+    id: string;
+    title: string;
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    channelUniqueNames: string[];
+  };
+  files: Array<Record<string, unknown>>;
+};
+
+const getUploadedDownloadableFiles = ({
+  driver,
+}: GetUploadedDownloadableFilesInput) => {
+  return async (
+    parent: unknown,
+    args: Args,
+    context: GraphQLContext
+  ): Promise<UploadedDownloadableFileRecord[]> => {
+    if (!context.user?.username) {
+      context.user = await setUserDataOnContext({ context });
+    }
+
+    if (!context.user?.username) {
+      throw new GraphQLError("User must be logged in");
+    }
+
+    if (context.user.username !== args.username) {
+      throw new GraphQLError("Not authorized to view uploaded downloadable files");
+    }
+
+    const session = driver.session({ defaultAccessMode: "READ" });
+
+    try {
+      const result = await session.run(
+        `
+        MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile)
+        WHERE file.uploadedByUsername = $username
+          AND coalesce(file.permanentlyRemoved, false) = false
+        OPTIONAL MATCH (discussion)-[:POSTED_IN_CHANNEL]->(discussionChannel:DiscussionChannel)
+        WITH discussion, file, collect(DISTINCT discussionChannel.channelUniqueName) AS channelUniqueNames
+        ORDER BY coalesce(file.createdAt, file.uploadedAt) DESC, file.fileName ASC
+        WITH discussion, channelUniqueNames, collect(file {
+          .*,
+          createdAt: toString(file.createdAt),
+          uploadedAt: toString(file.uploadedAt),
+          permanentlyRemovedAt: toString(file.permanentlyRemovedAt)
+        }) AS files
+        ORDER BY coalesce(discussion.updatedAt, discussion.createdAt) DESC, discussion.title ASC
+        RETURN {
+          discussion: {
+            id: discussion.id,
+            title: discussion.title,
+            createdAt: toString(discussion.createdAt),
+            updatedAt: toString(discussion.updatedAt),
+            channelUniqueNames: channelUniqueNames
+          },
+          files: files
+        } AS group
+        `,
+        { username: args.username }
+      );
+
+      return result.records.map((record) => record.get("group"));
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getUploadedDownloadableFiles;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -22,6 +22,7 @@ import publicCollectionsContaining from "./queries/publicCollectionsContaining.j
 import getOwnEmail from "./queries/getOwnEmail.js";
 import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
 import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
+import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -113,6 +114,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     getOwnEmail: getOwnEmail({
       Email
+    }),
+    getUploadedDownloadableFiles: getUploadedDownloadableFiles({
+      driver
     }),
     getServerHealthDashboard: getServerHealthDashboard({
       driver

--- a/permissions.ts
+++ b/permissions.ts
@@ -304,6 +304,8 @@ const permissionList = shield({
       archiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       unarchiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       permanentlyRemoveImage: and(isAuthenticated, canPermanentlyRemoveImage),
+      permanentlyDeleteImage: and(isAuthenticated, allow),
+      permanentlyDeleteDownloadableFile: and(isAuthenticated, allow),
 
       subscribeToDiscussionChannel: and(isAuthenticated, allow),
       unsubscribeFromDiscussionChannel: and(isAuthenticated, allow),

--- a/permissions.ts
+++ b/permissions.ts
@@ -76,6 +76,7 @@ const permissionList = shield({
       // access should be able to read them. Clients that need the caller's own
       // email use the self-scoped `getOwnEmail` query.
       emails: deny,
+      getUploadedDownloadableFiles: and(isAuthenticated, allow),
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
     },
     User: {

--- a/services/storageDeletion.test.ts
+++ b/services/storageDeletion.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  deleteStoredObject,
+  type StorageClient,
+} from "./storageDeletion.js";
+
+const buildStorageClient = () => {
+  const calls = {
+    bucket: [] as string[],
+    file: [] as string[],
+    delete: [] as Array<{ ignoreNotFound?: boolean } | undefined>,
+  };
+
+  const storage: StorageClient = {
+    bucket: (storageBucket: string) => {
+      calls.bucket.push(storageBucket);
+      return {
+        file: (storageObjectName: string) => {
+          calls.file.push(storageObjectName);
+          return {
+            delete: async (options?: { ignoreNotFound?: boolean }) => {
+              calls.delete.push(options);
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { storage, calls };
+};
+
+test("deleteStoredObject deletes the stored object and ignores missing GCS objects", async () => {
+  const { storage, calls } = buildStorageClient();
+
+  const result = await deleteStoredObject({
+    storageBucket: "bucket",
+    storageObjectName: "uploads/alice/file.stl",
+    storage,
+  });
+
+  assert.deepEqual(
+    {
+      result,
+      calls,
+    },
+    {
+      result: {
+        status: "deleted",
+        storageBucket: "bucket",
+        storageObjectName: "uploads/alice/file.stl",
+      },
+      calls: {
+        bucket: ["bucket"],
+        file: ["uploads/alice/file.stl"],
+        delete: [{ ignoreNotFound: true }],
+      },
+    }
+  );
+});
+
+test("deleteStoredObject skips deletion when storage metadata is missing", async () => {
+  const { storage, calls } = buildStorageClient();
+
+  const result = await deleteStoredObject({
+    storageBucket: "bucket",
+    storageObjectName: null,
+    storage,
+  });
+
+  assert.deepEqual(
+    {
+      result,
+      calls,
+    },
+    {
+      result: {
+        status: "skipped",
+        reason: "missing-storage-metadata",
+        storageBucket: "bucket",
+        storageObjectName: undefined,
+      },
+      calls: {
+        bucket: [],
+        file: [],
+        delete: [],
+      },
+    }
+  );
+});
+
+test("deleteStoredObject propagates storage client errors", async () => {
+  const storage: StorageClient = {
+    bucket: () => ({
+      file: () => ({
+        delete: async () => {
+          throw new Error("storage unavailable");
+        },
+      }),
+    }),
+  };
+
+  await assert.rejects(
+    deleteStoredObject({
+      storageBucket: "bucket",
+      storageObjectName: "uploads/alice/file.stl",
+      storage,
+    }),
+    /storage unavailable/
+  );
+});

--- a/services/storageDeletion.ts
+++ b/services/storageDeletion.ts
@@ -1,0 +1,58 @@
+import { Storage } from "@google-cloud/storage";
+
+export type StoredObjectMetadata = {
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+};
+
+export type StorageDeletionStatus = "deleted" | "skipped";
+
+export type StorageDeletionResult = {
+  status: StorageDeletionStatus;
+  storageBucket?: string;
+  storageObjectName?: string;
+  reason?: "missing-storage-metadata";
+};
+
+export type StorageFileClient = {
+  delete: (options?: { ignoreNotFound?: boolean }) => Promise<unknown>;
+};
+
+export type StorageBucketClient = {
+  file: (storageObjectName: string) => StorageFileClient;
+};
+
+export type StorageClient = {
+  bucket: (storageBucket: string) => StorageBucketClient;
+};
+
+type DeleteStoredObjectInput = StoredObjectMetadata & {
+  storage?: StorageClient;
+};
+
+export const deleteStoredObject = async ({
+  storageBucket,
+  storageObjectName,
+  storage,
+}: DeleteStoredObjectInput): Promise<StorageDeletionResult> => {
+  if (!storageBucket || !storageObjectName) {
+    return {
+      status: "skipped",
+      reason: "missing-storage-metadata",
+      storageBucket: storageBucket || undefined,
+      storageObjectName: storageObjectName || undefined,
+    };
+  }
+
+  const storageClient = storage || new Storage();
+  await storageClient
+    .bucket(storageBucket)
+    .file(storageObjectName)
+    .delete({ ignoreNotFound: true });
+
+  return {
+    status: "deleted",
+    storageBucket,
+    storageObjectName,
+  };
+};

--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -198,6 +198,14 @@ const authGatedImageMod: Array<{ name: string; op: string }> = [
     name: "permanentlyRemoveImage",
     op: `mutation { permanentlyRemoveImage(imageId: "i") { id } }`,
   },
+  {
+    name: "permanentlyDeleteImage",
+    op: `mutation { permanentlyDeleteImage(imageId: "i") { id } }`,
+  },
+  {
+    name: "permanentlyDeleteDownloadableFile",
+    op: `mutation { permanentlyDeleteDownloadableFile(downloadableFileId: "f") { id } }`,
+  },
 ];
 
 for (const { name, op } of authGatedImageMod) {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -404,6 +404,10 @@ const typeDefinitions = gql`
     uploadedByUsername: String
     uploadedByIp: String
     createdAt: DateTime! @timestamp(operations: [CREATE])
+    permanentlyRemoved: Boolean @default(value: false)
+    permanentlyRemovedAt: DateTime
+    PermanentlyRemovedByUser: User @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
+    PermanentlyRemovedByMod: ModerationProfile @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
 
     # commerce fields
     priceModel: PriceModel! @default(value: FREE)
@@ -1283,6 +1287,8 @@ const typeDefinitions = gql`
       imageId: ID!
       explanation: String
     ): Issue
+    permanentlyDeleteImage(imageId: ID!): Image
+    permanentlyDeleteDownloadableFile(downloadableFileId: ID!): DownloadableFile
     lockChannel(
       channelUniqueName: String!
       reason: String!

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -2047,6 +2047,19 @@ const typeDefinitions = gql`
     unreadNotificationCount: Int
   }
 
+  type UploadedDownloadableFileDiscussion @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    id: ID!
+    title: String!
+    createdAt: DateTime
+    updatedAt: DateTime
+    channelUniqueNames: [String!]!
+  }
+
+  type UploadedDownloadableFileGroup @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    discussion: UploadedDownloadableFileDiscussion!
+    files: [DownloadableFile!]!
+  }
+
   type Query {
     # Discovery
     """
@@ -2116,6 +2129,7 @@ const typeDefinitions = gql`
     with username: null when authenticated but no account exists yet.
     """
     getOwnEmail: OwnEmail
+    getUploadedDownloadableFiles(username: String!): [UploadedDownloadableFileGroup!]!
     getUserFavoriteComment(commentId: ID!): Boolean
     getSortedChannels(
       offset: Int


### PR DESCRIPTION
## Summary
- add an owner-scoped `getUploadedDownloadableFiles` query for uploaded downloadable files grouped by linked discussion
- exclude permanently removed files from the management result
- wire the query through permissions and custom query resolvers
- add focused resolver tests for owner access and cross-user rejection

Stacked on `codex/storage-deletion-utility`, which includes the permanent storage deletion utility and mutations.

## Validation
- `node --loader ts-node/esm --test customResolvers/queries/getUploadedDownloadableFiles.test.ts`
- `npm run codegen`
- `npm run tsc`