### PR TITLE
[codex] Add channel icons to sitewide discussion list

### DIFF
--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -58,12 +58,13 @@ WITH d, COLLECT(dc) AS discussionChannels, totalCount
 
 // Unwind the discussion channels to work with them individually for fetching related data
 UNWIND discussionChannels AS dc
+OPTIONAL MATCH (channelNode:Channel {uniqueName: dc.channelUniqueName})
 OPTIONAL MATCH (dc)-[:UPVOTED_DISCUSSION]->(upvoter:User)
 OPTIONAL MATCH (dc)<-[:SUPER_UPVOTED_DISCUSSION]-(superUpvoter:User)
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
 WHERE c.isFeedbackComment IS NULL OR c.isFeedbackComment = false
-WITH d, dc, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
-WITH d, COLLECT({dc: dc, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
+WITH d, dc, channelNode, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
+WITH d, COLLECT({dc: dc, channelIconURL: channelNode.channelIconURL, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
 
 // Now, you can proceed with calculating the score and other aggregations at the discussion level
 WITH d, channelData, totalCount,
@@ -75,6 +76,10 @@ WITH d, score, totalCount,
         createdAt: channel.dc.createdAt,
         channelUniqueName: channel.dc.channelUniqueName,
         discussionId: channel.dc.discussionId,
+        Channel: {
+          uniqueName: channel.dc.channelUniqueName,
+          channelIconURL: channel.channelIconURL
+        },
         UpvotedByUsers: [up in channel.upvotedByUsers | { username: up.username }],
         SuperUpvotedByUsers: [sup in channel.superUpvotedByUsers | { username: sup.username }],
         CommentsAggregate: {

--- a/tests/integration/listQueries.test.ts
+++ b/tests/integration/listQueries.test.ts
@@ -54,6 +54,63 @@ test("getSiteWideWikiList filters by search input", async () => {
   assert.equal(result.wikiPages[0].title, "Alpha Guide");
 });
 
+// --- getSiteWideDiscussionList ---
+
+test("getSiteWideDiscussionList includes channel icon URLs for discussion channels", async () => {
+  await run(
+    `CREATE (channel:Channel {
+        uniqueName: 'cats',
+        displayName: 'Cats',
+        channelIconURL: 'https://example.com/cats-icon.png'
+      })
+      CREATE (author:User {
+        username: 'alice',
+        createdAt: datetime(),
+        discussionKarma: 1,
+        commentKarma: 2
+      })
+      CREATE (discussion:Discussion {
+        id: 'd1',
+        title: 'Alpha discussion',
+        body: 'hello',
+        createdAt: datetime(),
+        hasDownload: false
+      })
+      CREATE (dc:DiscussionChannel {
+        id: 'dc1',
+        discussionId: 'd1',
+        channelUniqueName: 'cats',
+        createdAt: datetime(),
+        weightedVotesCount: 1
+      })
+      CREATE (author)-[:POSTED_DISCUSSION]->(discussion)
+      CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)`
+  );
+
+  const result = await env.resolvers.Query.getSiteWideDiscussionList(null, {
+    searchInput: "",
+    selectedChannels: [],
+    selectedTags: [],
+    showArchived: false,
+    hasDownload: false,
+    options: {
+      offset: "0",
+      limit: "10",
+      resultsOrder: "desc",
+      sort: "new",
+      timeFrame: "week",
+    },
+  });
+
+  assert.equal(result.discussions.length, 1);
+  assert.equal(result.discussions[0].DiscussionChannels.length, 1);
+  assert.equal(result.discussions[0].DiscussionChannels[0].Channel.uniqueName, "cats");
+  assert.equal(
+    result.discussions[0].DiscussionChannels[0].Channel.channelIconURL,
+    "https://example.com/cats-icon.png"
+  );
+});
+
 // --- getSortedChannels ---
 
 test("getSortedChannels returns channels with an aggregate count", async () => {


### PR DESCRIPTION
## What changed
- updated the sitewide discussion list Cypher query to include a nested `Channel` object for each returned `DiscussionChannel`
- populated that nested channel data with `uniqueName` and `channelIconURL`
- added an integration test covering `getSiteWideDiscussionList` returning the channel icon URL

## Why this changed
The sitewide discussion list returned discussion-channel entries without the forum icon URL, so the UI could not render the channel icons for the forums each discussion was submitted to.

## Impact
The frontend can now read `DiscussionChannels[].Channel.channelIconURL` from the sitewide discussion list response and render forum icons consistently with other channel-backed views.

## Root cause
The custom sitewide discussion list projection collected `DiscussionChannel` data but did not join the related `Channel` node or include its `channelIconURL` in the returned GraphQL shape.

## Validation
- ran `node --loader ts-node/esm --test --test-concurrency=1 tests/integration/listQueries.test.ts`
- verified the new `getSiteWideDiscussionList includes channel icon URLs for discussion channels` integration test passes