### PR TITLE
Share public collections as discussions

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -102,6 +102,7 @@ import {
   removeFromCollection,
   reorderCollectionItem,
 } from "./mutations/collectionOrdering.js";
+import shareCollectionAsDiscussion from "./mutations/shareCollectionAsDiscussion.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -565,6 +566,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       driver
     }),
     reorderCollectionItem: reorderCollectionItem({
+      driver
+    }),
+    shareCollectionAsDiscussion: shareCollectionAsDiscussion({
+      Discussion,
+      Collection,
+      Channel,
       driver
     }),
     updateDownloadLabels: updateDownloadLabels({

--- a/customResolvers/mutations/shareCollectionAsDiscussion.test.ts
+++ b/customResolvers/mutations/shareCollectionAsDiscussion.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test, { afterEach, beforeEach } from "node:test";
+import jwt from "jsonwebtoken";
+import type { Driver } from "neo4j-driver";
+import type {
+  ChannelModel,
+  CollectionModel,
+  DiscussionModel,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import shareCollectionAsDiscussion from "./shareCollectionAsDiscussion.js";
+
+let originalMockAuth: string | undefined;
+
+class CollectionModelStub {
+  constructor(private readonly records: Array<Record<string, unknown>>) {}
+  findCalls: Array<Record<string, unknown>> = [];
+
+  async find(args: Record<string, unknown>) {
+    this.findCalls.push(args);
+    return this.records;
+  }
+}
+
+class ChannelModelStub {
+  constructor(private readonly records: Array<Record<string, unknown>>) {}
+  findCalls: Array<Record<string, unknown>> = [];
+
+  async find(args: Record<string, unknown>) {
+    this.findCalls.push(args);
+    return this.records;
+  }
+}
+
+const buildContext = (username = "alice") =>
+  ({
+    req: {
+      headers: {
+        authorization: `Bearer ${jwt.sign(
+          {
+            email: `${username}@example.com`,
+            username,
+          },
+          "test-secret"
+        )}`,
+      },
+    },
+    ogm: {
+      model: (name: string) => {
+        if (name === "User") {
+          return {
+            find: async () => [{ username, ModerationProfile: null }],
+          };
+        }
+        throw new Error(`Unexpected model lookup: ${name}`);
+      },
+    },
+  }) as unknown as GraphQLContext;
+
+const publicCollection = {
+  id: "collection-1",
+  name: "Builds I love",
+  visibility: "PUBLIC",
+  CreatedBy: { username: "alice" },
+};
+
+const buildResolver = ({
+  collectionRecords = [publicCollection],
+  channelRecords = [{ uniqueName: "sims4_builds" }],
+  permissionResult = true,
+  createDiscussions,
+}: {
+  collectionRecords?: Array<Record<string, unknown>>;
+  channelRecords?: Array<Record<string, unknown>>;
+  permissionResult?: true | Error;
+  createDiscussions?: NonNullable<
+    Parameters<typeof shareCollectionAsDiscussion>[0]["createDiscussions"]
+  >;
+} = {}) => {
+  const Collection = new CollectionModelStub(collectionRecords);
+  const Channel = new ChannelModelStub(channelRecords);
+  const calls = {
+    permissions: [] as unknown[],
+    createDiscussions: [] as unknown[],
+  };
+  const create =
+    createDiscussions ??
+    (async (...args: unknown[]) => {
+      calls.createDiscussions.push(args);
+      return [{ id: "discussion-1", title: "Shared builds" }];
+    });
+
+  const resolver = shareCollectionAsDiscussion({
+    Discussion: {} as DiscussionModel,
+    Collection: Collection as unknown as CollectionModel,
+    Channel: Channel as unknown as ChannelModel,
+    driver: {} as Driver,
+    checkChannelPermissions: async (args) => {
+      calls.permissions.push(args);
+      return permissionResult;
+    },
+    createDiscussions: create,
+  });
+
+  return { resolver, calls, Collection, Channel };
+};
+
+beforeEach(() => {
+  originalMockAuth = process.env.E2E_MOCK_AUTH;
+  process.env.E2E_MOCK_AUTH = "true";
+});
+
+afterEach(() => {
+  if (originalMockAuth === undefined) {
+    delete process.env.E2E_MOCK_AUTH;
+  } else {
+    process.env.E2E_MOCK_AUTH = originalMockAuth;
+  }
+});
+
+test("shareCollectionAsDiscussion creates a discussion linked to a public owned collection", async () => {
+  const { resolver, calls } = buildResolver();
+
+  const result = await resolver(
+    null,
+    {
+      collectionId: "collection-1",
+      serverId: "sims4_builds",
+      title: "Shared builds",
+      shareMessage: "Some favorites from my library",
+    },
+    buildContext(),
+    {} as never
+  );
+
+  assert.deepEqual(result, { id: "discussion-1", title: "Shared builds" });
+  assert.equal(calls.permissions.length, 1);
+  assert.deepEqual((calls.permissions[0] as any).channelConnections, [
+    "sims4_builds",
+  ]);
+  assert.equal((calls.permissions[0] as any).permissionCheck, "canCreateDiscussion");
+
+  const createInput = (calls.createDiscussions[0] as any)[2][0];
+  assert.deepEqual(createInput.channelConnections, ["sims4_builds"]);
+  assert.equal(createInput.discussionCreateInput.title, "Shared builds");
+  assert.equal(createInput.discussionCreateInput.body, "Some favorites from my library");
+  assert.deepEqual(
+    createInput.discussionCreateInput.SharedCollection.connect.where.node,
+    { id: "collection-1" }
+  );
+  assert.deepEqual(createInput.discussionCreateInput.Author.connect.where.node, {
+    username: "alice",
+  });
+});
+
+test("shareCollectionAsDiscussion rejects private collections", async () => {
+  const { resolver } = buildResolver({
+    collectionRecords: [
+      {
+        ...publicCollection,
+        visibility: "PRIVATE",
+      },
+    ],
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        serverId: "sims4_builds",
+        title: "Shared builds",
+      },
+      buildContext(),
+      {} as never
+    ),
+    /Only public collections can be shared/
+  );
+});
+
+test("shareCollectionAsDiscussion rejects non-owners", async () => {
+  const { resolver } = buildResolver({
+    collectionRecords: [],
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        serverId: "sims4_builds",
+        title: "Shared builds",
+      },
+      buildContext(),
+      {} as never
+    ),
+    /Collection not found/
+  );
+});
+
+test("shareCollectionAsDiscussion rejects missing forum posting permission", async () => {
+  const { resolver } = buildResolver({
+    permissionResult: new Error("You do not have permission to post there."),
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        serverId: "sims4_builds",
+        title: "Shared builds",
+      },
+      buildContext(),
+      {} as never
+    ),
+    /permission to post/
+  );
+});
+
+test("shareCollectionAsDiscussion rejects unknown target forums", async () => {
+  const { resolver } = buildResolver({
+    channelRecords: [],
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        serverId: "missing_forum",
+        title: "Shared builds",
+      },
+      buildContext(),
+      {} as never
+    ),
+    /Forum not found/
+  );
+});

--- a/customResolvers/mutations/shareCollectionAsDiscussion.ts
+++ b/customResolvers/mutations/shareCollectionAsDiscussion.ts
@@ -1,0 +1,196 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLResolveInfo } from "graphql";
+import type {
+  ChannelModel,
+  CollectionModel,
+  DiscussionModel,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import {
+  checkChannelPermissions as defaultCheckChannelPermissions,
+} from "../../rules/permission/hasChannelPermission.js";
+import { createDiscussionsFromInput } from "./createDiscussionWithChannelConnections.js";
+import { logger } from "../../logger.js";
+
+type Args = {
+  collectionId: string;
+  serverId: string;
+  title: string;
+  content?: string | null;
+  shareMessage?: string | null;
+};
+
+type CollectionRecord = {
+  id: string;
+  name: string;
+  description?: string | null;
+  visibility: string;
+  CreatedBy?: {
+    username?: string | null;
+  } | null;
+};
+
+type ChannelRecord = {
+  uniqueName: string;
+};
+
+type CheckChannelPermissions = typeof defaultCheckChannelPermissions;
+
+type CreateDiscussions = typeof createDiscussionsFromInput;
+
+type Input = {
+  Discussion: DiscussionModel;
+  Collection: CollectionModel;
+  Channel: ChannelModel;
+  driver: Driver;
+  checkChannelPermissions?: CheckChannelPermissions;
+  createDiscussions?: CreateDiscussions;
+};
+
+const collectionSelectionSet = `
+  {
+    id
+    name
+    description
+    visibility
+    CreatedBy {
+      username
+    }
+  }
+`;
+
+const channelSelectionSet = `
+  {
+    uniqueName
+  }
+`;
+
+const getTrimmed = (value: string | null | undefined) => value?.trim() || "";
+
+const getResolver = (input: Input) => {
+  const {
+    Discussion,
+    Collection,
+    Channel,
+    driver,
+    checkChannelPermissions = defaultCheckChannelPermissions,
+    createDiscussions = createDiscussionsFromInput,
+  } = input;
+
+  return async (
+    _parent: unknown,
+    args: Args,
+    context: GraphQLContext,
+    _info: GraphQLResolveInfo
+  ) => {
+    const collectionId = getTrimmed(args.collectionId);
+    const channelUniqueName = getTrimmed(args.serverId);
+    const title = getTrimmed(args.title);
+    const body = getTrimmed(args.shareMessage) || getTrimmed(args.content);
+
+    if (!collectionId) {
+      throw new GraphQLError("Collection ID is required.");
+    }
+    if (!channelUniqueName) {
+      throw new GraphQLError("Forum is required.");
+    }
+    if (!title) {
+      throw new GraphQLError("Discussion title is required.");
+    }
+
+    context.user = await setUserDataOnContext({
+      context,
+    });
+
+    const username = context.user?.username;
+    if (!username) {
+      throw new GraphQLError("You must be logged in to share a collection.");
+    }
+
+    const collections = (await Collection.find({
+      where: {
+        id: collectionId,
+        CreatedBy: {
+          username,
+        },
+      },
+      selectionSet: collectionSelectionSet,
+    })) as CollectionRecord[];
+
+    const collection = collections[0];
+    if (!collection) {
+      throw new GraphQLError("Collection not found, or you do not own this collection.");
+    }
+
+    if (collection.visibility !== "PUBLIC") {
+      throw new GraphQLError("Only public collections can be shared to a forum discussion.");
+    }
+
+    const channels = (await Channel.find({
+      where: {
+        uniqueName: channelUniqueName,
+      },
+      selectionSet: channelSelectionSet,
+    })) as ChannelRecord[];
+
+    if (channels.length === 0) {
+      throw new GraphQLError("Forum not found.");
+    }
+
+    const permissionResult = await checkChannelPermissions({
+      channelConnections: [channelUniqueName],
+      context,
+      permissionCheck: "canCreateDiscussion",
+    });
+
+    if (permissionResult instanceof Error) {
+      throw new GraphQLError(permissionResult.message);
+    }
+
+    try {
+      const discussions = await createDiscussions(
+        Discussion,
+        driver,
+        [
+          {
+            discussionCreateInput: {
+              title,
+              body,
+              hasDownload: false,
+              Author: {
+                connect: {
+                  where: {
+                    node: {
+                      username,
+                    },
+                  },
+                },
+              },
+              SharedCollection: {
+                connect: {
+                  where: {
+                    node: {
+                      id: collectionId,
+                    },
+                  },
+                },
+              },
+            },
+            channelConnections: [channelUniqueName],
+          },
+        ],
+        context
+      );
+
+      return discussions[0];
+    } catch (error: unknown) {
+      logger.error("Error sharing collection as discussion:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new GraphQLError(`Failed to share collection: ${message}`);
+    }
+  };
+};
+
+export default getResolver;


### PR DESCRIPTION
## Summary
- implement shareCollectionAsDiscussion for public owned collections
- enforce collection ownership, public visibility, target forum existence, and canCreateDiscussion permission
- create a normal forum discussion linked to the shared collection
- add focused resolver tests for allowed, private, non-owner, missing permission, and unknown forum cases

## Tests
- node --loader ts-node/esm --test customResolvers/mutations/shareCollectionAsDiscussion.test.ts
- npm run codegen
- npm run tsc