### PR TITLE
[codex] Support images in multiple albums

### DIFF
--- a/customResolvers/mutations/createImageWithUploader.test.ts
+++ b/customResolvers/mutations/createImageWithUploader.test.ts
@@ -277,7 +277,7 @@ test("createImageWithUploader connects to album when albumId provided", async ()
           id: "img-1",
           url: "https://example.com/image.jpg",
           Uploader: { username: "user" },
-          Album: { id: "album-123" },
+          Albums: [{ id: "album-123" }],
         },
       ],
     })
@@ -303,14 +303,16 @@ test("createImageWithUploader connects to album when albumId provided", async ()
 
   const createInput = Image.createCalls[0].input[0];
 
-  assert.deepEqual(createInput.Album, {
-    connect: {
-      where: {
-        node: {
-          id: "album-123",
+  assert.deepEqual(createInput.Albums, {
+    connect: [
+      {
+        where: {
+          node: {
+            id: "album-123",
+          },
         },
       },
-    },
+    ],
   });
 });
 
@@ -323,7 +325,7 @@ test("createImageWithUploader does not connect album when albumId not provided",
           id: "img-1",
           url: "https://example.com/image.jpg",
           Uploader: { username: "user" },
-          Album: null,
+          Albums: [],
         },
       ],
     })
@@ -349,7 +351,7 @@ test("createImageWithUploader does not connect album when albumId not provided",
 
   const createInput = Image.createCalls[0].input[0];
 
-  assert.equal(createInput.Album, undefined);
+  assert.equal(createInput.Albums, undefined);
 });
 
 test("createImageWithUploader handles empty string albumId as no album", async () => {
@@ -386,8 +388,8 @@ test("createImageWithUploader handles empty string albumId as no album", async (
 
   const createInput = Image.createCalls[0].input[0];
 
-  // Empty string is falsy, so Album should not be set
-  assert.equal(createInput.Album, undefined);
+  // Empty string is falsy, so Albums should not be set.
+  assert.equal(createInput.Albums, undefined);
 });
 
 // Response structure tests
@@ -404,7 +406,7 @@ test("createImageWithUploader returns the created image", async () => {
     hasSpoiler: false,
     scanStatus: "pending",
     Uploader: { username: "photographer" },
-    Album: { id: "album-1" },
+    Albums: [{ id: "album-1" }],
   };
 
   const Image = new ModelStub(

--- a/customResolvers/mutations/createImageWithUploader.ts
+++ b/customResolvers/mutations/createImageWithUploader.ts
@@ -54,7 +54,7 @@ const selectionSet = `
     Uploader {
       username
     }
-    Album {
+    Albums {
       id
     }
   }
@@ -128,16 +128,18 @@ const getResolver = (input: Input) => {
       },
     };
 
-    // If an albumId is provided, connect the Album relationship
+    // If an albumId is provided, connect the Albums relationship.
     if (imageInput.albumId) {
-      createInput.Album = {
-        connect: {
-          where: {
-            node: {
-              id: imageInput.albumId,
+      createInput.Albums = {
+        connect: [
+          {
+            where: {
+              node: {
+                id: imageInput.albumId,
+              },
             },
           },
-        },
+        ],
       };
     }
 

--- a/customResolvers/mutations/createImagesWithUploader.ts
+++ b/customResolvers/mutations/createImagesWithUploader.ts
@@ -41,7 +41,7 @@ const selectionSet = `
     Uploader {
       username
     }
-    Album {
+    Albums {
       id
     }
   }

--- a/customResolvers/queries/getImageAlbumUsage.test.ts
+++ b/customResolvers/queries/getImageAlbumUsage.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import getImageAlbumUsage from "./getImageAlbumUsage.js";
+
+const record = (usage: unknown) => ({
+  get: (key: string) => (key === "usage" ? usage : undefined),
+});
+
+const createDriver = (records: unknown[]) => {
+  const runCalls: Array<{ query: string; params: Record<string, unknown> }> = [];
+  let closed = false;
+
+  return {
+    driver: {
+      session: () => ({
+        run: async (query: string, params: Record<string, unknown>) => {
+          runCalls.push({ query, params });
+          return { records };
+        },
+        close: async () => {
+          closed = true;
+        },
+      }),
+    },
+    runCalls,
+    isClosed: () => closed,
+  };
+};
+
+test("getImageAlbumUsage returns grouped uploader and non-uploader albums", async () => {
+  const usage = {
+    imageId: "image-1",
+    uploaderUsername: "alice",
+    uploaderOwnedAlbums: [
+      {
+        id: "album-1",
+        imageOrder: ["image-1"],
+        Owner: { username: "alice", displayName: "Alice" },
+        Discussions: [],
+      },
+    ],
+    otherAlbums: [
+      {
+        id: "album-2",
+        imageOrder: ["image-1"],
+        Owner: { username: "bob", displayName: "Bob" },
+        Discussions: [{ id: "discussion-1", title: "Bob's remix" }],
+      },
+    ],
+  };
+  const { driver, runCalls, isClosed } = createDriver([record(usage)]);
+  const resolver = getImageAlbumUsage({ driver: driver as never });
+
+  const result = await resolver(null, { imageId: "image-1" });
+
+  assert.deepEqual(result, usage);
+  assert.deepEqual(runCalls[0].params, { imageId: "image-1" });
+  assert.equal(isClosed(), true);
+});
+
+test("getImageAlbumUsage throws when the image does not exist", async () => {
+  const { driver, isClosed } = createDriver([]);
+  const resolver = getImageAlbumUsage({ driver: driver as never });
+
+  await assert.rejects(
+    () => resolver(null, { imageId: "missing" }),
+    /Image not found/
+  );
+  assert.equal(isClosed(), true);
+});
+
+test("getImageAlbumUsage rejects missing image id before querying", async () => {
+  const { driver, runCalls } = createDriver([]);
+  const resolver = getImageAlbumUsage({ driver: driver as never });
+
+  await assert.rejects(
+    () => resolver(null, { imageId: "" }),
+    /You must provide an image id/
+  );
+  assert.equal(runCalls.length, 0);
+});

--- a/customResolvers/queries/getImageAlbumUsage.ts
+++ b/customResolvers/queries/getImageAlbumUsage.ts
@@ -1,0 +1,100 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+
+type Input = {
+  driver: Driver;
+};
+
+type Args = {
+  imageId: string;
+};
+
+type AlbumUsage = {
+  imageId: string;
+  uploaderUsername: string | null;
+  uploaderOwnedAlbums: Array<Record<string, unknown>>;
+  otherAlbums: Array<Record<string, unknown>>;
+};
+
+const getImageAlbumUsage = ({ driver }: Input) => {
+  return async (
+    _parent: unknown,
+    args: Args
+  ): Promise<AlbumUsage> => {
+    if (!args.imageId) {
+      throw new GraphQLError("You must provide an image id.");
+    }
+
+    const session = driver.session({ defaultAccessMode: "READ" });
+
+    try {
+      const result = await session.run(
+        `
+        MATCH (image:Image { id: $imageId })
+        WHERE coalesce(image.archived, false) = false
+          AND coalesce(image.permanentlyRemoved, false) = false
+        OPTIONAL MATCH (uploader:User)-[:UPLOADED_IMAGE]->(image)
+        OPTIONAL MATCH (album:Album)-[:HAS_IMAGE]->(image)
+        OPTIONAL MATCH (owner:User)-[:HAS_ALBUM]->(album)
+        OPTIONAL MATCH (album)<-[:HAS_ALBUM]-(discussion:Discussion)
+        OPTIONAL MATCH (author:User)-[:POSTED_DISCUSSION]->(discussion)
+        OPTIONAL MATCH (discussion)-[:POSTED_IN_CHANNEL]->(discussionChannel:DiscussionChannel)
+        WITH image, uploader, album, owner, discussion, author,
+          collect(DISTINCT discussionChannel {
+            .id,
+            .channelUniqueName
+          }) AS discussionChannels
+        WITH image, uploader, album, owner,
+          collect(DISTINCT CASE
+            WHEN discussion IS NULL THEN null
+            ELSE discussion {
+              .id,
+              .title,
+              createdAt: toString(discussion.createdAt),
+              Author: author { .username, .displayName },
+              DiscussionChannels: discussionChannels
+            }
+          END) AS discussions
+        WITH image, uploader,
+          collect(DISTINCT CASE
+            WHEN album IS NULL THEN null
+            ELSE album {
+              .id,
+              imageOrder: album.imageOrder,
+              Owner: owner { .username, .displayName },
+              Discussions: [discussion IN discussions WHERE discussion IS NOT NULL]
+            }
+          END) AS albums
+        WITH image, uploader, [album IN albums WHERE album IS NOT NULL] AS albums
+        RETURN {
+          imageId: image.id,
+          uploaderUsername: uploader.username,
+          uploaderOwnedAlbums: [
+            album IN albums
+            WHERE album.Owner.username = uploader.username
+          ],
+          otherAlbums: [
+            album IN albums
+            WHERE album.Owner.username <> uploader.username
+              OR uploader.username IS NULL
+              OR album.Owner.username IS NULL
+          ]
+        } AS usage
+        `,
+        { imageId: args.imageId }
+      );
+
+      const usage = result.records[0]?.get("usage") as AlbumUsage | undefined;
+
+      if (!usage) {
+        throw new GraphQLError("Image not found.");
+      }
+
+      return usage;
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getImageAlbumUsage;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -24,6 +24,7 @@ import getOwnEmail from "./queries/getOwnEmail.js";
 import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
 import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
+import getImageAlbumUsage from "./queries/getImageAlbumUsage.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -121,6 +122,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
       Email
     }),
     getUploadedDownloadableFiles: getUploadedDownloadableFiles({
+      driver
+    }),
+    getImageAlbumUsage: getImageAlbumUsage({
       driver
     }),
     getServerHealthDashboard: getServerHealthDashboard({

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -98,7 +98,7 @@ const typeDefinitions = gql`
     PermanentlyRemovedByUser: User @relationship(type: "REMOVED_IMAGE", direction: IN)
     PermanentlyRemovedByMod: ModerationProfile @relationship(type: "REMOVED_IMAGE", direction: IN)
 
-    Album:    Album @relationship(type: "HAS_IMAGE", direction: IN)
+    Albums:   [Album!]! @relationship(type: "HAS_IMAGE", direction: IN)
     Uploader: User  @relationship(type: "UPLOADED_IMAGE", direction: IN)
     RelatedIssues: [Issue!]! @relationship(type: "CITED_ISSUE", direction: IN)
 
@@ -2066,12 +2066,26 @@ const typeDefinitions = gql`
     files: [DownloadableFile!]!
   }
 
+  type ImageAlbumUsage @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    imageId: ID!
+    uploaderUsername: String
+    uploaderOwnedAlbums: [Album!]!
+    otherAlbums: [Album!]!
+  }
+
   type Query {
     # Discovery
     """
     Return public collections that include the specified item (e.g. downloads are Discussions with hasDownload=true).
     """
     publicCollectionsContaining(itemId: ID!, itemType: CollectionItemType!): [Collection!]!
+
+    """
+    Return albums that contain an image, grouped by whether the album owner is
+    the original image uploader. Uses the existing HAS_IMAGE relationship, which
+    can support multiple albums per image.
+    """
+    getImageAlbumUsage(imageId: ID!): ImageAlbumUsage!
 
     getDiscussionsInChannel(
       channelUniqueName: String!


### PR DESCRIPTION
## Summary

Adds backend support for images belonging to multiple albums through the existing `HAS_IMAGE` relationship.

## Changes

- Changes `Image.Album` to plural `Image.Albums` in the schema.
- Adds `getImageAlbumUsage(imageId:)`, grouped into albums owned by the image uploader and albums owned by other users.
- Updates image creation resolvers to return/connect `Albums` using the generated plural relationship input shape.
- Adds focused unit tests for grouped album usage and plural album creation behavior.

## Validation

- `node --loader ts-node/esm --test customResolvers/queries/getImageAlbumUsage.test.ts customResolvers/mutations/createImageWithUploader.test.ts`
- `pnpm run tsc`