### PR TITLE
Add wiki page sidebar pin mutations

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -107,6 +107,10 @@ import {
   removeImageFromAlbum,
 } from "./mutations/albumImageReuse.js";
 import shareCollectionAsDiscussion from "./mutations/shareCollectionAsDiscussion.js";
+import {
+  pinWikiPageToChannel,
+  unpinWikiPageFromChannel,
+} from "./mutations/wikiPagePins.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -583,6 +587,16 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       Collection,
       Channel,
       driver
+    }),
+    pinWikiPageToChannel: pinWikiPageToChannel({
+      driver,
+      Channel,
+      WikiPage,
+    }),
+    unpinWikiPageFromChannel: unpinWikiPageFromChannel({
+      driver,
+      Channel,
+      WikiPage,
     }),
     updateDownloadLabels: updateDownloadLabels({
       Discussion,

--- a/customResolvers/mutations/wikiPagePins.test.ts
+++ b/customResolvers/mutations/wikiPagePins.test.ts
@@ -1,0 +1,204 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  pinWikiPageToChannel,
+  unpinWikiPageFromChannel,
+} from "./wikiPagePins.js";
+
+type ModelFindArgs = {
+  where: Record<string, unknown>;
+  selectionSet?: string;
+};
+
+const buildModels = ({
+  channel = { uniqueName: "cats", wikiEnabled: true },
+  wikiPage = { id: "wiki-1", channelUniqueName: "cats" },
+}: {
+  channel?: Record<string, unknown> | null;
+  wikiPage?: Record<string, unknown> | null;
+} = {}) => ({
+  Channel: {
+    find: async (_args: ModelFindArgs) => (channel ? [channel] : []),
+  },
+  WikiPage: {
+    find: async (_args: ModelFindArgs) => (wikiPage ? [wikiPage] : []),
+  },
+});
+
+const buildDriver = () => {
+  const calls = {
+    sessions: [] as Record<string, unknown>[],
+    writes: [] as Array<{ query: string; params: Record<string, unknown> }>,
+    closed: 0,
+  };
+
+  const driver = {
+    session: (options: Record<string, unknown>) => {
+      calls.sessions.push(options);
+      return {
+        run: async (query: string, params: Record<string, unknown>) => {
+          calls.writes.push({ query, params });
+          return { records: [] };
+        },
+        close: async () => {
+          calls.closed += 1;
+        },
+      };
+    },
+  };
+
+  return { driver, calls };
+};
+
+const context = {} as GraphQLContext;
+
+test("pinWikiPageToChannel delegates authorization to canUpdateChannel and merges the pin", async () => {
+  const models = buildModels();
+  const { driver, calls } = buildDriver();
+  const permissionCalls: unknown[] = [];
+  const resolver = pinWikiPageToChannel({
+    driver: driver as never,
+    Channel: models.Channel as never,
+    WikiPage: models.WikiPage as never,
+    checkPermissions: async (input) => {
+      permissionCalls.push(input);
+      return true;
+    },
+  });
+
+  const result = await resolver(
+    null,
+    { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+    context
+  );
+
+  assert.deepEqual(
+    {
+      result,
+      permissionCalls,
+      writeParams: calls.writes[0].params,
+      usesMerge: /MERGE \(channel\)-\[:PINNED_IN_CHANNEL\]->\(wikiPage\)/.test(
+        calls.writes[0].query
+      ),
+      session: calls.sessions[0],
+      closed: calls.closed,
+    },
+    {
+      result: true,
+      permissionCalls: [
+        {
+          channelConnections: ["cats"],
+          context,
+          permissionCheck: "canUpdateChannel",
+        },
+      ],
+      writeParams: { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+      usesMerge: true,
+      session: { defaultAccessMode: "WRITE" },
+      closed: 1,
+    }
+  );
+});
+
+test("unpinWikiPageFromChannel deletes the pin relationship", async () => {
+  const models = buildModels();
+  const { driver, calls } = buildDriver();
+  const resolver = unpinWikiPageFromChannel({
+    driver: driver as never,
+    Channel: models.Channel as never,
+    WikiPage: models.WikiPage as never,
+    checkPermissions: async () => true,
+  });
+
+  const result = await resolver(
+    null,
+    { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+    context
+  );
+
+  assert.deepEqual(
+    {
+      result,
+      deletesRelationship: /DELETE relationship/.test(calls.writes[0].query),
+      params: calls.writes[0].params,
+    },
+    {
+      result: true,
+      deletesRelationship: true,
+      params: { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+    }
+  );
+});
+
+test("pinWikiPageToChannel rejects wiki pages from another forum", async () => {
+  const models = buildModels({
+    wikiPage: { id: "wiki-1", channelUniqueName: "dogs" },
+  });
+  const { driver, calls } = buildDriver();
+  const resolver = pinWikiPageToChannel({
+    driver: driver as never,
+    Channel: models.Channel as never,
+    WikiPage: models.WikiPage as never,
+    checkPermissions: async () => {
+      throw new Error("permission should not be checked");
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+        context
+      ),
+    /does not belong to this forum/
+  );
+  assert.equal(calls.writes.length, 0);
+});
+
+test("pinWikiPageToChannel rejects disabled wiki channels", async () => {
+  const models = buildModels({
+    channel: { uniqueName: "cats", wikiEnabled: false },
+  });
+  const { driver, calls } = buildDriver();
+  const resolver = pinWikiPageToChannel({
+    driver: driver as never,
+    Channel: models.Channel as never,
+    WikiPage: models.WikiPage as never,
+    checkPermissions: async () => true,
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+        context
+      ),
+    /Wiki is disabled/
+  );
+  assert.equal(calls.writes.length, 0);
+});
+
+test("pinWikiPageToChannel surfaces role permission failures", async () => {
+  const models = buildModels();
+  const { driver, calls } = buildDriver();
+  const resolver = pinWikiPageToChannel({
+    driver: driver as never,
+    Channel: models.Channel as never,
+    WikiPage: models.WikiPage as never,
+    checkPermissions: async () => new Error("No channel permission"),
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { channelUniqueName: "cats", wikiPageId: "wiki-1" },
+        context
+      ),
+    /No channel permission/
+  );
+  assert.equal(calls.writes.length, 0);
+});

--- a/customResolvers/mutations/wikiPagePins.ts
+++ b/customResolvers/mutations/wikiPagePins.ts
@@ -1,0 +1,164 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { ChannelModel, WikiPageModel } from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import { checkChannelPermissions } from "../../rules/permission/hasChannelPermission.js";
+
+type PinWikiPageArgs = {
+  channelUniqueName: string;
+  wikiPageId: string;
+};
+
+type PermissionCheck = typeof checkChannelPermissions;
+
+type Deps = {
+  driver: Driver;
+  Channel: ChannelModel;
+  WikiPage: WikiPageModel;
+  checkPermissions?: PermissionCheck;
+};
+
+type ChannelLookup = {
+  uniqueName?: string | null;
+  wikiEnabled?: boolean | null;
+};
+
+type WikiPageLookup = {
+  id?: string | null;
+  channelUniqueName?: string | null;
+};
+
+const validateArgs = (args: PinWikiPageArgs) => {
+  if (!args.channelUniqueName) {
+    throw new GraphQLError("A forum is required to pin a wiki page.");
+  }
+
+  if (!args.wikiPageId) {
+    throw new GraphQLError("A wiki page is required.");
+  }
+};
+
+const getChannelAndWikiPage = async ({
+  Channel,
+  WikiPage,
+  args,
+}: {
+  Channel: ChannelModel;
+  WikiPage: WikiPageModel;
+  args: PinWikiPageArgs;
+}) => {
+  const [channels, wikiPages] = await Promise.all([
+    Channel.find({
+      where: { uniqueName: args.channelUniqueName },
+      selectionSet: `{
+        uniqueName
+        wikiEnabled
+      }`,
+    }) as Promise<ChannelLookup[]>,
+    WikiPage.find({
+      where: { id: args.wikiPageId },
+      selectionSet: `{
+        id
+        channelUniqueName
+      }`,
+    }) as Promise<WikiPageLookup[]>,
+  ]);
+
+  const channel = channels[0];
+  const wikiPage = wikiPages[0];
+
+  if (!channel) {
+    throw new GraphQLError("Forum not found.");
+  }
+
+  if (channel.wikiEnabled === false) {
+    throw new GraphQLError(`Wiki is disabled in channel '${args.channelUniqueName}'.`);
+  }
+
+  if (!wikiPage) {
+    throw new GraphQLError("Wiki page not found.");
+  }
+
+  if (wikiPage.channelUniqueName !== args.channelUniqueName) {
+    throw new GraphQLError("Wiki page does not belong to this forum.");
+  }
+};
+
+const assertCanPinWikiPage = async ({
+  args,
+  context,
+  checkPermissions,
+}: {
+  args: PinWikiPageArgs;
+  context: GraphQLContext;
+  checkPermissions: PermissionCheck;
+}) => {
+  const permissionResult = await checkPermissions({
+    channelConnections: [args.channelUniqueName],
+    context,
+    permissionCheck: "canUpdateChannel",
+  });
+
+  if (permissionResult instanceof Error) {
+    throw new GraphQLError(permissionResult.message);
+  }
+};
+
+export const pinWikiPageToChannel = ({
+  driver,
+  Channel,
+  WikiPage,
+  checkPermissions = checkChannelPermissions,
+}: Deps) => {
+  return async (_parent: unknown, args: PinWikiPageArgs, context: GraphQLContext) => {
+    validateArgs(args);
+    await getChannelAndWikiPage({ Channel, WikiPage, args });
+    await assertCanPinWikiPage({ args, context, checkPermissions });
+
+    const session = driver.session({ defaultAccessMode: "WRITE" });
+
+    try {
+      await session.run(
+        `
+        MATCH (channel:Channel { uniqueName: $channelUniqueName })
+        MATCH (wikiPage:WikiPage { id: $wikiPageId, channelUniqueName: $channelUniqueName })
+        MERGE (channel)-[:PINNED_IN_CHANNEL]->(wikiPage)
+        `,
+        args
+      );
+
+      return true;
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export const unpinWikiPageFromChannel = ({
+  driver,
+  Channel,
+  WikiPage,
+  checkPermissions = checkChannelPermissions,
+}: Deps) => {
+  return async (_parent: unknown, args: PinWikiPageArgs, context: GraphQLContext) => {
+    validateArgs(args);
+    await getChannelAndWikiPage({ Channel, WikiPage, args });
+    await assertCanPinWikiPage({ args, context, checkPermissions });
+
+    const session = driver.session({ defaultAccessMode: "WRITE" });
+
+    try {
+      await session.run(
+        `
+        MATCH (:Channel { uniqueName: $channelUniqueName })-[relationship:PINNED_IN_CHANNEL]->(:WikiPage { id: $wikiPageId, channelUniqueName: $channelUniqueName })
+        DELETE relationship
+        `,
+        args
+      );
+
+      return true;
+    } finally {
+      await session.close();
+    }
+  };
+};

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1063,6 +1063,10 @@ const typeDefinitions = gql`
     addImageToAlbum(albumId: ID!, imageId: ID!, position: Int): Boolean!
     removeImageFromAlbum(albumId: ID!, imageId: ID!): Boolean!
 
+    # Wiki sidebar pins
+    pinWikiPageToChannel(channelUniqueName: String!, wikiPageId: ID!): Boolean!
+    unpinWikiPageFromChannel(channelUniqueName: String!, wikiPageId: ID!): Boolean!
+
     # Share collection as discussion
     shareCollectionAsDiscussion(
       collectionId: ID!,


### PR DESCRIPTION
## Summary
- add dedicated pinWikiPageToChannel and unpinWikiPageFromChannel mutations
- validate channel/wiki membership and disabled wiki state before writing
- enforce pin changes through the existing canUpdateChannel channel-role permission path

## Tests
- node --loader /Users/catherineluse/gennit/gennit-backend/node_modules/ts-node/esm.mjs --test customResolvers/mutations/wikiPagePins.test.ts

## Notes
- Full backend tsc in the temporary worktree is blocked by unrelated missing type declarations for graphql-depth-limit/compression in that environment.