### PR TITLE
Add storage cleanup for profile and banner images

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -58,6 +58,8 @@ import unarchiveImage from "./mutations/unarchiveImage.js";
 import permanentlyRemoveImage from "./mutations/permanentlyRemoveImage.js";
 import permanentlyDeleteImage from "./mutations/permanentlyDeleteImage.js";
 import permanentlyDeleteDownloadableFile from "./mutations/permanentlyDeleteDownloadableFile.js";
+import permanentlyDeleteProfileImage from "./mutations/permanentlyDeleteProfileImage.js";
+import permanentlyDeleteChannelBanner from "./mutations/permanentlyDeleteChannelBanner.js";
 import createIssue from "./mutations/createIssue.js";
 import suspendUser from "./mutations/suspendUser.js";
 import suspendMod from "./mutations/suspendMod.js";
@@ -356,6 +358,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       driver
     }),
     permanentlyDeleteDownloadableFile: permanentlyDeleteDownloadableFile({
+      driver
+    }),
+    permanentlyDeleteProfileImage: permanentlyDeleteProfileImage({
+      driver
+    }),
+    permanentlyDeleteChannelBanner: permanentlyDeleteChannelBanner({
       driver
     }),
     lockChannel: lockChannel({

--- a/customResolvers/mutations/permanentlyDeleteChannelBanner.ts
+++ b/customResolvers/mutations/permanentlyDeleteChannelBanner.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getUrlBackedImageDeleteResolver from "./permanentlyDeleteUrlBackedImage.js";
+
+const permanentlyDeleteChannelBanner = ({ driver }: { driver: Driver }) =>
+  getUrlBackedImageDeleteResolver({
+    driver,
+    referenceType: "ChannelBanner",
+  });
+
+export default permanentlyDeleteChannelBanner;

--- a/customResolvers/mutations/permanentlyDeleteProfileImage.ts
+++ b/customResolvers/mutations/permanentlyDeleteProfileImage.ts
@@ -1,0 +1,10 @@
+import type { Driver } from "neo4j-driver";
+import getUrlBackedImageDeleteResolver from "./permanentlyDeleteUrlBackedImage.js";
+
+const permanentlyDeleteProfileImage = ({ driver }: { driver: Driver }) =>
+  getUrlBackedImageDeleteResolver({
+    driver,
+    referenceType: "ProfileImage",
+  });
+
+export default permanentlyDeleteProfileImage;

--- a/customResolvers/mutations/permanentlyDeleteUrlBackedImage.test.ts
+++ b/customResolvers/mutations/permanentlyDeleteUrlBackedImage.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import getResolver from "./permanentlyDeleteUrlBackedImage.js";
+
+type TargetRecord = {
+  ownerUsername?: string | null;
+  channelUniqueName?: string | null;
+  channelOwnerUsernames?: string[];
+  currentUrl?: string | null;
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+};
+
+const buildRecord = (values: Record<string, unknown>) => ({
+  keys: Object.keys(values),
+  get: (key: string) => values[key],
+});
+
+const buildDriver = ({ target }: { target: TargetRecord | null }) => {
+  const calls = {
+    reads: [] as Record<string, unknown>[],
+    writes: [] as Record<string, unknown>[],
+  };
+
+  const driver = {
+    session: ({ defaultAccessMode }: { defaultAccessMode: string }) => ({
+      run: async (query: string, params: Record<string, unknown>) => {
+        if (defaultAccessMode === "READ") {
+          calls.reads.push({ query, params });
+          return {
+            records: target
+              ? [
+                  buildRecord({
+                    ownerUsername: target.ownerUsername ?? null,
+                    channelUniqueName: target.channelUniqueName ?? null,
+                    channelOwnerUsernames: target.channelOwnerUsernames || [],
+                    currentUrl:
+                      target.currentUrl === undefined
+                        ? "https://storage.example/image.png"
+                        : target.currentUrl,
+                    storageBucket:
+                      target.storageBucket === undefined
+                        ? "bucket"
+                        : target.storageBucket,
+                    storageObjectName:
+                      target.storageObjectName === undefined
+                        ? "uploads/alice/image.png"
+                        : target.storageObjectName,
+                  }),
+                ]
+              : [],
+          };
+        }
+
+        calls.writes.push({ query, params });
+        return {
+          records: [
+            buildRecord(
+              query.includes("target:User")
+                ? {
+                    username: params.username,
+                    profilePicURL: null,
+                  }
+                : {
+                    uniqueName: params.channelUniqueName,
+                    channelBannerURL: null,
+                  }
+            ),
+          ],
+        };
+      },
+      close: async () => undefined,
+    }),
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const contextFor = (username: string, modProfileName?: string): GraphQLContext =>
+  ({
+    user: {
+      username,
+      data: modProfileName
+        ? {
+            ModerationProfile: {
+              displayName: modProfileName,
+            },
+          }
+        : null,
+    },
+  }) as unknown as GraphQLContext;
+
+test("permanentlyDeleteProfileImage lets the profile owner delete the active stored image", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      ownerUsername: "alice",
+    },
+  });
+  const deleted: Record<string, unknown>[] = [];
+  const resolver = getResolver({
+    driver,
+    referenceType: "ProfileImage",
+    deleteObject: async (input) => {
+      deleted.push(input);
+      return { status: "deleted" };
+    },
+    checkServerModPermission: async () => {
+      throw new Error("permission should not be checked for owner");
+    },
+  });
+
+  const result = await resolver(
+    null,
+    { username: "alice", imageUrl: "https://storage.example/image.png" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      result,
+      deleted,
+      writeCount: calls.writes.length,
+      writeParams: calls.writes[0]?.params,
+    },
+    {
+      result: {
+        username: "alice",
+        profilePicURL: null,
+      },
+      deleted: [
+        {
+          storageBucket: "bucket",
+          storageObjectName: "uploads/alice/image.png",
+        },
+      ],
+      writeCount: 1,
+      writeParams: {
+        username: "alice",
+        channelUniqueName: undefined,
+        imageUrl: "https://storage.example/image.png",
+        removedAt: (calls.writes[0]?.params as Record<string, unknown>).removedAt,
+        removedByUsername: "alice",
+        removedByModName: null,
+      },
+    }
+  );
+});
+
+test("permanentlyDeleteChannelBanner lets a channel owner delete the active banner", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      channelUniqueName: "cats",
+      channelOwnerUsernames: ["alice"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    referenceType: "ChannelBanner",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => {
+      throw new Error("permission should not be checked for owner");
+    },
+  });
+
+  const result = await resolver(
+    null,
+    {
+      channelUniqueName: "cats",
+      imageUrl: "https://storage.example/image.png",
+    },
+    contextFor("alice")
+  );
+
+  assert.deepEqual(
+    {
+      result,
+      writeCount: calls.writes.length,
+    },
+    {
+      result: {
+        uniqueName: "cats",
+        channelBannerURL: null,
+      },
+      writeCount: 1,
+    }
+  );
+});
+
+test("permanentlyDeleteChannelBanner lets a server mod delete another channel's active banner", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      channelUniqueName: "cats",
+      channelOwnerUsernames: ["alice"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    referenceType: "ChannelBanner",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async (permission) => {
+      assert.equal(permission, "canPermanentlyRemoveImage");
+      return true;
+    },
+  });
+
+  const result = await resolver(
+    null,
+    {
+      channelUniqueName: "cats",
+      imageUrl: "https://storage.example/image.png",
+    },
+    contextFor("moderator", "Mod One")
+  );
+
+  assert.deepEqual(
+    {
+      result,
+      writeParams: calls.writes[0]?.params,
+    },
+    {
+      result: {
+        uniqueName: "cats",
+        channelBannerURL: null,
+      },
+      writeParams: {
+        username: undefined,
+        channelUniqueName: "cats",
+        imageUrl: "https://storage.example/image.png",
+        removedAt: (calls.writes[0]?.params as Record<string, unknown>).removedAt,
+        removedByUsername: "moderator",
+        removedByModName: "Mod One",
+      },
+    }
+  );
+});
+
+test("permanentlyDeleteProfileImage rejects an unrelated non-mod user", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      ownerUsername: "alice",
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    referenceType: "ProfileImage",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => new Error("no permission"),
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { username: "alice", imageUrl: "https://storage.example/image.png" },
+      contextFor("mallory")
+    ),
+    /no permission/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteProfileImage rejects active images without storage metadata", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      ownerUsername: "alice",
+      storageBucket: null,
+      storageObjectName: null,
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    referenceType: "ProfileImage",
+    deleteObject: async () => ({ status: "deleted" }),
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { username: "alice", imageUrl: "https://legacy.example/image.png" },
+      contextFor("alice")
+    ),
+    /Storage metadata not found/
+  );
+  assert.deepEqual(calls.writes, []);
+});
+
+test("permanentlyDeleteChannelBanner does not clear the banner when storage deletion fails", async () => {
+  const { driver, calls } = buildDriver({
+    target: {
+      channelUniqueName: "cats",
+      channelOwnerUsernames: ["alice"],
+    },
+  });
+  const resolver = getResolver({
+    driver,
+    referenceType: "ChannelBanner",
+    deleteObject: async () => {
+      throw new Error("storage unavailable");
+    },
+    checkServerModPermission: async () => new Error("not a mod"),
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        channelUniqueName: "cats",
+        imageUrl: "https://storage.example/image.png",
+      },
+      contextFor("alice")
+    ),
+    /storage unavailable/
+  );
+  assert.deepEqual(calls.writes, []);
+});

--- a/customResolvers/mutations/permanentlyDeleteUrlBackedImage.ts
+++ b/customResolvers/mutations/permanentlyDeleteUrlBackedImage.ts
@@ -1,0 +1,279 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import {
+  deleteStoredObject,
+  type StoredObjectMetadata,
+} from "../../services/storageDeletion.js";
+
+type DeleteObject = typeof deleteStoredObject;
+type CheckServerModPermission = typeof hasServerModPermission;
+
+type ReferenceType = "ProfileImage" | "ChannelBanner";
+
+type UrlBackedImageTarget = StoredObjectMetadata & {
+  ownerUsername?: string | null;
+  channelUniqueName?: string | null;
+  channelOwnerUsernames?: string[];
+  currentUrl?: string | null;
+};
+
+type ResolverInput = {
+  driver: Driver;
+  referenceType: ReferenceType;
+  deleteObject?: DeleteObject;
+  checkServerModPermission?: CheckServerModPermission;
+};
+
+type Args = {
+  username?: string;
+  channelUniqueName?: string;
+  imageUrl?: string;
+};
+
+const getRequiredArg = (value: string | undefined, message: string): string => {
+  if (!value?.trim()) {
+    throw new GraphQLError(message);
+  }
+
+  return value;
+};
+
+const readTarget = async ({
+  driver,
+  referenceType,
+  username,
+  channelUniqueName,
+  imageUrl,
+}: {
+  driver: Driver;
+  referenceType: ReferenceType;
+  username?: string;
+  channelUniqueName?: string;
+  imageUrl: string;
+}): Promise<UrlBackedImageTarget | null> => {
+  const session = driver.session({ defaultAccessMode: "READ" });
+
+  try {
+    const result = await session.run(
+      referenceType === "ProfileImage"
+        ? `
+          MATCH (target:User {username: $username})
+          WHERE target.profilePicURL = $imageUrl
+          OPTIONAL MATCH (audit:UploadedFileAudit {storageUrl: $imageUrl})
+          RETURN
+            target.username AS ownerUsername,
+            target.profilePicURL AS currentUrl,
+            audit.storageBucket AS storageBucket,
+            audit.storageObjectName AS storageObjectName,
+            null AS channelUniqueName,
+            [] AS channelOwnerUsernames
+          `
+        : `
+          MATCH (target:Channel {uniqueName: $channelUniqueName})
+          WHERE target.channelBannerURL = $imageUrl
+          OPTIONAL MATCH (admin:User)-[:ADMIN_OF_CHANNEL]->(target)
+          OPTIONAL MATCH (audit:UploadedFileAudit {storageUrl: $imageUrl})
+          RETURN
+            null AS ownerUsername,
+            target.channelBannerURL AS currentUrl,
+            audit.storageBucket AS storageBucket,
+            audit.storageObjectName AS storageObjectName,
+            target.uniqueName AS channelUniqueName,
+            collect(DISTINCT admin.username) AS channelOwnerUsernames
+          `,
+      { username, channelUniqueName, imageUrl }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return {
+      ownerUsername: record.get("ownerUsername"),
+      channelUniqueName: record.get("channelUniqueName"),
+      channelOwnerUsernames: record.get("channelOwnerUsernames") || [],
+      currentUrl: record.get("currentUrl"),
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+    };
+  } finally {
+    await session.close();
+  }
+};
+
+const assertCanDelete = async ({
+  context,
+  target,
+  checkServerModPermission,
+}: {
+  context: GraphQLContext;
+  target: UrlBackedImageTarget;
+  checkServerModPermission: CheckServerModPermission;
+}): Promise<void> => {
+  if (!context.user?.username) {
+    context.user = await setUserDataOnContext({ context });
+  }
+
+  const username = context.user?.username || null;
+  if (!username) {
+    throw new GraphQLError("User must be logged in");
+  }
+
+  if (
+    target.ownerUsername === username ||
+    target.channelOwnerUsernames?.includes(username)
+  ) {
+    return;
+  }
+
+  const serverModPermission = await checkServerModPermission(
+    "canPermanentlyRemoveImage",
+    context
+  );
+
+  if (serverModPermission === true) {
+    return;
+  }
+
+  throw new GraphQLError(
+    serverModPermission instanceof Error
+      ? serverModPermission.message
+      : "Not authorized to permanently delete this image"
+  );
+};
+
+const clearReference = async ({
+  driver,
+  referenceType,
+  username,
+  channelUniqueName,
+  imageUrl,
+  removedByUsername,
+  removedByModName,
+}: {
+  driver: Driver;
+  referenceType: ReferenceType;
+  username?: string;
+  channelUniqueName?: string;
+  imageUrl: string;
+  removedByUsername: string;
+  removedByModName?: string | null;
+}): Promise<Record<string, unknown>> => {
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+  const removedAt = new Date().toISOString();
+
+  try {
+    const result = await session.run(
+      referenceType === "ProfileImage"
+        ? `
+          MATCH (target:User {username: $username})
+          WHERE target.profilePicURL = $imageUrl
+          SET target.profilePicURL = null
+          WITH target
+          OPTIONAL MATCH (audit:UploadedFileAudit {storageUrl: $imageUrl})
+          SET audit.permanentlyRemoved = true,
+              audit.permanentlyRemovedAt = datetime($removedAt),
+              audit.permanentlyRemovedByUsername = $removedByUsername,
+              audit.permanentlyRemovedByModName = $removedByModName
+          RETURN target.username AS username,
+                 target.profilePicURL AS profilePicURL
+          `
+        : `
+          MATCH (target:Channel {uniqueName: $channelUniqueName})
+          WHERE target.channelBannerURL = $imageUrl
+          SET target.channelBannerURL = null
+          WITH target
+          OPTIONAL MATCH (audit:UploadedFileAudit {storageUrl: $imageUrl})
+          SET audit.permanentlyRemoved = true,
+              audit.permanentlyRemovedAt = datetime($removedAt),
+              audit.permanentlyRemovedByUsername = $removedByUsername,
+              audit.permanentlyRemovedByModName = $removedByModName
+          RETURN target.uniqueName AS uniqueName,
+                 target.channelBannerURL AS channelBannerURL
+          `,
+      {
+        username,
+        channelUniqueName,
+        imageUrl,
+        removedAt,
+        removedByUsername,
+        removedByModName: removedByModName || null,
+      }
+    );
+
+    const record = result.records[0];
+    if (!record) {
+      throw new GraphQLError("Image reference changed before deletion completed");
+    }
+
+    return Object.fromEntries(record.keys.map((key) => [key, record.get(key)]));
+  } finally {
+    await session.close();
+  }
+};
+
+const getResolver = ({
+  driver,
+  referenceType,
+  deleteObject = deleteStoredObject,
+  checkServerModPermission = hasServerModPermission,
+}: ResolverInput) => {
+  return async (
+    parent: unknown,
+    args: Args,
+    context: GraphQLContext
+  ): Promise<Record<string, unknown>> => {
+    const imageUrl = getRequiredArg(args.imageUrl, "Image URL is required");
+    const username =
+      referenceType === "ProfileImage"
+        ? getRequiredArg(args.username, "Username is required")
+        : undefined;
+    const channelUniqueName =
+      referenceType === "ChannelBanner"
+        ? getRequiredArg(args.channelUniqueName, "Channel unique name is required")
+        : undefined;
+
+    const target = await readTarget({
+      driver,
+      referenceType,
+      username,
+      channelUniqueName,
+      imageUrl,
+    });
+
+    if (!target) {
+      throw new GraphQLError("Active image reference not found");
+    }
+
+    if (!target.storageBucket || !target.storageObjectName) {
+      throw new GraphQLError("Storage metadata not found for active image");
+    }
+
+    await assertCanDelete({
+      context,
+      target,
+      checkServerModPermission,
+    });
+
+    await deleteObject({
+      storageBucket: target.storageBucket,
+      storageObjectName: target.storageObjectName,
+    });
+
+    return clearReference({
+      driver,
+      referenceType,
+      username,
+      channelUniqueName,
+      imageUrl,
+      removedByUsername: context.user?.username || "",
+      removedByModName: context.user?.data?.ModerationProfile?.displayName || null,
+    });
+  };
+};
+
+export default getResolver;

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1293,6 +1293,8 @@ const typeDefinitions = gql`
     ): Issue
     permanentlyDeleteImage(imageId: ID!): Image
     permanentlyDeleteDownloadableFile(downloadableFileId: ID!): DownloadableFile
+    permanentlyDeleteProfileImage(username: String!, imageUrl: String!): User
+    permanentlyDeleteChannelBanner(channelUniqueName: String!, imageUrl: String!): Channel
     lockChannel(
       channelUniqueName: String!
       reason: String!


### PR DESCRIPTION
## Summary
- Add storage-backed permanent delete mutations for URL-backed profile images and forum banners.
- Resolve active profile/banner URLs through upload audit metadata before deleting the stored object and clearing the owning field.
- Enforce profile owner/channel owner self-delete plus server-mod override via `canPermanentlyRemoveImage`.
- Preserve audit metadata by marking the upload audit record permanently removed after successful storage deletion.

## Validation
- `npm run codegen`
- `npm run tsc`
- `node --loader ts-node/esm --test customResolvers/mutations/permanentlyDeleteUrlBackedImage.test.ts customResolvers/mutations/permanentlyDeleteStoredUpload.test.ts services/storageDeletion.test.ts`