### PR TITLE
Add featured wiki pages settings

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -116,6 +116,7 @@ import {
   lockWikiPage,
   unlockWikiPage,
 } from "./mutations/wikiPageLocks.js";
+import { setFeaturedWikiPages } from "./mutations/setFeaturedWikiPages.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -615,6 +616,10 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     }),
     unlockWikiPage: unlockWikiPage({
       Channel,
+      WikiPage,
+    }),
+    setFeaturedWikiPages: setFeaturedWikiPages({
+      ServerConfig,
       WikiPage,
     }),
     updateDownloadLabels: updateDownloadLabels({

--- a/customResolvers/mutations/setFeaturedWikiPages.test.ts
+++ b/customResolvers/mutations/setFeaturedWikiPages.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setFeaturedWikiPages } from "./setFeaturedWikiPages.js";
+
+type FindArgs = {
+  where?: Record<string, unknown>;
+  selectionSet?: string;
+};
+
+type UpdateArgs = {
+  where: Record<string, unknown>;
+  update: Record<string, unknown>;
+  selectionSet?: string;
+};
+
+const buildModels = ({
+  serverConfig = { serverName: "test-server" },
+  wikiPages = [{ id: "w1" }, { id: "w2" }],
+}: {
+  serverConfig?: Record<string, unknown> | null;
+  wikiPages?: Array<Record<string, unknown>>;
+} = {}) => {
+  const calls = {
+    updates: [] as UpdateArgs[],
+  };
+
+  return {
+    calls,
+    ServerConfig: {
+      find: async (_args: FindArgs) => (serverConfig ? [serverConfig] : []),
+      update: async (args: UpdateArgs) => {
+        calls.updates.push(args);
+        return {
+          serverConfigs: [
+            {
+              ...serverConfig,
+              ...args.update,
+            },
+          ],
+        };
+      },
+    },
+    WikiPage: {
+      find: async ({ where }: FindArgs) => {
+        const ids = (where?.id_IN || []) as string[];
+        return wikiPages.filter((page) => ids.includes(page.id as string));
+      },
+    },
+  };
+};
+
+test("setFeaturedWikiPages validates pages and stores ordered IDs", async () => {
+  const models = buildModels();
+  const resolver = setFeaturedWikiPages({
+    ServerConfig: models.ServerConfig as never,
+    WikiPage: models.WikiPage as never,
+  });
+
+  const result = await resolver(null, {
+    serverName: "test-server",
+    wikiPageIds: ["w2", "w1"],
+  });
+
+  assert.deepEqual(
+    {
+      result,
+      update: models.calls.updates[0].update,
+    },
+    {
+      result: {
+        serverName: "test-server",
+        featuredWikiPageIds: ["w2", "w1"],
+      },
+      update: {
+        featuredWikiPageIds: ["w2", "w1"],
+      },
+    }
+  );
+});
+
+test("setFeaturedWikiPages rejects duplicate IDs", async () => {
+  const models = buildModels();
+  const resolver = setFeaturedWikiPages({
+    ServerConfig: models.ServerConfig as never,
+    WikiPage: models.WikiPage as never,
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(null, {
+        serverName: "test-server",
+        wikiPageIds: ["w1", "w1"],
+      }),
+    /duplicates/
+  );
+  assert.equal(models.calls.updates.length, 0);
+});
+
+test("setFeaturedWikiPages rejects missing wiki pages", async () => {
+  const models = buildModels({ wikiPages: [{ id: "w1" }] });
+  const resolver = setFeaturedWikiPages({
+    ServerConfig: models.ServerConfig as never,
+    WikiPage: models.WikiPage as never,
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(null, {
+        serverName: "test-server",
+        wikiPageIds: ["w1", "missing"],
+      }),
+    /missing/
+  );
+  assert.equal(models.calls.updates.length, 0);
+});
+
+test("setFeaturedWikiPages allows clearing the featured page list", async () => {
+  const models = buildModels();
+  const resolver = setFeaturedWikiPages({
+    ServerConfig: models.ServerConfig as never,
+    WikiPage: models.WikiPage as never,
+  });
+
+  const result = await resolver(null, {
+    serverName: "test-server",
+    wikiPageIds: [],
+  });
+
+  assert.deepEqual(result.featuredWikiPageIds, []);
+});

--- a/customResolvers/mutations/setFeaturedWikiPages.ts
+++ b/customResolvers/mutations/setFeaturedWikiPages.ts
@@ -1,0 +1,83 @@
+import { GraphQLError } from "graphql";
+import type { ServerConfigModel, WikiPageModel } from "../../ogm_types.js";
+
+type Deps = {
+  ServerConfig: ServerConfigModel;
+  WikiPage: WikiPageModel;
+};
+
+type Args = {
+  serverName: string;
+  wikiPageIds: string[];
+};
+
+type WikiPageLookup = {
+  id?: string | null;
+};
+
+const returnedServerConfigSelectionSet = `{
+  serverConfigs {
+    serverName
+    featuredWikiPageIds
+  }
+}`;
+
+const validateArgs = ({ serverName, wikiPageIds }: Args) => {
+  if (!serverName) {
+    throw new GraphQLError("A server name is required.");
+  }
+
+  const uniqueIds = new Set(wikiPageIds);
+  if (uniqueIds.size !== wikiPageIds.length) {
+    throw new GraphQLError("Featured wiki pages cannot contain duplicates.");
+  }
+};
+
+export const setFeaturedWikiPages = ({ ServerConfig, WikiPage }: Deps) => {
+  return async (_parent: unknown, args: Args) => {
+    validateArgs(args);
+
+    const serverConfigs = await ServerConfig.find({
+      where: { serverName: args.serverName },
+      selectionSet: `{
+        serverName
+      }`,
+    });
+
+    if (!serverConfigs.length) {
+      throw new GraphQLError("Server configuration not found.");
+    }
+
+    if (args.wikiPageIds.length > 0) {
+      const wikiPages = (await WikiPage.find({
+        where: { id_IN: args.wikiPageIds },
+        selectionSet: `{
+          id
+        }`,
+      })) as WikiPageLookup[];
+      const foundIds = new Set(wikiPages.map((page) => page.id).filter(Boolean));
+      const missingIds = args.wikiPageIds.filter((id) => !foundIds.has(id));
+
+      if (missingIds.length) {
+        throw new GraphQLError(
+          `Featured wiki page IDs were not found: ${missingIds.join(", ")}.`
+        );
+      }
+    }
+
+    const result = await ServerConfig.update({
+      where: { serverName: args.serverName },
+      update: {
+        featuredWikiPageIds: args.wikiPageIds,
+      } as never,
+      selectionSet: returnedServerConfigSelectionSet,
+    });
+
+    const serverConfig = result.serverConfigs[0];
+    if (!serverConfig) {
+      throw new GraphQLError("Server configuration could not be updated.");
+    }
+
+    return serverConfig;
+  };
+};

--- a/customResolvers/queries/getSiteWideWikiList.ts
+++ b/customResolvers/queries/getSiteWideWikiList.ts
@@ -2,6 +2,21 @@ import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import { getSiteWideWikiPagesQuery } from "../cypher/cypherQueries.js";
 import { logger } from "../../logger.js";
 
+type WikiPageListItem = {
+  id?: string | null;
+  title?: string | null;
+  body?: string | null;
+  slug?: string | null;
+  channelUniqueName?: string | null;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+  VersionAuthor?: {
+    username?: string | null;
+    displayName?: string | null;
+    profilePicURL?: string | null;
+  } | null;
+};
+
 type Input = {
   driver: Driver;
 };
@@ -50,9 +65,11 @@ const getResolver = (input: Input) => {
       const wikiPages = result.records.map((record: Neo4jRecord) =>
         record.get("wikiPage")
       );
+      const featuredWikiPages = await getFeaturedWikiPages(driver);
 
       return {
         wikiPages,
+        featuredWikiPages,
         aggregateWikiPageCount: totalCount,
       };
     } catch (error: unknown) {
@@ -63,6 +80,47 @@ const getResolver = (input: Input) => {
       session.close();
     }
   };
+};
+
+const getFeaturedWikiPages = async (driver: Driver) => {
+  const session = driver.session();
+
+  try {
+    const result = await session.run(`
+      MATCH (serverConfig:ServerConfig)
+      WITH coalesce(serverConfig.featuredWikiPageIds, []) AS featuredIds
+      UNWIND range(0, size(featuredIds) - 1) AS index
+      WITH featuredIds, index
+      WHERE index >= 0
+      MATCH (w:WikiPage { id: featuredIds[index] })
+      OPTIONAL MATCH (w)<-[:AUTHORED_VERSION]-(author:User)
+      WITH index, w, author
+      ORDER BY index ASC
+      RETURN {
+        id: w.id,
+        title: w.title,
+        body: w.body,
+        slug: w.slug,
+        channelUniqueName: w.channelUniqueName,
+        createdAt: w.createdAt,
+        updatedAt: w.updatedAt,
+        VersionAuthor: CASE
+          WHEN author IS NULL THEN null
+          ELSE {
+            username: author.username,
+            displayName: author.displayName,
+            profilePicURL: author.profilePicURL
+          }
+        END
+      } AS wikiPage
+    `);
+
+    return result.records.map((record: Neo4jRecord) =>
+      record.get("wikiPage")
+    ) as WikiPageListItem[];
+  } finally {
+    await session.close();
+  }
 };
 
 export default getResolver;

--- a/permissions.ts
+++ b/permissions.ts
@@ -293,6 +293,7 @@ const permissionList = shield({
       unlockChannel: and(isAuthenticated, canLockChannel),
       lockWikiPage: and(isAuthenticated, allow),
       unlockWikiPage: and(isAuthenticated, allow),
+      setFeaturedWikiPages: and(isAuthenticated, canManageServerSettings),
       suspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       suspendUser: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       unsuspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),

--- a/tests/integration/listQueries.test.ts
+++ b/tests/integration/listQueries.test.ts
@@ -54,6 +54,21 @@ test("getSiteWideWikiList filters by search input", async () => {
   assert.equal(result.wikiPages[0].title, "Alpha Guide");
 });
 
+test("getSiteWideWikiList returns featured wiki pages in configured order", async () => {
+  await run(
+    `CREATE (:ServerConfig { serverName: 'test-server', featuredWikiPageIds: ['w2', 'w1'] })
+     CREATE (:WikiPage { id: 'w1', title: 'Alpha Guide', slug: 'alpha', body: 'aaa', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (:WikiPage { id: 'w2', title: 'Beta Guide', slug: 'beta', body: 'bbb', channelUniqueName: 'dogs', createdAt: datetime() })`
+  );
+
+  const result = await env.resolvers.Query.getSiteWideWikiList(null, {});
+
+  assert.deepEqual(
+    result.featuredWikiPages.map((page: { id: string }) => page.id),
+    ["w2", "w1"]
+  );
+});
+
 // --- getSortedChannels ---
 
 test("getSortedChannels returns channels with an aggregate count", async () => {

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1075,6 +1075,7 @@ const typeDefinitions = gql`
     unpinWikiPageFromChannel(channelUniqueName: String!, wikiPageId: ID!): Boolean!
     lockWikiPage(channelUniqueName: String!, wikiPageId: ID!, reason: String!): WikiPage!
     unlockWikiPage(channelUniqueName: String!, wikiPageId: ID!): WikiPage!
+    setFeaturedWikiPages(serverName: String!, wikiPageIds: [ID!]!): ServerConfig!
 
     # Share collection as discussion
     shareCollectionAsDiscussion(
@@ -1485,6 +1486,7 @@ const typeDefinitions = gql`
   type SiteWideWikiListFormat {
     aggregateWikiPageCount: Int!
     wikiPages: [WikiPage!]!
+    featuredWikiPages: [WikiPage!]!
   }
 
   type SiteWideIssueListItem {
@@ -1778,6 +1780,7 @@ const typeDefinitions = gql`
     serverIconURL: String
     rules: JSON
     allowedFileTypes: [String]
+    featuredWikiPageIds: [ID]
     enableDownloads: Boolean
     enableEvents: Boolean
     DefaultServerRole: ServerRole


### PR DESCRIPTION
## Summary
- add server-config storage and mutation for ordered featured wiki page IDs
- include featured wiki pages in the site-wide wiki list response
- add resolver unit coverage and integration coverage for configured ordering

## Tests
- corepack pnpm run codegen
- corepack pnpm exec node --loader ts-node/esm --test customResolvers/mutations/setFeaturedWikiPages.test.ts
- corepack pnpm run tsc
- corepack pnpm exec node --loader ts-node/esm --test --test-concurrency=1 tests/integration/listQueries.test.ts