### PR TITLE
Harden downloadable file permanent delete

### DIFF
--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts
@@ -76,6 +76,8 @@ const buildDriver = ({
                 storageUrl: "https://storage.example/file.stl",
                 permanentlyRemoved: true,
                 permanentlyRemovedAt: "2026-07-01T12:00:00.000Z",
+                permanentlyRemovedByUsername: params.username,
+                permanentlyRemovedByModName: params.modProfileName,
               }),
             ],
           };
@@ -185,6 +187,179 @@ test("permanentlyDeleteDownloadableFile lets a discussion author delete an older
       writeCount: 1,
     }
   );
+});
+
+test("permanentlyDeleteDownloadableFile lets the original uploader delete a stored file", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+      discussionAuthorUsernames: ["bob"],
+    },
+  });
+  const deleted: Record<string, unknown>[] = [];
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async (input) => {
+      deleted.push(input);
+      return { status: "deleted" };
+    },
+    checkServerModPermission: async () => {
+      throw new Error("permission should not be checked for owner");
+    },
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("alice")
+  );
+  const writeParams = calls.writes[0]?.params as
+    | Record<string, unknown>
+    | undefined;
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      permanentlyRemovedByUsername: result.permanentlyRemovedByUsername,
+      permanentlyRemovedByModName: result.permanentlyRemovedByModName,
+      deleted,
+      writeParams,
+    },
+    {
+      permanentlyRemoved: true,
+      permanentlyRemovedByUsername: "alice",
+      permanentlyRemovedByModName: null,
+      deleted: [
+        {
+          storageBucket: "bucket",
+          storageObjectName: "uploads/alice/file.stl",
+        },
+      ],
+      writeParams: {
+        id: "file-1",
+        removedAt: writeParams?.removedAt,
+        username: "alice",
+        modProfileName: null,
+      },
+    }
+  );
+});
+
+test("permanentlyDeleteDownloadableFile lets a server mod with permanent removal permission delete another user's file", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+      discussionAuthorUsernames: ["bob"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async (permission) => {
+      assert.equal(permission, "canPermanentlyRemoveImage");
+      return true;
+    },
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("moderator", "Mod One")
+  );
+  const writeParams = calls.writes[0]?.params as
+    | Record<string, unknown>
+    | undefined;
+
+  assert.deepEqual(
+    {
+      permanentlyRemoved: result.permanentlyRemoved,
+      permanentlyRemovedByUsername: result.permanentlyRemovedByUsername,
+      permanentlyRemovedByModName: result.permanentlyRemovedByModName,
+      writeParams,
+    },
+    {
+      permanentlyRemoved: true,
+      permanentlyRemovedByUsername: "moderator",
+      permanentlyRemovedByModName: "Mod One",
+      writeParams: {
+        id: "file-1",
+        removedAt: writeParams?.removedAt,
+        username: "moderator",
+        modProfileName: "Mod One",
+      },
+    }
+  );
+});
+
+test("permanentlyDeleteDownloadableFile rejects an unrelated non-mod user", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+      discussionAuthorUsernames: ["bob"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => new Error("no permission"),
+  });
+
+  await assert.rejects(
+    resolver(null, { downloadableFileId: "file-1" }, contextFor("mallory")),
+    /no permission/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteDownloadableFile rejects a moderator without permanent removal permission", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+      discussionAuthorUsernames: ["bob"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () =>
+      new Error("You do not have permission to permanently remove uploads"),
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      contextFor("moderator", "Mod One")
+    ),
+    /do not have permission/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteDownloadableFile does not mark the DB removed when storage deletion fails", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      uploadedByUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    mediaType: "DownloadableFile",
+    deleteObject: async () => {
+      throw new Error("storage unavailable");
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  await assert.rejects(
+    resolver(null, { downloadableFileId: "file-1" }, contextFor("alice")),
+    /storage unavailable/
+  );
+  assert.deepEqual(calls.writes, []);
 });
 
 test("permanentlyDeleteImage lets a server mod with permanent removal permission delete another user's upload", async () => {

--- a/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
+++ b/customResolvers/mutations/permanentlyDeleteStoredUpload.ts
@@ -172,7 +172,9 @@ const markStoredUploadRemoved = async ({
         ? `
           MATCH (target:Image {id: $id})
           SET target.permanentlyRemoved = true,
-              target.permanentlyRemovedAt = datetime($removedAt)
+              target.permanentlyRemovedAt = datetime($removedAt),
+              target.permanentlyRemovedByUsername = $username,
+              target.permanentlyRemovedByModName = $modProfileName
           WITH target
           OPTIONAL MATCH (removerUser:User {username: $username})
           FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
@@ -190,12 +192,16 @@ const markStoredUploadRemoved = async ({
             target.storageObjectName AS storageObjectName,
             target.storageUrl AS storageUrl,
             target.permanentlyRemoved AS permanentlyRemoved,
-            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt,
+            target.permanentlyRemovedByUsername AS permanentlyRemovedByUsername,
+            target.permanentlyRemovedByModName AS permanentlyRemovedByModName
           `
         : `
           MATCH (target:DownloadableFile {id: $id})
           SET target.permanentlyRemoved = true,
-              target.permanentlyRemovedAt = datetime($removedAt)
+              target.permanentlyRemovedAt = datetime($removedAt),
+              target.permanentlyRemovedByUsername = $username,
+              target.permanentlyRemovedByModName = $modProfileName
           WITH target
           OPTIONAL MATCH (removerUser:User {username: $username})
           FOREACH (_ IN CASE WHEN removerUser IS NULL THEN [] ELSE [1] END |
@@ -216,7 +222,9 @@ const markStoredUploadRemoved = async ({
             target.storageObjectName AS storageObjectName,
             target.storageUrl AS storageUrl,
             target.permanentlyRemoved AS permanentlyRemoved,
-            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt
+            toString(target.permanentlyRemovedAt) AS permanentlyRemovedAt,
+            target.permanentlyRemovedByUsername AS permanentlyRemovedByUsername,
+            target.permanentlyRemovedByModName AS permanentlyRemovedByModName
           `,
       {
         id,

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -93,6 +93,8 @@ const typeDefinitions = gql`
     archived: Boolean @default(value: false)
     permanentlyRemoved: Boolean @default(value: false)
     permanentlyRemovedAt: DateTime
+    permanentlyRemovedByUsername: String
+    permanentlyRemovedByModName: String
     PermanentlyRemovedByUser: User @relationship(type: "REMOVED_IMAGE", direction: IN)
     PermanentlyRemovedByMod: ModerationProfile @relationship(type: "REMOVED_IMAGE", direction: IN)
 
@@ -406,6 +408,8 @@ const typeDefinitions = gql`
     createdAt: DateTime! @timestamp(operations: [CREATE])
     permanentlyRemoved: Boolean @default(value: false)
     permanentlyRemovedAt: DateTime
+    permanentlyRemovedByUsername: String
+    permanentlyRemovedByModName: String
     PermanentlyRemovedByUser: User @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
     PermanentlyRemovedByMod: ModerationProfile @relationship(type: "REMOVED_DOWNLOADABLE_FILE", direction: IN)
 


### PR DESCRIPTION
## Summary
- Add scalar permanent-removal audit fields for images and downloadable files so direct DB queries can see who removed an upload.
- Set `permanentlyRemovedByUsername` and `permanentlyRemovedByModName` when permanent upload deletion succeeds.
- Expand focused resolver coverage for downloadable-file permanent deletion permissions and storage-failure behavior.

## Validation
- `npm run codegen`
- `npm run tsc`
- `node --loader ts-node/esm --test customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts`

## Frontend pair
Pairs with the frontend hardening PR stacked on the uploaded-file management PR.