### PR TITLE
Implement collection ordering mutations

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -97,6 +97,11 @@ import createScratchpadEntry from "./mutations/createScratchpadEntry.js";
 import undoSuperUpvote from "./mutations/undoSuperUpvote.js";
 import updateScratchpadEntryVisibility from "./mutations/updateScratchpadEntryVisibility.js";
 import deleteScratchpadEntry from "./mutations/deleteScratchpadEntry.js";
+import {
+  addToCollection,
+  removeFromCollection,
+  reorderCollectionItem,
+} from "./mutations/collectionOrdering.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -552,6 +557,15 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     createCollections: createCollectionsWithOwner({
       Collection,
       User
+    }),
+    addToCollection: addToCollection({
+      driver
+    }),
+    removeFromCollection: removeFromCollection({
+      driver
+    }),
+    reorderCollectionItem: reorderCollectionItem({
+      driver
     }),
     updateDownloadLabels: updateDownloadLabels({
       Discussion,

--- a/customResolvers/mutations/collectionOrdering.test.ts
+++ b/customResolvers/mutations/collectionOrdering.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  addToCollection,
+  removeFromCollection,
+  reorderCollectionItem,
+} from "./collectionOrdering.js";
+
+const buildDriver = ({ records = [{}] }: { records?: unknown[] } = {}) => {
+  const calls = {
+    run: [] as Array<[string, Record<string, unknown>]>,
+    close: 0,
+  };
+
+  const driver = {
+    session: () => ({
+      run: async (query: string, params: Record<string, unknown>) => {
+        calls.run.push([query, params]);
+        return {
+          records: records.map((record) => ({
+            get: () => record,
+          })),
+        };
+      },
+      close: async () => {
+        calls.close += 1;
+      },
+    }),
+  };
+
+  return { driver: driver as unknown as Driver, calls };
+};
+
+const context = { user: { username: "alice" } } as unknown as GraphQLContext;
+
+test("addToCollection owner-checks and inserts the item at the requested position", async () => {
+  const { driver, calls } = buildDriver();
+  const resolver = addToCollection({ driver });
+
+  const result = await resolver(
+    null,
+    {
+      input: {
+        collectionId: "collection-1",
+        itemId: "discussion-1",
+        itemType: "DISCUSSION",
+        position: 1,
+      },
+    },
+    context
+  );
+
+  assert.equal(result, true);
+  assert.match(calls.run[0][0], /CREATED_BY/);
+  assert.match(calls.run[0][0], /CONTAINS_DISCUSSION/);
+  assert.match(calls.run[0][0], /existingOrder WHERE id <> \$itemId/);
+  assert.equal(calls.run[0][1].username, "alice");
+  assert.equal(calls.run[0][1].position, 1);
+  assert.equal(calls.close, 1);
+});
+
+test("addToCollection appends channels by uniqueName", async () => {
+  const { driver, calls } = buildDriver();
+  const resolver = addToCollection({ driver });
+
+  await resolver(
+    null,
+    {
+      input: {
+        collectionId: "collection-1",
+        itemId: "sims4_builds",
+        itemType: "CHANNEL",
+      },
+    },
+    context
+  );
+
+  assert.match(calls.run[0][0], /item:Channel \{uniqueName: \$itemId\}/);
+  assert.equal(calls.run[0][1].position, null);
+});
+
+test("removeFromCollection removes the relationship and prunes stale order entries", async () => {
+  const { driver, calls } = buildDriver();
+  const resolver = removeFromCollection({ driver });
+
+  const result = await resolver(
+    null,
+    {
+      collectionId: "collection-1",
+      itemId: "image-1",
+      itemType: "IMAGE",
+    },
+    context
+  );
+
+  assert.equal(result, true);
+  assert.match(calls.run[0][0], /CONTAINS_IMAGE/);
+  assert.match(calls.run[0][0], /WHERE id <> \$itemId/);
+});
+
+test("reorderCollectionItem normalizes stored order and clamps the target position", async () => {
+  const { driver, calls } = buildDriver();
+  const resolver = reorderCollectionItem({ driver });
+
+  const result = await resolver(
+    null,
+    {
+      collectionId: "collection-1",
+      itemId: "discussion-2",
+      newPosition: -10,
+    },
+    context
+  );
+
+  assert.equal(result, true);
+  assert.match(calls.run[0][0], /CONTAINS_DISCUSSION\|CONTAINS_COMMENT\|CONTAINS_DOWNLOAD\|CONTAINS_IMAGE\|CONTAINS_CHANNEL/);
+  assert.match(calls.run[0][0], /WHERE \$itemId IN itemIds/);
+  assert.match(calls.run[0][0], /WHEN \$newPosition < 0 THEN 0/);
+});
+
+test("collection mutations reject missing ownership or missing items", async () => {
+  const { driver } = buildDriver({ records: [] });
+  const resolver = reorderCollectionItem({ driver });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        itemId: "missing",
+        newPosition: 0,
+      },
+      context
+    ),
+    /Item is not in this collection/
+  );
+});
+
+test("collection mutations require a logged-in user", async () => {
+  const { driver } = buildDriver();
+  const resolver = addToCollection({ driver });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        input: {
+          collectionId: "collection-1",
+          itemId: "discussion-1",
+          itemType: "DISCUSSION",
+        },
+      },
+      {} as GraphQLContext
+    ),
+    /logged in/
+  );
+});

--- a/customResolvers/mutations/collectionOrdering.ts
+++ b/customResolvers/mutations/collectionOrdering.ts
@@ -1,0 +1,202 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+
+type CollectionItemType = "DISCUSSION" | "COMMENT" | "DOWNLOAD" | "IMAGE" | "CHANNEL";
+
+type AddArgs = {
+  input: {
+    collectionId: string;
+    itemId: string;
+    itemType: CollectionItemType;
+    position?: number | null;
+  };
+};
+
+type RemoveArgs = {
+  collectionId: string;
+  itemId: string;
+  itemType: CollectionItemType;
+};
+
+type ReorderArgs = {
+  collectionId: string;
+  itemId: string;
+  newPosition: number;
+};
+
+type ItemConfig = {
+  label: string;
+  relationship: string;
+  idProperty: string;
+};
+
+const itemConfigs: Record<CollectionItemType, ItemConfig> = {
+  DISCUSSION: {
+    label: "Discussion",
+    relationship: "CONTAINS_DISCUSSION",
+    idProperty: "id",
+  },
+  COMMENT: {
+    label: "Comment",
+    relationship: "CONTAINS_COMMENT",
+    idProperty: "id",
+  },
+  DOWNLOAD: {
+    label: "Discussion",
+    relationship: "CONTAINS_DOWNLOAD",
+    idProperty: "id",
+  },
+  IMAGE: {
+    label: "Image",
+    relationship: "CONTAINS_IMAGE",
+    idProperty: "id",
+  },
+  CHANNEL: {
+    label: "Channel",
+    relationship: "CONTAINS_CHANNEL",
+    idProperty: "uniqueName",
+  },
+};
+
+const getUsername = (context: GraphQLContext) => {
+  const username = context.user?.username;
+  if (!username) {
+    throw new GraphQLError("You must be logged in to update collections.");
+  }
+  return username;
+};
+
+const getItemConfig = (itemType: CollectionItemType) => {
+  const config = itemConfigs[itemType];
+  if (!config) {
+    throw new GraphQLError("Unsupported collection item type.");
+  }
+  return config;
+};
+
+const getWriteSession = (driver: Driver) =>
+  driver.session({ defaultAccessMode: "WRITE" });
+
+export const addToCollection = ({ driver }: { driver: Driver }) => {
+  return async (_parent: unknown, args: AddArgs, context: GraphQLContext) => {
+    const username = getUsername(context);
+    const { collectionId, itemId, itemType, position } = args.input;
+    const { label, relationship, idProperty } = getItemConfig(itemType);
+    const session = getWriteSession(driver);
+
+    try {
+      const result = await session.run(
+        `
+        MATCH (collection:Collection {id: $collectionId})-[:CREATED_BY]->(:User {username: $username})
+        MATCH (item:${label} {${idProperty}: $itemId})
+        MERGE (collection)-[:${relationship}]->(item)
+        WITH collection, coalesce(collection.itemOrder, []) AS existingOrder
+        WITH collection, [id IN existingOrder WHERE id <> $itemId] AS withoutItem
+        WITH collection,
+          CASE
+            WHEN $position IS NULL OR $position < 0 OR $position >= size(withoutItem)
+              THEN withoutItem + [$itemId]
+            ELSE withoutItem[0..$position] + [$itemId] + withoutItem[$position..]
+          END AS nextOrder
+        SET collection.itemOrder = nextOrder
+        RETURN collection.itemOrder AS itemOrder
+        `,
+        {
+          collectionId,
+          itemId,
+          position: position ?? null,
+          username,
+        }
+      );
+
+      if (result.records.length === 0) {
+        throw new GraphQLError("Collection or item not found, or you do not own this collection.");
+      }
+
+      return true;
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export const removeFromCollection = ({ driver }: { driver: Driver }) => {
+  return async (_parent: unknown, args: RemoveArgs, context: GraphQLContext) => {
+    const username = getUsername(context);
+    const { collectionId, itemId, itemType } = args;
+    const { label, relationship, idProperty } = getItemConfig(itemType);
+    const session = getWriteSession(driver);
+
+    try {
+      const result = await session.run(
+        `
+        MATCH (collection:Collection {id: $collectionId})-[:CREATED_BY]->(:User {username: $username})
+        OPTIONAL MATCH (collection)-[relationship:${relationship}]->(item:${label} {${idProperty}: $itemId})
+        DELETE relationship
+        SET collection.itemOrder = [id IN coalesce(collection.itemOrder, []) WHERE id <> $itemId]
+        RETURN collection.itemOrder AS itemOrder
+        `,
+        {
+          collectionId,
+          itemId,
+          username,
+        }
+      );
+
+      if (result.records.length === 0) {
+        throw new GraphQLError("Collection not found, or you do not own this collection.");
+      }
+
+      return true;
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export const reorderCollectionItem = ({ driver }: { driver: Driver }) => {
+  return async (_parent: unknown, args: ReorderArgs, context: GraphQLContext) => {
+    const username = getUsername(context);
+    const { collectionId, itemId, newPosition } = args;
+    const session = getWriteSession(driver);
+
+    try {
+      const result = await session.run(
+        `
+        MATCH (collection:Collection {id: $collectionId})-[:CREATED_BY]->(:User {username: $username})
+        OPTIONAL MATCH (collection)-[:CONTAINS_DISCUSSION|CONTAINS_COMMENT|CONTAINS_DOWNLOAD|CONTAINS_IMAGE|CONTAINS_CHANNEL]->(item)
+        WITH collection, collect(coalesce(item.id, item.uniqueName)) AS itemIds
+        WITH collection, itemIds,
+          [id IN coalesce(collection.itemOrder, []) WHERE id IN itemIds] +
+          [id IN itemIds WHERE NOT id IN coalesce(collection.itemOrder, [])] AS normalizedOrder
+        WITH collection, itemIds, normalizedOrder
+        WHERE $itemId IN itemIds
+        WITH collection, [id IN normalizedOrder WHERE id <> $itemId] AS withoutItem
+        WITH collection, withoutItem,
+          CASE
+            WHEN $newPosition < 0 THEN 0
+            WHEN $newPosition > size(withoutItem) THEN size(withoutItem)
+            ELSE $newPosition
+          END AS targetPosition
+        SET collection.itemOrder = withoutItem[0..targetPosition] + [$itemId] + withoutItem[targetPosition..]
+        RETURN collection.itemOrder AS itemOrder
+        `,
+        {
+          collectionId,
+          itemId,
+          newPosition,
+          username,
+        }
+      );
+
+      if (result.records.length === 0) {
+        throw new GraphQLError("Item is not in this collection, or you do not own this collection.");
+      }
+
+      return true;
+    } finally {
+      await session.close();
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- implement custom add/remove/reorder collection mutations with owner checks
- keep itemOrder deduplicated, prune removed IDs, and normalize stale stored order during reorder
- add focused node:test coverage for ordering behavior and auth requirements

## Tests
- node --loader ts-node/esm --test customResolvers/mutations/collectionOrdering.test.ts
- npm run codegen
- npm run tsc