### PR TITLE
[codex] Add album image reuse mutations

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -102,6 +102,10 @@ import {
   removeFromCollection,
   reorderCollectionItem,
 } from "./mutations/collectionOrdering.js";
+import {
+  addImageToAlbum,
+  removeImageFromAlbum,
+} from "./mutations/albumImageReuse.js";
 import shareCollectionAsDiscussion from "./mutations/shareCollectionAsDiscussion.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
@@ -566,6 +570,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       driver
     }),
     reorderCollectionItem: reorderCollectionItem({
+      driver
+    }),
+    addImageToAlbum: addImageToAlbum({
+      driver
+    }),
+    removeImageFromAlbum: removeImageFromAlbum({
       driver
     }),
     shareCollectionAsDiscussion: shareCollectionAsDiscussion({

--- a/customResolvers/mutations/albumImageReuse.test.ts
+++ b/customResolvers/mutations/albumImageReuse.test.ts
@@ -1,0 +1,222 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  addImageToAlbum,
+  removeImageFromAlbum,
+} from "./albumImageReuse.js";
+
+process.env.PLAYWRIGHT_MOCK_AUTH = "true";
+
+const statusRecord = (status: string) => ({
+  get: (key: string) => (key === "status" ? status : undefined),
+});
+
+const createDriver = (records: unknown[]) => {
+  const runCalls: Array<{ query: string; params: Record<string, unknown> }> = [];
+  const sessionCalls: Array<Record<string, unknown> | undefined> = [];
+  let closed = false;
+
+  return {
+    driver: {
+      session: (options?: Record<string, unknown>) => {
+        sessionCalls.push(options);
+        return {
+          run: async (query: string, params: Record<string, unknown>) => {
+            runCalls.push({ query, params });
+            return { records };
+          },
+          close: async () => {
+            closed = true;
+          },
+        };
+      },
+    },
+    runCalls,
+    sessionCalls,
+    isClosed: () => closed,
+  };
+};
+
+const createMockContext = (username: string | null = null) =>
+  ({
+    req: {
+      headers: username
+        ? {
+            authorization: `Bearer ${jwt.sign(
+              { email: `${username}@example.com`, username },
+              "test-secret"
+            )}`,
+          }
+        : {},
+    },
+    ogm: {
+      model: (name: string) => {
+        if (name === "User") {
+          return {
+            find: async () => [
+              {
+                ModerationProfile: {
+                  displayName: username ? `mod-${username}` : null,
+                },
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected model lookup: ${name}`);
+      },
+    },
+  } as unknown as GraphQLContext);
+
+test("addImageToAlbum connects an active image to an owned album", async () => {
+  const { driver, runCalls, sessionCalls, isClosed } = createDriver([
+    statusRecord("OK"),
+  ]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  const result = await resolver(
+    null,
+    { albumId: "album-1", imageId: "image-1", position: 1 },
+    createMockContext("alice")
+  );
+
+  assert.equal(result, true);
+  assert.deepEqual(runCalls[0].params, {
+    albumId: "album-1",
+    imageId: "image-1",
+    position: 1,
+    username: "alice",
+  });
+  assert.match(runCalls[0].query, /coalesce\(image\.archived, false\)/);
+  assert.match(runCalls[0].query, /MERGE \(album\)-\[:HAS_IMAGE\]->\(image\)/);
+  assert.deepEqual(sessionCalls[0], { defaultAccessMode: "WRITE" });
+  assert.equal(isClosed(), true);
+});
+
+test("addImageToAlbum appends when position is omitted", async () => {
+  const { driver, runCalls } = createDriver([statusRecord("OK")]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  await resolver(
+    null,
+    { albumId: "album-1", imageId: "image-1" },
+    createMockContext("alice")
+  );
+
+  assert.equal(runCalls[0].params.position, null);
+});
+
+test("addImageToAlbum rejects non-owner album updates", async () => {
+  const { driver, isClosed } = createDriver([statusRecord("NOT_OWNER")]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "album-1", imageId: "image-1" },
+        createMockContext("mallory")
+      ),
+    /You must be the owner of this album/
+  );
+  assert.equal(isClosed(), true);
+});
+
+test("addImageToAlbum rejects duplicate membership", async () => {
+  const { driver } = createDriver([statusRecord("ALREADY_IN_ALBUM")]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "album-1", imageId: "image-1" },
+        createMockContext("alice")
+      ),
+    /Image is already in this album/
+  );
+});
+
+test("addImageToAlbum rejects archived or missing images", async () => {
+  const { driver } = createDriver([statusRecord("IMAGE_NOT_FOUND")]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "album-1", imageId: "image-1" },
+        createMockContext("alice")
+      ),
+    /Image not found/
+  );
+});
+
+test("addImageToAlbum rejects missing auth before querying", async () => {
+  const { driver, runCalls } = createDriver([]);
+  const resolver = addImageToAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "album-1", imageId: "image-1" },
+        createMockContext(null)
+      ),
+    /You must be logged in to update albums/
+  );
+  assert.equal(runCalls.length, 0);
+});
+
+test("removeImageFromAlbum disconnects an image and prunes imageOrder", async () => {
+  const { driver, runCalls, isClosed } = createDriver([statusRecord("OK")]);
+  const resolver = removeImageFromAlbum({ driver: driver as never });
+
+  const result = await resolver(
+    null,
+    { albumId: "album-1", imageId: "image-1" },
+    createMockContext("alice")
+  );
+
+  assert.equal(result, true);
+  assert.deepEqual(runCalls[0].params, {
+    albumId: "album-1",
+    imageId: "image-1",
+    username: "alice",
+  });
+  assert.match(runCalls[0].query, /DELETE relationship/);
+  assert.match(runCalls[0].query, /SET album\.imageOrder/);
+  assert.equal(isClosed(), true);
+});
+
+test("removeImageFromAlbum rejects non-owner album updates", async () => {
+  const { driver } = createDriver([statusRecord("NOT_OWNER")]);
+  const resolver = removeImageFromAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "album-1", imageId: "image-1" },
+        createMockContext("mallory")
+      ),
+    /You must be the owner of this album/
+  );
+});
+
+test("removeImageFromAlbum validates ids before querying", async () => {
+  const { driver, runCalls } = createDriver([]);
+  const resolver = removeImageFromAlbum({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { albumId: "", imageId: "image-1" },
+        createMockContext("alice")
+      ),
+    /You must provide an album id/
+  );
+  assert.equal(runCalls.length, 0);
+});

--- a/customResolvers/mutations/albumImageReuse.ts
+++ b/customResolvers/mutations/albumImageReuse.ts
@@ -1,0 +1,174 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import type { GraphQLContext } from "../../types/context.js";
+
+type AddArgs = {
+  albumId: string;
+  imageId: string;
+  position?: number | null;
+};
+
+type RemoveArgs = {
+  albumId: string;
+  imageId: string;
+};
+
+const getUsername = async (context: GraphQLContext) => {
+  context.user = await setUserDataOnContext({ context });
+  const username = context.user?.username;
+
+  if (!username) {
+    throw new GraphQLError("You must be logged in to update albums.");
+  }
+
+  return username;
+};
+
+const validateIds = ({ albumId, imageId }: RemoveArgs) => {
+  if (!albumId) {
+    throw new GraphQLError(ERROR_MESSAGES.album.noId);
+  }
+
+  if (!imageId) {
+    throw new GraphQLError(ERROR_MESSAGES.image.noId);
+  }
+};
+
+const getWriteSession = (driver: Driver) =>
+  driver.session({ defaultAccessMode: "WRITE" });
+
+export const addImageToAlbum = ({ driver }: { driver: Driver }) => {
+  return async (_parent: unknown, args: AddArgs, context: GraphQLContext) => {
+    validateIds(args);
+    const username = await getUsername(context);
+    const session = getWriteSession(driver);
+
+    try {
+      const result = await session.run(
+        `
+        OPTIONAL MATCH (album:Album { id: $albumId })
+        OPTIONAL MATCH (owner:User { username: $username })-[:HAS_ALBUM]->(album)
+        OPTIONAL MATCH (image:Image { id: $imageId })
+        WITH album, owner, image
+        OPTIONAL MATCH (album)-[existing:HAS_IMAGE]->(image)
+        WITH album, owner, image, existing,
+          CASE
+            WHEN album IS NULL THEN "ALBUM_NOT_FOUND"
+            WHEN owner IS NULL THEN "NOT_OWNER"
+            WHEN image IS NULL
+              OR coalesce(image.archived, false) = true
+              OR coalesce(image.permanentlyRemoved, false) = true
+              THEN "IMAGE_NOT_FOUND"
+            WHEN existing IS NOT NULL THEN "ALREADY_IN_ALBUM"
+            ELSE "OK"
+          END AS status
+        FOREACH (_ IN CASE WHEN status = "OK" THEN [1] ELSE [] END |
+          MERGE (album)-[:HAS_IMAGE]->(image)
+        )
+        WITH album, image, status,
+          [id IN coalesce(album.imageOrder, []) WHERE id <> $imageId] AS withoutImage
+        WITH album, image, status, withoutImage,
+          CASE
+            WHEN status <> "OK" THEN coalesce(album.imageOrder, [])
+            WHEN $position IS NULL OR $position < 0 OR $position >= size(withoutImage)
+              THEN withoutImage + [$imageId]
+            ELSE withoutImage[0..$position] + [$imageId] + withoutImage[$position..]
+          END AS nextOrder
+        FOREACH (_ IN CASE WHEN status = "OK" THEN [1] ELSE [] END |
+          SET album.imageOrder = nextOrder
+        )
+        RETURN status
+        `,
+        {
+          albumId: args.albumId,
+          imageId: args.imageId,
+          position: args.position ?? null,
+          username,
+        }
+      );
+
+      const status = result.records[0]?.get("status");
+
+      if (status === "OK") {
+        return true;
+      }
+
+      if (status === "ALBUM_NOT_FOUND") {
+        throw new GraphQLError(ERROR_MESSAGES.album.notFound);
+      }
+
+      if (status === "NOT_OWNER") {
+        throw new GraphQLError(ERROR_MESSAGES.album.notOwner);
+      }
+
+      if (status === "IMAGE_NOT_FOUND") {
+        throw new GraphQLError(ERROR_MESSAGES.image.notFound);
+      }
+
+      if (status === "ALREADY_IN_ALBUM") {
+        throw new GraphQLError("Image is already in this album.");
+      }
+
+      throw new GraphQLError("Could not add image to album.");
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export const removeImageFromAlbum = ({ driver }: { driver: Driver }) => {
+  return async (_parent: unknown, args: RemoveArgs, context: GraphQLContext) => {
+    validateIds(args);
+    const username = await getUsername(context);
+    const session = getWriteSession(driver);
+
+    try {
+      const result = await session.run(
+        `
+        OPTIONAL MATCH (album:Album { id: $albumId })
+        OPTIONAL MATCH (owner:User { username: $username })-[:HAS_ALBUM]->(album)
+        WITH album, owner
+        OPTIONAL MATCH (album)-[relationship:HAS_IMAGE]->(:Image { id: $imageId })
+        WITH album, owner, relationship,
+          CASE
+            WHEN album IS NULL THEN "ALBUM_NOT_FOUND"
+            WHEN owner IS NULL THEN "NOT_OWNER"
+            ELSE "OK"
+          END AS status
+        FOREACH (_ IN CASE WHEN status = "OK" AND relationship IS NOT NULL THEN [1] ELSE [] END |
+          DELETE relationship
+        )
+        FOREACH (_ IN CASE WHEN status = "OK" THEN [1] ELSE [] END |
+          SET album.imageOrder = [id IN coalesce(album.imageOrder, []) WHERE id <> $imageId]
+        )
+        RETURN status
+        `,
+        {
+          albumId: args.albumId,
+          imageId: args.imageId,
+          username,
+        }
+      );
+
+      const status = result.records[0]?.get("status");
+
+      if (status === "OK") {
+        return true;
+      }
+
+      if (status === "ALBUM_NOT_FOUND") {
+        throw new GraphQLError(ERROR_MESSAGES.album.notFound);
+      }
+
+      if (status === "NOT_OWNER") {
+        throw new GraphQLError(ERROR_MESSAGES.album.notOwner);
+      }
+
+      throw new GraphQLError("Could not remove image from album.");
+    } finally {
+      await session.close();
+    }
+  };
+};

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1059,6 +1059,10 @@ const typeDefinitions = gql`
     removeFromCollection(collectionId: ID!, itemId: ID!, itemType: CollectionItemType!): Boolean!
     reorderCollectionItem(collectionId: ID!, itemId: ID!, newPosition: Int!): Boolean!
 
+    # Album reuse custom mutations
+    addImageToAlbum(albumId: ID!, imageId: ID!, position: Int): Boolean!
+    removeImageFromAlbum(albumId: ID!, imageId: ID!): Boolean!
+
     # Share collection as discussion
     shareCollectionAsDiscussion(
       collectionId: ID!,


### PR DESCRIPTION
## Summary

- Add `addImageToAlbum` and `removeImageFromAlbum` mutations for linking existing image nodes into albums without re-uploading.
- Enforce logged-in album ownership for add/remove while allowing active, non-permanently-removed images to be reused.
- Keep attribution intact by reusing the same `Image` node and maintaining album `imageOrder` on add/remove.

## Verification

- `node --loader ts-node/esm --test customResolvers/mutations/albumImageReuse.test.ts`
- `npx pnpm@10.28.2 run tsc`