### PR TITLE
[codex] Add wiki page locks

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -111,6 +111,10 @@ import {
   pinWikiPageToChannel,
   unpinWikiPageFromChannel,
 } from "./mutations/wikiPagePins.js";
+import {
+  lockWikiPage,
+  unlockWikiPage,
+} from "./mutations/wikiPageLocks.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -596,6 +600,12 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     unpinWikiPageFromChannel: unpinWikiPageFromChannel({
       driver,
       Channel,
+      WikiPage,
+    }),
+    lockWikiPage: lockWikiPage({
+      WikiPage,
+    }),
+    unlockWikiPage: unlockWikiPage({
       WikiPage,
     }),
     updateDownloadLabels: updateDownloadLabels({

--- a/customResolvers/mutations/wikiPageLocks.test.ts
+++ b/customResolvers/mutations/wikiPageLocks.test.ts
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  lockWikiPage,
+  unlockWikiPage,
+} from "./wikiPageLocks.js";
+
+type WikiPageRecord = {
+  id: string;
+  title?: string;
+  slug?: string;
+  channelUniqueName: string;
+  locked?: boolean | null;
+};
+
+type LockedWikiPageResult = WikiPageRecord & {
+  lockReason?: string | null;
+  lockedByUsername?: string | null;
+};
+
+const buildContext = ({
+  wikiPage = { id: "wiki-1", channelUniqueName: "cats", locked: false },
+  channel = {
+    uniqueName: "cats",
+    wikiEnabled: true,
+    Admins: [{ username: "alice" }],
+    ElevatedChannelRole: { canUpdateChannel: true },
+  },
+}: {
+  wikiPage?: WikiPageRecord | null;
+  channel?: Record<string, unknown> | null;
+} = {}) =>
+  ({
+    user: { username: "alice", data: {} },
+    ogm: {
+      model: (name: string) => {
+        if (name === "WikiPage") {
+          return {
+            find: async () => (wikiPage ? [wikiPage] : []),
+          };
+        }
+
+        if (name === "Channel") {
+          return {
+            find: async () => (channel ? [channel] : []),
+          };
+        }
+
+        throw new Error(`Unexpected model lookup: ${name}`);
+      },
+    },
+  } as unknown as GraphQLContext);
+
+const buildWikiPageModel = () => {
+  const calls: Array<Record<string, unknown>> = [];
+
+  return {
+    calls,
+    WikiPage: {
+      update: async (input: Record<string, unknown>) => {
+        calls.push(input);
+        const update = input.update as Record<string, unknown>;
+        return {
+          wikiPages: [
+            {
+              id: "wiki-1",
+              title: "Intro",
+              slug: "intro",
+              channelUniqueName: "cats",
+              locked: update.locked,
+              lockedAt: update.lockedAt,
+              lockReason: update.lockReason,
+              lockedByUsername: update.lockedByUsername,
+            },
+          ],
+        };
+      },
+    },
+  };
+};
+
+test("lockWikiPage records lock metadata for a channel owner", async () => {
+  const { WikiPage, calls } = buildWikiPageModel();
+  const resolver = lockWikiPage({ WikiPage: WikiPage as never });
+
+  const result = (await resolver(
+    null,
+    { wikiPageId: "wiki-1", reason: "Settled canon" },
+    buildContext()
+  )) as LockedWikiPageResult;
+
+  assert.deepEqual(
+    {
+      locked: result.locked,
+      lockReason: result.lockReason,
+      lockedByUsername: result.lockedByUsername,
+      update: calls[0].update,
+    },
+    {
+      locked: true,
+      lockReason: "Settled canon",
+      lockedByUsername: "alice",
+      update: {
+        locked: true,
+        lockedAt: (calls[0].update as Record<string, unknown>).lockedAt,
+        lockReason: "Settled canon",
+        lockedByUsername: "alice",
+      },
+    }
+  );
+});
+
+test("unlockWikiPage clears lock metadata", async () => {
+  const { WikiPage, calls } = buildWikiPageModel();
+  const resolver = unlockWikiPage({ WikiPage: WikiPage as never });
+
+  const result = (await resolver(
+    null,
+    { wikiPageId: "wiki-1" },
+    buildContext({
+      wikiPage: { id: "wiki-1", channelUniqueName: "cats", locked: true },
+    })
+  )) as LockedWikiPageResult;
+
+  assert.deepEqual(
+    {
+      locked: result.locked,
+      update: calls[0].update,
+    },
+    {
+      locked: false,
+      update: {
+        locked: false,
+        lockedAt: null,
+        lockReason: null,
+        lockedByUsername: null,
+      },
+    }
+  );
+});
+
+test("lockWikiPage rejects non-owner callers", async () => {
+  const { WikiPage, calls } = buildWikiPageModel();
+  const resolver = lockWikiPage({ WikiPage: WikiPage as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { wikiPageId: "wiki-1", reason: "Settled canon" },
+        buildContext({
+          channel: {
+            uniqueName: "cats",
+            wikiEnabled: true,
+            Admins: [{ username: "bob" }],
+            ElevatedChannelRole: { canUpdateChannel: true },
+          },
+        })
+      ),
+    /permission/i
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("lockWikiPage rejects already locked pages", async () => {
+  const { WikiPage, calls } = buildWikiPageModel();
+  const resolver = lockWikiPage({ WikiPage: WikiPage as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        { wikiPageId: "wiki-1", reason: "Settled canon" },
+        buildContext({
+          wikiPage: { id: "wiki-1", channelUniqueName: "cats", locked: true },
+        })
+      ),
+    /already locked/
+  );
+  assert.equal(calls.length, 0);
+});

--- a/customResolvers/mutations/wikiPageLocks.ts
+++ b/customResolvers/mutations/wikiPageLocks.ts
@@ -1,0 +1,135 @@
+import { GraphQLError } from "graphql";
+import type { WikiPageModel } from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  assertCanManageLockedWikiPage,
+  getWikiPageById,
+  validateWikiPageChannelEnabled,
+} from "../../rules/definitions/wikiRules.js";
+
+type LockWikiPageArgs = {
+  wikiPageId: string;
+  reason: string;
+};
+
+type UnlockWikiPageArgs = {
+  wikiPageId: string;
+};
+
+type Deps = {
+  WikiPage: WikiPageModel;
+};
+
+const requireWikiPageId = (wikiPageId?: string | null) => {
+  if (!wikiPageId) {
+    throw new GraphQLError("A wiki page is required.");
+  }
+};
+
+export const lockWikiPage = ({ WikiPage }: Deps) => {
+  return async (_parent: unknown, args: LockWikiPageArgs, context: GraphQLContext) => {
+    requireWikiPageId(args.wikiPageId);
+
+    if (!args.reason || !args.reason.trim()) {
+      throw new GraphQLError("A reason is required to lock a wiki page.");
+    }
+
+    const wikiPage = await getWikiPageById(args.wikiPageId, context);
+
+    if (!wikiPage) {
+      throw new GraphQLError("Wiki page not found.");
+    }
+
+    if (wikiPage.locked) {
+      throw new GraphQLError("Wiki page is already locked.");
+    }
+
+    await validateWikiPageChannelEnabled(wikiPage.channelUniqueName, context);
+    await assertCanManageLockedWikiPage(wikiPage.channelUniqueName, context);
+
+    const update = {
+      locked: true,
+      lockedAt: new Date().toISOString(),
+      lockReason: args.reason.trim(),
+      lockedByUsername: context.user?.username ?? null,
+    } as Record<string, unknown>;
+
+    const result = await WikiPage.update({
+      where: { id: args.wikiPageId },
+      update: update as never,
+      selectionSet: `{
+        wikiPages {
+          id
+          title
+          body
+          slug
+          channelUniqueName
+          locked
+          lockedAt
+          lockReason
+          lockedByUsername
+        }
+      }`,
+    });
+
+    const updatedWikiPage = result.wikiPages[0];
+
+    if (!updatedWikiPage) {
+      throw new GraphQLError("Could not lock wiki page.");
+    }
+
+    return updatedWikiPage;
+  };
+};
+
+export const unlockWikiPage = ({ WikiPage }: Deps) => {
+  return async (_parent: unknown, args: UnlockWikiPageArgs, context: GraphQLContext) => {
+    requireWikiPageId(args.wikiPageId);
+
+    const wikiPage = await getWikiPageById(args.wikiPageId, context);
+
+    if (!wikiPage) {
+      throw new GraphQLError("Wiki page not found.");
+    }
+
+    if (!wikiPage.locked) {
+      throw new GraphQLError("Wiki page is not locked.");
+    }
+
+    await validateWikiPageChannelEnabled(wikiPage.channelUniqueName, context);
+    await assertCanManageLockedWikiPage(wikiPage.channelUniqueName, context);
+
+    const update = {
+      locked: false,
+      lockedAt: null,
+      lockReason: null,
+      lockedByUsername: null,
+    } as Record<string, unknown>;
+
+    const result = await WikiPage.update({
+      where: { id: args.wikiPageId },
+      update: update as never,
+      selectionSet: `{
+        wikiPages {
+          id
+          title
+          body
+          slug
+          channelUniqueName
+          locked
+          lockedAt
+          lockReason
+          lockedByUsername
+        }
+      }`,
+    });
+
+    const updatedWikiPage = result.wikiPages[0];
+
+    if (!updatedWikiPage) {
+      throw new GraphQLError("Could not unlock wiki page.");
+    }
+
+    return updatedWikiPage;
+  };
+};

--- a/rules/canEditWikiPagesRule.test.ts
+++ b/rules/canEditWikiPagesRule.test.ts
@@ -15,10 +15,16 @@ type BuildOgmInput = {
   channels?: Array<{
     uniqueName: string;
     wikiEnabled?: boolean;
+    Admins?: Array<{ username: string }>;
+    ElevatedChannelRole?: {
+      canUpdateChannel?: boolean;
+    } | null;
   }>;
   wikiPages?: Array<{
     id?: string;
     channelUniqueName: string;
+    slug?: string;
+    locked?: boolean;
     OriginalAuthor?: { username: string };
     ChildPages?: Array<{ id: string }>;
   }>;
@@ -43,7 +49,8 @@ const buildOgm = ({
             {
               uniqueName: where?.uniqueName,
               wikiEnabled: channel?.wikiEnabled,
-              Admins: [],
+              Admins: channel?.Admins || [],
+              ElevatedChannelRole: channel?.ElevatedChannelRole ?? null,
               DefaultChannelRole: {
                 canUpdateChannel: defaultCanUpdateChannel,
               },
@@ -57,6 +64,11 @@ const buildOgm = ({
                 suspendedUntil: null,
               })),
               SuspendedMods: [],
+              WikiHomePage: wikiPages.find(
+                (wikiPage) =>
+                  wikiPage.channelUniqueName === where?.uniqueName &&
+                  wikiPage.slug === "home"
+              ),
             },
           ];
         },
@@ -123,6 +135,43 @@ const buildContext = (input: BuildOgmInput = {}) =>
 test("allows wiki page updates when the channel role can update the channel", async () => {
   const ctx = buildContext({
     wikiPages: [{ id: "wiki-page-1", channelUniqueName: "sourceit" }],
+  });
+
+  const result = await evaluateCanEditWikiPagesRule(
+    { where: { id: "wiki-page-1" }, update: { body: "Updated" } },
+    ctx
+  );
+
+  assert.equal(result, true);
+});
+
+test("blocks default-role editors from updating locked wiki pages", async () => {
+  const ctx = buildContext({
+    wikiPages: [
+      { id: "wiki-page-1", channelUniqueName: "sourceit", locked: true },
+    ],
+  });
+
+  const result = await evaluateCanEditWikiPagesRule(
+    { where: { id: "wiki-page-1" }, update: { body: "Updated" } },
+    ctx
+  );
+
+  assert.ok(result instanceof Error);
+});
+
+test("allows channel owners with elevated update permission to update locked wiki pages", async () => {
+  const ctx = buildContext({
+    channels: [
+      {
+        uniqueName: "sourceit",
+        Admins: [{ username: "wiki-author" }],
+        ElevatedChannelRole: { canUpdateChannel: true },
+      },
+    ],
+    wikiPages: [
+      { id: "wiki-page-1", channelUniqueName: "sourceit", locked: true },
+    ],
   });
 
   const result = await evaluateCanEditWikiPagesRule(

--- a/rules/definitions/wikiRules.ts
+++ b/rules/definitions/wikiRules.ts
@@ -4,8 +4,13 @@ import { rule } from "graphql-shield";
 import type { GraphQLResolveInfo } from "graphql";
 import type { GraphQLContext } from "../../types/context.js";
 import { ERROR_MESSAGES } from "../errorMessages.js";
-import { checkChannelPermissions } from "../permission/hasChannelPermission.js";
+import {
+  checkChannelPermissions,
+  evaluateChannelOwnerPermission,
+  isChannelAdmin,
+} from "../permission/hasChannelPermission.js";
 import { checkChannelModPermissions, ModChannelPermission } from "../permission/hasChannelModPermission.js";
+import { setUserDataOnContext } from "../permission/userDataHelperFunctions.js";
 import {
   MutationCreateWikiPagesArgs,
   MutationDeleteWikiPagesArgs,
@@ -19,6 +24,7 @@ import {
 type WikiPageLookup = {
   id?: string | null;
   channelUniqueName?: string | null;
+  locked?: boolean | null;
   OriginalAuthor?: {
     username?: string | null;
   } | null;
@@ -30,6 +36,10 @@ type WikiPageLookup = {
 type WikiChannelPreference = {
   uniqueName?: string | null;
   wikiEnabled?: boolean | null;
+  Admins?: Array<{ username?: string | null }> | null;
+  ElevatedChannelRole?: {
+    canUpdateChannel?: boolean | null;
+  } | null;
 };
 
 type WikiPageMutationArgs = Partial<
@@ -68,6 +78,7 @@ async function getWikiPagesByWhere(where: WikiPageWhere | null, ctx: GraphQLCont
     selectionSet: `{
       id
       channelUniqueName
+      locked
       OriginalAuthor {
         username
       }
@@ -76,6 +87,23 @@ async function getWikiPagesByWhere(where: WikiPageWhere | null, ctx: GraphQLCont
       }
     }`,
   })) as WikiPageLookup[];
+}
+
+export async function getWikiPageById(
+  wikiPageId: string,
+  ctx: GraphQLContext
+) {
+  const WikiPage = ctx.ogm.model("WikiPage");
+  const wikiPages = (await WikiPage.find({
+    where: { id: wikiPageId },
+    selectionSet: `{
+      id
+      channelUniqueName
+      locked
+    }`,
+  })) as WikiPageLookup[];
+
+  return wikiPages[0] ?? null;
 }
 
 function collectWikiPageChannelNames(wikiPages: WikiPageLookup[]) {
@@ -164,10 +192,92 @@ async function validateWikiChannelsEnabled(
   return true;
 }
 
+export async function validateWikiPageChannelEnabled(
+  channelName: string | null | undefined,
+  ctx: GraphQLContext
+) {
+  if (!channelName) {
+    throw new Error("No channel specified for this wiki page.");
+  }
+
+  const result = await validateWikiChannelsEnabled([channelName], ctx);
+
+  if (result instanceof Error) {
+    throw result;
+  }
+}
+
+export async function assertCanManageLockedWikiPage(
+  channelName: string | null | undefined,
+  ctx: GraphQLContext
+) {
+  if (!channelName) {
+    throw new Error("No channel specified for this wiki page.");
+  }
+
+  if (!ctx.user?.username) {
+    ctx.user = await setUserDataOnContext({ context: ctx });
+  }
+
+  const username = ctx.user?.username;
+
+  if (!username) {
+    throw new Error(ERROR_MESSAGES.channel.notAuthenticated);
+  }
+
+  const Channel = ctx.ogm.model("Channel");
+  const channels = (await Channel.find({
+    where: { uniqueName: channelName },
+    selectionSet: `{
+      uniqueName
+      Admins {
+        username
+      }
+      ElevatedChannelRole {
+        canUpdateChannel
+      }
+    }`,
+  })) as WikiChannelPreference[];
+  const channel = channels[0];
+
+  if (!channel) {
+    throw new Error(ERROR_MESSAGES.channel.notFound);
+  }
+
+  if (!isChannelAdmin(channel.Admins, username)) {
+    throw new Error(ERROR_MESSAGES.channel.noChannelPermission);
+  }
+
+  if (!evaluateChannelOwnerPermission(channel.ElevatedChannelRole, "canUpdateChannel")) {
+    throw new Error(ERROR_MESSAGES.channel.noChannelPermission);
+  }
+
+  return true;
+}
+
+async function validateLockedWikiPageEdits(
+  wikiPages: WikiPageLookup[],
+  ctx: GraphQLContext
+) {
+  const lockedChannelNames = Array.from(
+    new Set(
+      wikiPages
+        .filter((wikiPage) => wikiPage.locked === true)
+        .map((wikiPage) => wikiPage.channelUniqueName)
+        .filter((channelName): channelName is string => !!channelName)
+    )
+  );
+
+  for (const channelName of lockedChannelNames) {
+    await assertCanManageLockedWikiPage(channelName, ctx);
+  }
+}
+
 export async function evaluateCanEditWikiPagesRule(
   args: WikiPageMutationArgs,
   ctx: GraphQLContext
 ) {
+  const wikiPages = await getWikiPagesByWhere(args?.where || null, ctx);
   const whereChannelNames = await getWikiPageChannelNamesByWhere(args, ctx);
   const createdChildChannelNames = getChildPageCreateChannelNames(
     args?.update?.ChildPages
@@ -187,6 +297,12 @@ export async function evaluateCanEditWikiPagesRule(
 
   if (wikiEnabledResult instanceof Error) {
     return wikiEnabledResult;
+  }
+
+  try {
+    await validateLockedWikiPageEdits(wikiPages, ctx);
+  } catch (error) {
+    return error instanceof Error ? error : new Error("Cannot edit locked wiki page.");
   }
 
   return checkChannelPermissions({
@@ -231,6 +347,25 @@ export async function evaluateCanEditWikiHomePageRule(
 
   if (wikiEnabledResult instanceof Error) {
     return wikiEnabledResult;
+  }
+
+  const Channel = ctx.ogm.model("Channel");
+  const channels = (await Channel.find({
+    where: { uniqueName: args?.where?.uniqueName || "" },
+    selectionSet: `{
+      WikiHomePage {
+        id
+        channelUniqueName
+        locked
+      }
+    }`,
+  })) as Array<{ WikiHomePage?: WikiPageLookup | null }>;
+  const wikiHomePage = channels[0]?.WikiHomePage;
+
+  try {
+    await validateLockedWikiPageEdits(wikiHomePage ? [wikiHomePage] : [], ctx);
+  } catch (error) {
+    return error instanceof Error ? error : new Error("Cannot edit locked wiki page.");
   }
 
   return checkChannelPermissions({

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -366,6 +366,10 @@ const typeDefinitions = gql`
     editReason: String
     slug: String!
     channelUniqueName: String
+    locked: Boolean @default(value: false)
+    lockedAt: DateTime
+    lockReason: String
+    lockedByUsername: String
     createdAt: DateTime! @timestamp(operations: [CREATE])
     updatedAt: DateTime @timestamp(operations: [UPDATE])
     OriginalAuthor: User @relationship(type: "AUTHORED_WIKI_PAGE", direction: IN)
@@ -1066,6 +1070,10 @@ const typeDefinitions = gql`
     # Wiki sidebar pins
     pinWikiPageToChannel(channelUniqueName: String!, wikiPageId: ID!): Boolean!
     unpinWikiPageFromChannel(channelUniqueName: String!, wikiPageId: ID!): Boolean!
+
+    # Wiki page locks
+    lockWikiPage(wikiPageId: ID!, reason: String!): WikiPage!
+    unlockWikiPage(wikiPageId: ID!): WikiPage!
 
     # Share collection as discussion
     shareCollectionAsDiscussion(


### PR DESCRIPTION
## Summary

Adds backend support for locking and unlocking wiki pages. Locked pages record lock metadata, block default-role wiki editors from editing, and allow edits only for channel owners whose elevated channel role grants `canUpdateChannel`.

This is stacked on #137 (`codex/wiki-pinned-sidebar-pages-backend`).

## Validation

- `node --loader /Users/catherineluse/gennit/gennit-backend/node_modules/ts-node/esm.mjs --test customResolvers/mutations/wikiPageLocks.test.ts rules/canEditWikiPagesRule.test.ts`