### PR TITLE
Fail closed for permanent image removal permission

### DIFF
--- a/rules/permission/canPermanentlyRemoveImage.ts
+++ b/rules/permission/canPermanentlyRemoveImage.ts
@@ -21,6 +21,8 @@ export const canPermanentlyRemoveImage = rule({ cache: "contextual" })(
       context
     );
 
-    return normalizeServerModPermissionResult(permissionResult);
+    return normalizeServerModPermissionResult(permissionResult, {
+      denyOnFalsy: true,
+    });
   }
 );

--- a/rules/permission/serverModPermissionResult.test.ts
+++ b/rules/permission/serverModPermissionResult.test.ts
@@ -12,12 +12,12 @@ test("returns an Error result unchanged", () => {
 });
 
 test("default behavior treats a falsy non-error result as allowed", () => {
-  // Mirrors canPermanentlyRemoveImage / image server-scope.
+  // Preserved for legacy callers that do not opt into fail-closed behavior.
   assert.equal(normalizeServerModPermissionResult(false), true);
 });
 
-test("denyOnFalsy treats a falsy non-error result as denied", () => {
-  // Mirrors canLockChannel.
+test("denyOnFalsy treats a falsy non-error result as denied for destructive actions", () => {
+  // Mirrors canLockChannel and canPermanentlyRemoveImage.
   assert.equal(
     normalizeServerModPermissionResult(false, { denyOnFalsy: true }),
     false

--- a/rules/permission/serverModPermissionResult.ts
+++ b/rules/permission/serverModPermissionResult.ts
@@ -3,13 +3,15 @@
 // return type allows `false`, so callers historically handled the falsy case
 // inconsistently:
 //
-//   - canLockChannel: a falsy (non-Error) result denies (returns false).
-//   - canPermanentlyRemoveImage / canArchiveAndUnarchiveImage (server scope):
-//     a falsy result is treated as allowed (returns true).
+//   - canLockChannel / canPermanentlyRemoveImage: a falsy (non-Error)
+//     result denies (returns false).
+//   - canArchiveAndUnarchiveImage (server scope): a falsy result is treated
+//     as allowed (returns true).
 //
-// `denyOnFalsy` preserves that distinction so existing behavior is unchanged.
+// `denyOnFalsy` makes destructive permission checks fail closed while preserving
+// older behavior for callers that intentionally leave it false.
 // (The falsy branch is currently unreachable given hasServerModPermission's
-// real returns; the flag documents intent rather than fixing a live bug.)
+// real returns; the flag documents intent and protects future changes.)
 export function normalizeServerModPermissionResult(
   result: boolean | Error,
   { denyOnFalsy = false }: { denyOnFalsy?: boolean } = {}


### PR DESCRIPTION
## Summary
- Make `canPermanentlyRemoveImage` fail closed if `hasServerModPermission` ever returns a falsy non-Error value.
- Keep legacy default behavior in `normalizeServerModPermissionResult` for callers that do not opt into `denyOnFalsy`.
- Update helper documentation/tests to reflect that permanent image removal now matches `canLockChannel`.

## Validation
- `npm run codegen`
- `npm run tsc`
- `node --loader ts-node/esm --test rules/permission/serverModPermissionResult.test.ts customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts`