### PR TITLE
perf(P0-2c): request-cache server-suspension lookups

### DIFF
--- a/rules/permission/activeServerSuspensionTypes.ts
+++ b/rules/permission/activeServerSuspensionTypes.ts
@@ -1,0 +1,11 @@
+import type { Suspension } from "../../ogm_types.js";
+
+export type ActiveServerSuspensionResult = {
+  activeSuspension: Suspension | null;
+  isSuspended: boolean;
+  relatedIssueId: string | null;
+  relatedIssueNumber: number | null;
+  expiredUserSuspensions: Suspension[];
+  expiredModSuspensions: Suspension[];
+  suspendedEntity: "user" | "mod" | null;
+};

--- a/rules/permission/getActiveServerSuspension.test.ts
+++ b/rules/permission/getActiveServerSuspension.test.ts
@@ -34,6 +34,14 @@ const buildDriver = (responses: {
   }),
 });
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 test("returns active server user suspension metadata", async () => {
   const result = await getActiveServerSuspension({
     context: {
@@ -80,4 +88,121 @@ test("returns expired server mod suspensions for cleanup", async () => {
   assert.equal(result.isSuspended, false);
   assert.equal(result.expiredModSuspensions.length, 1);
   assert.equal(result.expiredModSuspensions[0].id, "server-mod-1");
+});
+
+test("memoizes concurrent identical lookups within one request", async () => {
+  const deferred = createDeferred<any>();
+  let userQueryCalls = 0;
+
+  const context = {
+    driver: {
+      session: () => ({
+        run: async (query: string) => {
+          if (!query.includes("MATCH (serverConfig)-[:SUSPENDED_AS_USER]->")) {
+            throw new Error(`Unexpected query: ${query}`);
+          }
+          userQueryCalls += 1;
+          const suspension = await deferred.promise;
+          return {
+            records: [{ get: () => suspension }],
+          };
+        },
+        close: async () => {},
+      }),
+    },
+  } as unknown as GraphQLContext;
+
+  const first = getActiveServerSuspension({ context, username: "alice" });
+  const second = getActiveServerSuspension({ context, username: "alice" });
+
+  assert.equal(userQueryCalls, 1);
+
+  deferred.resolve({
+    id: "server-user-2",
+    username: "alice",
+    serverName: "test-server",
+    suspendedUntil: futureDate(),
+    suspendedIndefinitely: false,
+  });
+
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+  assert.equal(firstResult.activeSuspension?.id, "server-user-2");
+  assert.equal(secondResult.activeSuspension?.id, "server-user-2");
+});
+
+test("does not alias distinct actor tuples in the request cache", async () => {
+  let userQueryCalls = 0;
+  let modQueryCalls = 0;
+  const context = {
+    driver: {
+      session: () => ({
+        run: async (query: string, params: { username?: string; modProfileName?: string }) => {
+          if (query.includes("MATCH (serverConfig)-[:SUSPENDED_AS_USER]->")) {
+            userQueryCalls += 1;
+            return {
+              records: params.username === "alice"
+                ? [{ get: () => ({
+                    id: "user-suspension",
+                    username: "alice",
+                    serverName: "test-server",
+                    suspendedUntil: futureDate(),
+                    suspendedIndefinitely: false,
+                  }) }]
+                : params.username === "alice|mod"
+                  ? [{ get: () => ({
+                      id: "split-user-suspension",
+                      username: "alice|mod",
+                      serverName: "test-server",
+                      suspendedUntil: futureDate(),
+                      suspendedIndefinitely: false,
+                    }) }]
+                : [],
+            };
+          }
+
+          if (query.includes("MATCH (serverConfig)-[:SUSPENDED_AS_MOD]->")) {
+            modQueryCalls += 1;
+            return {
+              records: params.modProfileName === "mod|profile"
+                ? [{ get: () => ({
+                    id: "mod-suspension",
+                    modProfileName: "mod|profile",
+                    serverName: "test-server",
+                    suspendedUntil: futureDate(),
+                    suspendedIndefinitely: false,
+                  }) }]
+                : params.modProfileName === "profile"
+                  ? [{ get: () => ({
+                      id: "split-mod-suspension",
+                      modProfileName: "profile",
+                      serverName: "test-server",
+                      suspendedUntil: futureDate(),
+                      suspendedIndefinitely: false,
+                    }) }]
+                : [],
+            };
+          }
+
+          throw new Error(`Unexpected query: ${query}`);
+        },
+        close: async () => {},
+      }),
+    },
+  } as unknown as GraphQLContext;
+
+  const userResult = await getActiveServerSuspension({
+    context,
+    username: "alice",
+    modProfileName: "mod|profile",
+  });
+  const modResult = await getActiveServerSuspension({
+    context,
+    username: "alice|mod",
+    modProfileName: "profile",
+  });
+
+  assert.equal(userResult.activeSuspension?.id, "user-suspension");
+  assert.equal(modResult.activeSuspension?.id, "split-user-suspension");
+  assert.equal(userQueryCalls, 2);
+  assert.equal(modQueryCalls, 2);
 });

--- a/rules/permission/getActiveServerSuspension.ts
+++ b/rules/permission/getActiveServerSuspension.ts
@@ -8,6 +8,12 @@ type ActiveServerSuspensionInput = {
   modProfileName?: string;
 };
 
+const buildCacheKey = ({
+  username,
+  modProfileName,
+}: Pick<ActiveServerSuspensionInput, "username" | "modProfileName">) =>
+  JSON.stringify([username ?? null, modProfileName ?? null]);
+
 export type ActiveServerSuspensionResult = {
   activeSuspension: Suspension | null;
   isSuspended: boolean;
@@ -208,10 +214,11 @@ export async function getActiveServerSuspension(
   // single request, but this is called by several server-scoped rules
   // (passesAsServerAdminOrRoot, hasServerPermission, hasServerModPermission),
   // each of which otherwise issued its own 1-2 suspension queries. Cache the
-  // promise (keyed by username|modProfileName) so concurrent callers share one
-  // lookup. Never TTL-cached — a new suspension takes effect on the next request.
+  // promise (keyed by the exact [username, modProfileName] tuple) so concurrent
+  // callers share one lookup without aliasing distinct actors. Never TTL-cached
+  // — a new suspension takes effect on the next request.
   const cache = getPermissionRequestCache(context);
-  const cacheKey = `${username ?? ""}|${modProfileName ?? ""}`;
+  const cacheKey = buildCacheKey({ username, modProfileName });
   const cached = cache.activeServerSuspensionByKey.get(cacheKey);
   if (cached) {
     return cached;

--- a/rules/permission/getActiveServerSuspension.ts
+++ b/rules/permission/getActiveServerSuspension.ts
@@ -1,5 +1,6 @@
 import type { Suspension } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import type { ActiveServerSuspensionResult } from "./activeServerSuspensionTypes.js";
 import { getPermissionRequestCache } from "./getPermissionRequestCache.js";
 
 type ActiveServerSuspensionInput = {
@@ -13,16 +14,6 @@ const buildCacheKey = ({
   modProfileName,
 }: Pick<ActiveServerSuspensionInput, "username" | "modProfileName">) =>
   JSON.stringify([username ?? null, modProfileName ?? null]);
-
-export type ActiveServerSuspensionResult = {
-  activeSuspension: Suspension | null;
-  isSuspended: boolean;
-  relatedIssueId: string | null;
-  relatedIssueNumber: number | null;
-  expiredUserSuspensions: Suspension[];
-  expiredModSuspensions: Suspension[];
-  suspendedEntity: "user" | "mod" | null;
-};
 
 const normalizeValue = (value: any): any => {
   if (value == null) return value;

--- a/rules/permission/getActiveServerSuspension.ts
+++ b/rules/permission/getActiveServerSuspension.ts
@@ -1,5 +1,6 @@
 import type { Suspension } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { getPermissionRequestCache } from "./getPermissionRequestCache.js";
 
 type ActiveServerSuspensionInput = {
   context: GraphQLContext;
@@ -7,7 +8,7 @@ type ActiveServerSuspensionInput = {
   modProfileName?: string;
 };
 
-type ActiveServerSuspensionResult = {
+export type ActiveServerSuspensionResult = {
   activeSuspension: Suspension | null;
   isSuspended: boolean;
   relatedIssueId: string | null;
@@ -141,14 +142,10 @@ async function fetchTargetedServerSuspensions(params: {
   }
 }
 
-export async function getActiveServerSuspension(
+async function computeActiveServerSuspension(
   input: ActiveServerSuspensionInput
 ): Promise<ActiveServerSuspensionResult> {
   const { context, username, modProfileName } = input;
-
-  if (!username && !modProfileName) {
-    throw new Error("Must provide a username or modProfileName to check server suspension.");
-  }
 
   const now = new Date();
   const expiredUserSuspensions: Suspension[] = [];
@@ -194,4 +191,33 @@ export async function getActiveServerSuspension(
     expiredModSuspensions,
     suspendedEntity,
   };
+}
+
+export async function getActiveServerSuspension(
+  input: ActiveServerSuspensionInput
+): Promise<ActiveServerSuspensionResult> {
+  const { context, username, modProfileName } = input;
+
+  if (!username && !modProfileName) {
+    throw new Error(
+      "Must provide a username or modProfileName to check server suspension."
+    );
+  }
+
+  // Request-scoped memoization: a user's server suspension is stable within a
+  // single request, but this is called by several server-scoped rules
+  // (passesAsServerAdminOrRoot, hasServerPermission, hasServerModPermission),
+  // each of which otherwise issued its own 1-2 suspension queries. Cache the
+  // promise (keyed by username|modProfileName) so concurrent callers share one
+  // lookup. Never TTL-cached — a new suspension takes effect on the next request.
+  const cache = getPermissionRequestCache(context);
+  const cacheKey = `${username ?? ""}|${modProfileName ?? ""}`;
+  const cached = cache.activeServerSuspensionByKey.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = computeActiveServerSuspension(input);
+  cache.activeServerSuspensionByKey.set(cacheKey, promise);
+  return promise;
 }

--- a/rules/permission/getPermissionRequestCache.ts
+++ b/rules/permission/getPermissionRequestCache.ts
@@ -1,10 +1,13 @@
 import type { GraphQLContext } from "../../types/context.js";
+import type { ActiveServerSuspensionResult } from "./getActiveServerSuspension.js";
 
 type PermissionRequestCache = {
   // Holds the cached ServerConfig lookup. Kept as `any` because downstream
   // permission checks read many dynamically-selected fields off the result.
   serverConfigPromise?: Promise<any>;
-  activeServerSuspensionByUsername: Map<string, Promise<boolean>>;
+  // Memoized server-suspension lookups, keyed by `username|modProfileName`
+  // (see getActiveServerSuspension). Request-scoped only.
+  activeServerSuspensionByKey: Map<string, Promise<ActiveServerSuspensionResult>>;
 };
 
 type ContextWithPermissionCache = GraphQLContext & {
@@ -16,7 +19,7 @@ export const getPermissionRequestCache = (
 ): PermissionRequestCache => {
   if (!context.__permissionRequestCache) {
     context.__permissionRequestCache = {
-      activeServerSuspensionByUsername: new Map(),
+      activeServerSuspensionByKey: new Map(),
     };
   }
 

--- a/rules/permission/getPermissionRequestCache.ts
+++ b/rules/permission/getPermissionRequestCache.ts
@@ -1,5 +1,5 @@
 import type { GraphQLContext } from "../../types/context.js";
-import type { ActiveServerSuspensionResult } from "./getActiveServerSuspension.js";
+import type { ActiveServerSuspensionResult } from "./activeServerSuspensionTypes.js";
 
 type PermissionRequestCache = {
   // Holds the cached ServerConfig lookup. Kept as `any` because downstream

--- a/rules/permission/getPermissionRequestCache.ts
+++ b/rules/permission/getPermissionRequestCache.ts
@@ -5,8 +5,9 @@ type PermissionRequestCache = {
   // Holds the cached ServerConfig lookup. Kept as `any` because downstream
   // permission checks read many dynamically-selected fields off the result.
   serverConfigPromise?: Promise<any>;
-  // Memoized server-suspension lookups, keyed by `username|modProfileName`
-  // (see getActiveServerSuspension). Request-scoped only.
+  // Memoized server-suspension lookups, keyed by the exact
+  // `[username, modProfileName]` tuple (see getActiveServerSuspension).
+  // Request-scoped only.
   activeServerSuspensionByKey: Map<string, Promise<ActiveServerSuspensionResult>>;
 };
 

--- a/rules/permission/hasServerPermission.test.ts
+++ b/rules/permission/hasServerPermission.test.ts
@@ -190,11 +190,14 @@ async function testHasServerPermissionCachesRequestLookups() {
   await hasServerPermission("canCreateChannel", context as unknown as GraphQLContext);
   await hasServerPermission("canCreateChannel", context as unknown as GraphQLContext);
 
+  // Both the ServerConfig lookup and the server-suspension lookup are memoized
+  // on the per-request permission cache, so calling the rule twice within one
+  // request issues each underlying query exactly once.
   assert.deepEqual({
     suspensionQueryCalls,
     serverConfigFindCalls,
   }, {
-    suspensionQueryCalls: 2,
+    suspensionQueryCalls: 1,
     serverConfigFindCalls: 1,
   });
 }


### PR DESCRIPTION
## Purpose

Completes the auth hot-path work (P0-2c). `getActiveServerSuspension` issued 1–2 Cypher queries per call and is invoked by several server-scoped rules (`passesAsServerAdminOrRoot`, `hasServerPermission`, `hasServerModPermission`), so one request re-ran the same suspension lookup multiple times.

> **Stacked on [PR #130](https://github.com/gennit-project/multiforum-backend/pull/130)** (the P0 auth changes it builds on). Review/merge #130 first.

## Change
- Wire up the previously-declared-but-unused request cache: memoize the lookup **promise** keyed by `username|modProfileName` on the per-request permission cache. (Renamed `activeServerSuspensionByUsername` → `activeServerSuspensionByKey` and corrected its value type from the leftover `Promise<boolean>` to the actual result.)
- Split the heavy computation into `computeActiveServerSuspension`; `getActiveServerSuspension` is now a thin caching wrapper (promise-caching also dedups concurrent callers).

## Safety
- **Strictly request-scoped** (on `context.__permissionRequestCache`, never TTL) — a new/lifted suspension still takes effect on the next request, no auth staleness. Per-request `context` can't bleed across users.
- A single `now` snapshot per request also makes suspension evaluation consistent across a request's rules.

## Verified
- `pnpm run tsc` clean, `pnpm run lint` clean, **212 permission unit tests pass**.
- **29 suspension integration tests pass** against real Neo4j (`suspension`, `suspensionEnforcement`, `serverSuspension`, `modSuspensionEnforcement`).
- The `hasServerPermission` caching test asserted the old un-cached count (`suspensionQueryCalls: 2` across two rule invocations); it's now `1`, making it a regression guard for this cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)