### PR TITLE
[codex] Fix user wiki edits profile count

### DIFF
--- a/customResolvers/cypher/cypherQueries.ts
+++ b/customResolvers/cypher/cypherQueries.ts
@@ -22,5 +22,6 @@ export const getSiteWideWikiPagesQuery = fs.readFileSync(path.resolve(__dirname,
 export const getCommentRepliesQuery = fs.readFileSync(path.resolve(__dirname, './getCommentRepliesQuery.cypher'), 'utf8');
 export const getEventCommentsQuery = fs.readFileSync(path.resolve(__dirname, './getEventCommentsQuery.cypher'), 'utf8');
 export const getUserContributionsQuery = fs.readFileSync(path.resolve(__dirname, './getUserContributionsQuery.cypher'), 'utf8');
+export const getUserWikiEditsCountQuery = fs.readFileSync(path.resolve(__dirname, './getUserWikiEditsCountQuery.cypher'), 'utf8');
 export const getChannelContributionsQuery = fs.readFileSync(path.resolve(__dirname, './getChannelContributionsQuery.cypher'), 'utf8');
 export const getModContributionsQuery = fs.readFileSync(path.resolve(__dirname, './getModContributionsQuery.cypher'), 'utf8');

--- a/customResolvers/cypher/getUserWikiEditsCountQuery.cypher
+++ b/customResolvers/cypher/getUserWikiEditsCountQuery.cypher
@@ -1,0 +1,8 @@
+MATCH (u:User {username: $username})
+
+OPTIONAL MATCH (u)-[:AUTHORED_VERSION]->(currentWikiPage:WikiPage)
+WITH u, count(DISTINCT currentWikiPage) AS currentWikiEditsCount
+
+OPTIONAL MATCH (u)-[:AUTHORED_VERSION]->(wikiRevision:TextVersion)<-[:HAS_VERSION]-(wikiPage:WikiPage)
+WITH currentWikiEditsCount, count(DISTINCT wikiRevision) AS historicalWikiEditsCount
+RETURN currentWikiEditsCount + historicalWikiEditsCount AS count

--- a/customResolvers/queries/getUserWikiEditsCount.test.ts
+++ b/customResolvers/queries/getUserWikiEditsCount.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import getUserWikiEditsCountResolver from "./getUserWikiEditsCount.js";
+
+type RunCall = {
+  query: string;
+  params: Record<string, unknown>;
+};
+
+const createDriver = (count: number) => {
+  const runCalls: RunCall[] = [];
+
+  return {
+    runCalls,
+    driver: {
+      session: () => ({
+        run: async (query: string, params: Record<string, unknown>) => {
+          runCalls.push({ query, params });
+          return {
+            records: [
+              {
+                get: (key: string) =>
+                  key === "count"
+                    ? {
+                        toNumber: () => count,
+                      }
+                    : undefined,
+              },
+            ],
+          };
+        },
+        close: async () => {},
+      }),
+    },
+  };
+};
+
+test("getUserWikiEditsCount returns the counted wiki edits for an existing user", async () => {
+  const { driver, runCalls } = createDriver(3);
+  const resolver = getUserWikiEditsCountResolver({
+    User: {
+      find: async () => [{ username: "alice" }],
+    } as any,
+    driver: driver as any,
+  });
+
+  const result = await resolver(null, { username: "alice" });
+
+  assert.equal(result, 3);
+  assert.equal(runCalls.length, 1);
+  assert.equal(runCalls[0].params.username, "alice");
+  assert.match(runCalls[0].query, /AUTHORED_VERSION/);
+  assert.match(runCalls[0].query, /WikiPage/);
+});
+
+test("getUserWikiEditsCount throws when the user does not exist", async () => {
+  const { driver } = createDriver(0);
+  const resolver = getUserWikiEditsCountResolver({
+    User: {
+      find: async () => [],
+    } as any,
+    driver: driver as any,
+  });
+
+  await assert.rejects(
+    resolver(null, { username: "ghost" }),
+    /not found|Failed to fetch wiki edits count/i
+  );
+});

--- a/customResolvers/queries/getUserWikiEditsCount.ts
+++ b/customResolvers/queries/getUserWikiEditsCount.ts
@@ -1,0 +1,48 @@
+import { getUserWikiEditsCountQuery } from "../cypher/cypherQueries.js";
+import type { Driver } from "neo4j-driver";
+import type { UserModel } from "../../ogm_types.js";
+import { logger } from "../../logger.js";
+
+type Input = {
+  User: UserModel;
+  driver: Driver;
+};
+
+type Args = {
+  username: string;
+};
+
+const getUserWikiEditsCountResolver = (input: Input) => {
+  const { driver, User } = input;
+
+  return async (_parent: unknown, args: Args) => {
+    const { username } = args;
+    const session = driver.session({ defaultAccessMode: "READ" });
+
+    try {
+      const userExists = await User.find({
+        where: { username },
+        selectionSet: `{ username }`,
+      });
+
+      if (userExists.length === 0) {
+        throw new Error(`User ${username} not found.`);
+      }
+
+      const result = await session.run(getUserWikiEditsCountQuery, { username });
+      const firstRecord = result.records[0];
+      const count = firstRecord?.get("count");
+      return count?.toNumber ? count.toNumber() : Number(count ?? 0);
+    } catch (error: unknown) {
+      logger.error("Error fetching user wiki edits count:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to fetch wiki edits count for user ${username}: ${message}`
+      );
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getUserWikiEditsCountResolver;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -8,6 +8,7 @@ import getEventComments from "./queries/getEventComments.js";
 import getCommentReplies from "./queries/getCommentReplies.js";
 import getDiscussionsInChannel from "./queries/getDiscussionsInChannel.js";
 import getUserContributions from "./queries/getUserContributions.js";
+import getUserWikiEditsCount from "./queries/getUserWikiEditsCount.js";
 import getChannelContributions from "./queries/getChannelContributions.js";
 import getModContributions from "./queries/getModContributions.js";
 import getUserFavoriteComment from "./queries/getUserFavoriteComment.js";
@@ -75,6 +76,10 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
       driver,
     }),
     getUserContributions: getUserContributions({
+      User,
+      driver,
+    }),
+    getUserWikiEditsCount: getUserWikiEditsCount({
       User,
       driver,
     }),

--- a/tests/integration/contributionsQueries.test.ts
+++ b/tests/integration/contributionsQueries.test.ts
@@ -61,6 +61,72 @@ test("getUserContributions returns nothing for a user with no activity", async (
   assert.equal(total, 0, "a user with no authored content has no contributions");
 });
 
+test("getUserWikiEditsCount counts current and historical wiki edits only", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice' })
+     CREATE (wikiCurrent:WikiPage {
+       id: 'wiki-current',
+       title: 'Current Wiki',
+       slug: 'current-wiki',
+       channelUniqueName: 'cats',
+       createdAt: datetime()
+     })
+     CREATE (wikiOld:WikiPage {
+       id: 'wiki-old',
+       title: 'Old Wiki',
+       slug: 'old-wiki',
+       channelUniqueName: 'cats',
+       createdAt: datetime()
+     })
+     CREATE (wikiRev:TextVersion {
+       id: 'wiki-rev-1',
+       body: 'old body',
+       createdAt: datetime()
+     })
+     CREATE (comment:Comment {
+       id: 'comment-1',
+       text: 'comment',
+       isRootComment: true,
+       createdAt: datetime()
+     })
+     CREATE (commentRev:TextVersion {
+       id: 'comment-rev-1',
+       body: 'old comment',
+       createdAt: datetime()
+     })
+     CREATE (discussion:Discussion {
+       id: 'discussion-1',
+       title: 'Discussion',
+       createdAt: datetime()
+     })
+     CREATE (discussionRev:TextVersion {
+       id: 'discussion-rev-1',
+       body: 'old discussion',
+       createdAt: datetime()
+     })
+     CREATE (alice)-[:AUTHORED_VERSION]->(wikiCurrent)
+     CREATE (alice)-[:AUTHORED_VERSION]->(wikiRev)
+     CREATE (alice)-[:AUTHORED_VERSION]->(commentRev)
+     CREATE (alice)-[:AUTHORED_VERSION]->(discussionRev)
+     CREATE (wikiOld)-[:HAS_VERSION]->(wikiRev)
+     CREATE (comment)-[:HAS_VERSION]->(commentRev)
+     CREATE (discussion)-[:HAS_BODY_VERSION]->(discussionRev)`
+  );
+
+  const result = await env.resolvers.Query.getUserWikiEditsCount(null, {
+    username: "alice",
+  });
+
+  assert.equal(result, 2);
+});
+
+test("getUserWikiEditsCount throws when the user does not exist", async () => {
+  await assert.rejects(
+    env.resolvers.Query.getUserWikiEditsCount(null, { username: "ghost" }),
+    /not found|Failed to fetch wiki edits count/i
+  );
+});
+
 // --- getModContributions ---
 
 test("getModContributions returns a mod's moderation actions grouped by date", async () => {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -2124,6 +2124,7 @@ const typeDefinitions = gql`
       endDate: String
       year: Int
     ): [DayData!]!
+    getUserWikiEditsCount(username: String!): Int!
     getChannelContributions(
       channelUniqueName: String!
       startDate: String


### PR DESCRIPTION
## What changed
Adds a dedicated `getUserWikiEditsCount(username)` query so the profile wiki-edits badge counts only real wiki edits instead of all authored `TextVersion` records.

## Why
The previous badge used `AuthoredWikiPageVersionsAggregate`, but `TextVersion` is shared by wiki, comment, and discussion revisions. That caused profile badges like Alice's to overcount badly.

## Impact
The backend now exposes a wiki-specific count that includes current wiki authorship and historical wiki revisions, which lets the frontend badge agree with the actual wiki-edits list.

## Validation
- `node --loader ts-node/esm --test customResolvers/queries/getUserWikiEditsCount.test.ts`
- `TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 tests/integration/contributionsQueries.test.ts`