### PR TITLE
Add computed favorite state for images and channels

### DIFF
--- a/customResolvers/queries/getSortedChannels.ts
+++ b/customResolvers/queries/getSortedChannels.ts
@@ -1,6 +1,7 @@
 import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
 import { logger } from "../../logger.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 
 type Input = {
   driver: Driver;
@@ -20,12 +21,14 @@ const DEFAULT_OFFSET = "0";
 const getSortedChannelsResolver = (input: Input) => {
   const { driver } = input;
 
-  return async (_parent: unknown, args: Args, _context: GraphQLContext) => {
+  return async (_parent: unknown, args: Args, context: GraphQLContext) => {
     const limit = args.limit || DEFAULT_LIMIT;
     const offset = args.offset || DEFAULT_OFFSET;
     const tags = args.tags || [];
     const searchInput = args.searchInput || "";
     const countDownloads = args.countDownloads;
+    context.user = await setUserDataOnContext({ context });
+    const loggedInUsername = context.user?.username || null;
     const session = driver.session();
 
     try {
@@ -65,8 +68,10 @@ const getSortedChannelsResolver = (input: Input) => {
           RETURN COUNT(DISTINCT ec) AS eventChannelsCount
         }
         
+        OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_CHANNELS]->(c)
+        
         // Collect tags again for the final output
-        WITH c, tags, validDiscussionChannelsCount, eventChannelsCount
+        WITH c, tags, validDiscussionChannelsCount, eventChannelsCount, COUNT(DISTINCT favUser) > 0 AS isFavorited
         
         // Aggregate channel count
         WITH collect({
@@ -74,6 +79,7 @@ const getSortedChannelsResolver = (input: Input) => {
           displayName: c.displayName,
           channelIconURL: c.channelIconURL,
           description: c.description,
+          isFavorited: CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null ELSE isFavorited END,
           Tags: [tag IN tags | { text: tag.text }],
           EventChannelsAggregate: { count: eventChannelsCount },
           DiscussionChannelsAggregate: { count: validDiscussionChannelsCount }
@@ -93,6 +99,7 @@ const getSortedChannelsResolver = (input: Input) => {
           tags,
           searchInput,
           countDownloads,
+          loggedInUsername,
         }
       );
 

--- a/customResolvers/queries/getSortedChannels.ts
+++ b/customResolvers/queries/getSortedChannels.ts
@@ -21,14 +21,16 @@ const DEFAULT_OFFSET = "0";
 const getSortedChannelsResolver = (input: Input) => {
   const { driver } = input;
 
-  return async (_parent: unknown, args: Args, context: GraphQLContext) => {
+  return async (_parent: unknown, args: Args, context?: GraphQLContext) => {
     const limit = args.limit || DEFAULT_LIMIT;
     const offset = args.offset || DEFAULT_OFFSET;
     const tags = args.tags || [];
     const searchInput = args.searchInput || "";
     const countDownloads = args.countDownloads;
-    context.user = await setUserDataOnContext({ context });
-    const loggedInUsername = context.user?.username || null;
+    if (context) {
+      context.user = await setUserDataOnContext({ context });
+    }
+    const loggedInUsername = context?.user?.username || null;
     const session = driver.session();
 
     try {

--- a/tests/integration/getSortedChannels.test.ts
+++ b/tests/integration/getSortedChannels.test.ts
@@ -83,6 +83,16 @@ test("returns all channels with their event/discussion sub-counts when unfiltere
   assert.equal(num(dogs.EventChannelsAggregate.count), 0);
 });
 
+test("works when called without a GraphQL context", async () => {
+  await seedChannels();
+
+  const result = await env.resolvers.Query.getSortedChannels(null, {
+    countDownloads: null,
+  });
+
+  assert.deepEqual(names(result.channels), ["cars", "cats", "dogs"]);
+});
+
 test("filters by search term across uniqueName and description", async () => {
   await seedChannels();
 

--- a/tests/integration/getSortedChannels.test.ts
+++ b/tests/integration/getSortedChannels.test.ts
@@ -31,8 +31,15 @@ beforeEach(async () => {
 // countDownloads is passed straight to Cypher; GraphQL would supply null when
 // omitted, so default it here (a direct call would otherwise pass undefined,
 // which the driver rejects).
-const getSortedChannels = (args: Record<string, unknown> = {}) =>
-  env.resolvers.Query.getSortedChannels(null, { countDownloads: null, ...args }, {});
+const getSortedChannels = (
+  args: Record<string, unknown> = {},
+  context: Record<string, unknown> = {}
+) =>
+  env.resolvers.Query.getSortedChannels(
+    null,
+    { countDownloads: null, ...args },
+    context
+  );
 
 const num = (v: any) => (v?.toNumber ? v.toNumber() : v);
 const names = (channels: any[]) => channels.map((c) => c.uniqueName).sort();
@@ -122,4 +129,21 @@ test("countDownloads flag excludes non-download discussions from the count", asy
     num(channelByName(defaultCount, "cats").DiscussionChannelsAggregate.count),
     1
   );
+});
+
+test("returns favorite state for the logged-in user", async () => {
+  await seedChannels();
+  await run(
+    `MATCH (cats:Channel { uniqueName: 'cats' })
+     CREATE (alice:User { username: 'alice' })
+     CREATE (alice)-[:DEFAULT_FAVORITES_CHANNELS]->(cats)`
+  );
+
+  const result = await getSortedChannels(
+    {},
+    { user: { username: "alice", email: null, email_verified: true, data: null } }
+  );
+
+  assert.equal(channelByName(result, "cats").isFavorited, true);
+  assert.equal(channelByName(result, "dogs").isFavorited, false);
 });

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -104,6 +104,14 @@ const typeDefinitions = gql`
 
     # Collection support
     InCollections: [Collection!]! @relationship(type: "CONTAINS_IMAGE", direction: IN)
+    isFavorited(username: String): Boolean @cypher(statement: """
+      OPTIONAL MATCH (favUser:User {username: $username})-[:DEFAULT_FAVORITES_IMAGES]->(this)
+      RETURN CASE
+        WHEN $username IS NULL OR $username = '' THEN null
+        WHEN favUser IS NOT NULL THEN true
+        ELSE false
+      END AS isFavorited
+    """, columnName: "isFavorited")
   }
 
   """SPDX or custom content licence"""
@@ -493,6 +501,14 @@ const typeDefinitions = gql`
 
     # Collection support
     InCollections: [Collection!]! @relationship(type: "CONTAINS_CHANNEL", direction: IN)
+    isFavorited(username: String): Boolean @cypher(statement: """
+      OPTIONAL MATCH (favUser:User {username: $username})-[:DEFAULT_FAVORITES_CHANNELS]->(this)
+      RETURN CASE
+        WHEN $username IS NULL OR $username = '' THEN null
+        WHEN favUser IS NOT NULL THEN true
+        ELSE false
+      END AS isFavorited
+    """, columnName: "isFavorited")
 
     # feature toggles
     eventsEnabled: Boolean @default(value: true)


### PR DESCRIPTION
## Summary
- add computed isFavorited(username:) fields for images and channels
- include authenticated favorite state in getSortedChannels results
- add integration coverage for sorted-channel favorite state

## Tests
- corepack pnpm run codegen
- corepack pnpm run tsc
- corepack pnpm exec node --loader ts-node/esm --test --test-concurrency=1 tests/integration/getSortedChannels.test.ts