### PR TITLE
Fix download filter include exclude semantics

### DIFF
--- a/customResolvers/cypher/downloadListEligibility.test.ts
+++ b/customResolvers/cypher/downloadListEligibility.test.ts
@@ -25,6 +25,24 @@ test("channel download list query requires an attached downloadable file when ha
   );
 });
 
+test("channel download label filters honor include and exclude filter group modes", () => {
+  assert.match(
+    getDiscussionChannelsQuery,
+    /fg\.mode = "EXCLUDE"[\s\S]*NOT EXISTS[\s\S]*excludedOption\.value IN labelFilter\.values/
+  );
+  assert.match(
+    getDiscussionChannelsQuery,
+    /ELSE EXISTS[\s\S]*includedOption\.value IN labelFilter\.values/
+  );
+});
+
+test("channel download label filters are scoped to the current channel's filter groups", () => {
+  assert.match(
+    getDiscussionChannelsQuery,
+    /:Channel \{uniqueName: dc\.channelUniqueName\}\)-\[:HAS_FILTER_GROUP\]->\(fg:FilterGroup \{key: labelFilter\.groupKey\}\)/
+  );
+});
+
 test("user contributions query still treats hasDownload as a presentation flag without list-only file gating", () => {
   assert.match(
     getUserContributionsQuery,

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -34,13 +34,24 @@ WHERE
             )
         }
     END
-    // Filter by label options if specified
+    // Filter by label options if specified. INCLUDE groups require at least
+    // one selected option on the download; EXCLUDE groups reject downloads
+    // that have any selected option.
     AND (
         SIZE($labelFilters) = 0 OR
         ALL(labelFilter IN $labelFilters WHERE
             EXISTS {
-                MATCH (dc)-[:HAS_LABEL_OPTION]->(fo:FilterOption)-[:HAS_FILTER_OPTION]-(fg:FilterGroup)
-                WHERE fg.key = labelFilter.groupKey AND fo.value IN labelFilter.values
+                MATCH (:Channel {uniqueName: dc.channelUniqueName})-[:HAS_FILTER_GROUP]->(fg:FilterGroup {key: labelFilter.groupKey})
+                WHERE CASE
+                    WHEN fg.mode = "EXCLUDE" THEN NOT EXISTS {
+                        MATCH (dc)-[:HAS_LABEL_OPTION]->(excludedOption:FilterOption)<-[:HAS_FILTER_OPTION]-(fg)
+                        WHERE excludedOption.value IN labelFilter.values
+                    }
+                    ELSE EXISTS {
+                        MATCH (dc)-[:HAS_LABEL_OPTION]->(includedOption:FilterOption)<-[:HAS_FILTER_OPTION]-(fg)
+                        WHERE includedOption.value IN labelFilter.values
+                    }
+                END
             }
         )
     )
@@ -83,13 +94,24 @@ WHERE
             )
         }
     END
-    // Filter by label options if specified
+    // Filter by label options if specified. INCLUDE groups require at least
+    // one selected option on the download; EXCLUDE groups reject downloads
+    // that have any selected option.
     AND (
         SIZE($labelFilters) = 0 OR
         ALL(labelFilter IN $labelFilters WHERE
             EXISTS {
-                MATCH (dc)-[:HAS_LABEL_OPTION]->(fo:FilterOption)-[:HAS_FILTER_OPTION]-(fg:FilterGroup)
-                WHERE fg.key = labelFilter.groupKey AND fo.value IN labelFilter.values
+                MATCH (:Channel {uniqueName: dc.channelUniqueName})-[:HAS_FILTER_GROUP]->(fg:FilterGroup {key: labelFilter.groupKey})
+                WHERE CASE
+                    WHEN fg.mode = "EXCLUDE" THEN NOT EXISTS {
+                        MATCH (dc)-[:HAS_LABEL_OPTION]->(excludedOption:FilterOption)<-[:HAS_FILTER_OPTION]-(fg)
+                        WHERE excludedOption.value IN labelFilter.values
+                    }
+                    ELSE EXISTS {
+                        MATCH (dc)-[:HAS_LABEL_OPTION]->(includedOption:FilterOption)<-[:HAS_FILTER_OPTION]-(fg)
+                        WHERE includedOption.value IN labelFilter.values
+                    }
+                END
             }
         )
     )


### PR DESCRIPTION
## Summary
- Fix channel download-list label filtering so filter group mode is honored.
- `INCLUDE` groups now require at least one selected label on the download.
- `EXCLUDE` groups now reject downloads that have any selected label.
- Scope label filters to the current channel's filter groups.

## Frontend pair
- gennit-project/multiforum-nuxt#274

## Validation
- `npm run codegen`
- `npm run tsc`
- `node --loader ts-node/esm --test customResolvers/cypher/downloadListEligibility.test.ts`

## Notes
A broader resolver test import crashed in the temp clone before assertions with an opaque ts-node loader object; the changed Cypher eligibility test and backend type-check pass after codegen.