### PR TITLE
Test download label exclude priority

### DIFF
--- a/tests/integration/getDiscussionsInChannel.test.ts
+++ b/tests/integration/getDiscussionsInChannel.test.ts
@@ -11,6 +11,7 @@ import {
   startImageModEnv,
   stopImageModEnv,
   resetDb,
+  run,
   type ImageModEnv,
 } from "./imageModerationHarness.js";
 
@@ -59,3 +60,71 @@ for (const sort of ["new", "top", "hot"]) {
     assert.equal(Number(result.aggregateDiscussionChannelsCount), 0);
   });
 }
+
+test("download label filters include matching packs and exclude excluded packs first", async () => {
+  await run(
+    `CREATE (owner:User { username: 'sims-builder', createdAt: datetime() })
+     CREATE (channel:Channel { uniqueName: 'sims4_builds', displayName: 'Sims 4 Builds', createdAt: datetime() })
+     CREATE (includePacks:FilterGroup { id: 'fg-include-packs', key: 'include_game_packs', displayName: 'Game Packs', order: 1, mode: 'INCLUDE' })
+     CREATE (excludePacks:FilterGroup { id: 'fg-exclude-packs', key: 'exclude_game_packs', displayName: 'Game Packs', order: 2, mode: 'EXCLUDE' })
+     CREATE (includeVampires:FilterOption { id: 'fo-include-vampires', value: 'vampires', displayName: 'Vampires', order: 1 })
+     CREATE (includeDineOut:FilterOption { id: 'fo-include-dine-out', value: 'dine_out', displayName: 'Dine Out', order: 2 })
+     CREATE (excludeVampires:FilterOption { id: 'fo-exclude-vampires', value: 'vampires', displayName: 'Vampires', order: 1 })
+     CREATE (excludeDineOut:FilterOption { id: 'fo-exclude-dine-out', value: 'dine_out', displayName: 'Dine Out', order: 2 })
+     CREATE (channel)-[:HAS_FILTER_GROUP]->(includePacks)
+     CREATE (channel)-[:HAS_FILTER_GROUP]->(excludePacks)
+     CREATE (includePacks)-[:HAS_FILTER_OPTION]->(includeVampires)
+     CREATE (includePacks)-[:HAS_FILTER_OPTION]->(includeDineOut)
+     CREATE (excludePacks)-[:HAS_FILTER_OPTION]->(excludeVampires)
+     CREATE (excludePacks)-[:HAS_FILTER_OPTION]->(excludeDineOut)
+
+     CREATE (vampireOnly:Discussion { id: 'disc-vampire-only', title: 'Vampire Manor', body: 'Uses Vampires only', hasDownload: true, createdAt: datetime() })
+     CREATE (vampireRestaurant:Discussion { id: 'disc-vampire-restaurant', title: 'Vampire Restaurant', body: 'Uses Vampires and Dine Out', hasDownload: true, createdAt: datetime() })
+     CREATE (dinerOnly:Discussion { id: 'disc-diner-only', title: 'Modern Diner', body: 'Uses Dine Out only', hasDownload: true, createdAt: datetime() })
+     CREATE (owner)-[:POSTED_DISCUSSION]->(vampireOnly)
+     CREATE (owner)-[:POSTED_DISCUSSION]->(vampireRestaurant)
+     CREATE (owner)-[:POSTED_DISCUSSION]->(dinerOnly)
+     CREATE (vampireOnly)-[:HAS_DOWNLOADABLE_FILE]->(:DownloadableFile { id: 'file-vampire-only', storageObjectName: 'uploads/sims-builder/vampire.zip' })
+     CREATE (vampireRestaurant)-[:HAS_DOWNLOADABLE_FILE]->(:DownloadableFile { id: 'file-vampire-restaurant', storageObjectName: 'uploads/sims-builder/vampire-restaurant.zip' })
+     CREATE (dinerOnly)-[:HAS_DOWNLOADABLE_FILE]->(:DownloadableFile { id: 'file-diner-only', storageObjectName: 'uploads/sims-builder/diner.zip' })
+
+     CREATE (dcVampireOnly:DiscussionChannel { id: 'dc-vampire-only', discussionId: 'disc-vampire-only', channelUniqueName: 'sims4_builds', createdAt: datetime() })
+     CREATE (dcVampireRestaurant:DiscussionChannel { id: 'dc-vampire-restaurant', discussionId: 'disc-vampire-restaurant', channelUniqueName: 'sims4_builds', createdAt: datetime() })
+     CREATE (dcDinerOnly:DiscussionChannel { id: 'dc-diner-only', discussionId: 'disc-diner-only', channelUniqueName: 'sims4_builds', createdAt: datetime() })
+     CREATE (dcVampireOnly)-[:POSTED_IN_CHANNEL]->(vampireOnly)
+     CREATE (dcVampireOnly)-[:POSTED_IN_CHANNEL]->(channel)
+     CREATE (dcVampireRestaurant)-[:POSTED_IN_CHANNEL]->(vampireRestaurant)
+     CREATE (dcVampireRestaurant)-[:POSTED_IN_CHANNEL]->(channel)
+     CREATE (dcDinerOnly)-[:POSTED_IN_CHANNEL]->(dinerOnly)
+     CREATE (dcDinerOnly)-[:POSTED_IN_CHANNEL]->(channel)
+     CREATE (dcVampireOnly)-[:HAS_LABEL_OPTION]->(includeVampires)
+     CREATE (dcVampireRestaurant)-[:HAS_LABEL_OPTION]->(includeVampires)
+     CREATE (dcVampireRestaurant)-[:HAS_LABEL_OPTION]->(excludeDineOut)
+     CREATE (dcDinerOnly)-[:HAS_LABEL_OPTION]->(excludeDineOut)`
+  );
+
+  const result = await env.resolvers.Query.getDiscussionsInChannel(
+    null,
+    {
+      channelUniqueName: "sims4_builds",
+      options: { offset: "0", limit: "10", sort: "new" },
+      selectedTags: [],
+      searchInput: "",
+      showArchived: false,
+      hasDownload: true,
+      labelFilters: [
+        { groupKey: "include_game_packs", values: ["vampires"] },
+        { groupKey: "exclude_game_packs", values: ["dine_out"] },
+      ],
+    },
+    anon(),
+    {} as never
+  );
+
+  const titles = result.discussionChannels.map(
+    (discussionChannel: any) => discussionChannel.Discussion.title
+  );
+
+  assert.deepEqual(titles, ["Vampire Manor"]);
+  assert.equal(Number(result.aggregateDiscussionChannelsCount), 1);
+});


### PR DESCRIPTION
## Summary
- adds a live getDiscussionsInChannel integration case for the Sims 4 downloads filter use case
- seeds paired INCLUDE/EXCLUDE game-pack filter groups and verifies include=vampires plus exclude=dine_out returns only the Vampires-only download
- documents backend behavior where exclude labels take priority over include matches

## Verification
- node --loader ts-node/esm --test customResolvers/cypher/downloadListEligibility.test.ts customResolvers/queries/getDiscussionsInChannel.test.ts
- npm run tsc

## Notes
- The integration file was attempted locally, but Testcontainers/Neo4j did not reach the test body reliably in this checkout: one reused-container run failed during resetDb() with ServiceUnavailable, and later runs hung during container startup/schema initialization. The test is included for CI to exercise against a clean integration environment.
- npm test was also stopped locally because this checkout's script traverses hidden nested .claude/worktrees paths, making it an unreliable branch-scoped signal.