### PR TITLE
Add issue links to subscription notifications

### DIFF
--- a/services/issueNotifications.test.ts
+++ b/services/issueNotifications.test.ts
@@ -32,6 +32,7 @@ const buildDriver = () => {
 };
 
 test("notifyIssueSubscribers notifies subscribers and only emails opted-in users", async () => {
+  delete process.env.FRONTEND_URL;
   const { driver, sessions } = buildDriver();
   const sendBatchEmailsCalls: any[] = [];
 
@@ -110,6 +111,73 @@ test("notifyIssueSubscribers notifies subscribers and only emails opted-in users
     notificationText: "New reply on Issue #42: Broken image links",
   });
   assert.match(sessions[0]?.runCalls[0]?.query, /notificationType: "moderation"/);
+});
+
+test("notifyIssueSubscribers links the issue label in notification text when a URL is available", async () => {
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+  process.env.FRONTEND_URL = "https://example.com";
+
+  try {
+    const { driver, sessions } = buildDriver();
+
+    const IssueModel = {
+      async find() {
+        return [
+          {
+            id: "issue-6",
+            issueNumber: 6,
+            title: "test event with tag",
+            channelUniqueName: "photography",
+            SubscribedToNotifications: [
+              {
+                username: "alice",
+                notifyOnSubscribedIssueUpdates: false,
+                Email: null,
+              },
+            ],
+          },
+        ];
+      },
+    };
+
+    // Comment reply notification links the issue label.
+    await notifyIssueSubscribers({
+      IssueModel: IssueModel as unknown as IssueModel,
+      driver: driver as unknown as Driver,
+      issueId: "issue-6",
+      actorUsername: "editor",
+      actionType: "comment",
+      actionDescription: "commented on the issue",
+    });
+
+    const replyText = sessions[0]?.runCalls[0]?.params?.notificationText as string;
+    assert.match(
+      replyText,
+      /^New reply on \[Issue #6\]\(https:\/\/example\.com\/forums\/photography\/issues\/6\): test event with tag/
+    );
+
+    // Non-comment update notification links the issue label too.
+    await notifyIssueSubscribers({
+      IssueModel: IssueModel as unknown as IssueModel,
+      driver: driver as unknown as Driver,
+      issueId: "issue-6",
+      actorUsername: "editor",
+      actionType: "archive",
+      actionDescription: "Un-archived the event",
+    });
+
+    const updateText = sessions[1]?.runCalls[0]?.params?.notificationText as string;
+    assert.match(
+      updateText,
+      /^\[Issue #6\]\(https:\/\/example\.com\/forums\/photography\/issues\/6\) was updated: Un-archived the event/
+    );
+  } finally {
+    if (originalFrontendUrl === undefined) {
+      delete process.env.FRONTEND_URL;
+    } else {
+      process.env.FRONTEND_URL = originalFrontendUrl;
+    }
+  }
 });
 
 test("notifyIssueSubscribers skips report actions", async () => {

--- a/services/issueNotifications.ts
+++ b/services/issueNotifications.ts
@@ -42,21 +42,27 @@ const getIssueNotificationCopy = (input: {
   issueTitle?: string | null;
   actionType?: string | null;
   actionDescription: string;
+  issueUrl?: string | null;
 }) => {
-  const { issueNumber, issueTitle, actionType, actionDescription } = input;
+  const { issueNumber, issueTitle, actionType, actionDescription, issueUrl } =
+    input;
   const issueLabel = issueNumber != null ? `Issue #${issueNumber}` : "Issue";
+  // In-app notifications render markdown, so link the issue label when we have
+  // a URL. Email subject/summary stay plain because the email builds its own
+  // link to the issue separately.
+  const linkedIssueLabel = issueUrl ? `[${issueLabel}](${issueUrl})` : issueLabel;
   const titleSuffix = issueTitle ? `: ${issueTitle}` : "";
 
   if (actionType === "comment") {
     return {
-      notificationText: `New reply on ${issueLabel}${titleSuffix}`,
+      notificationText: `New reply on ${linkedIssueLabel}${titleSuffix}`,
       subject: `New reply on ${issueLabel}`,
       summary: `There is a new reply on ${issueLabel}${titleSuffix}.`,
     };
   }
 
   return {
-    notificationText: `${issueLabel} was updated: ${actionDescription}`,
+    notificationText: `${linkedIssueLabel} was updated: ${actionDescription}`,
     subject: `${issueLabel} was updated`,
     summary: `${issueLabel}${titleSuffix} was updated: ${actionDescription}.`,
   };
@@ -111,13 +117,14 @@ export const notifyIssueSubscribers = async ({
     return false;
   }
 
+  const issueUrl = buildIssueUrl(issue.channelUniqueName, issue.issueNumber);
   const copy = getIssueNotificationCopy({
     issueNumber: issue.issueNumber,
     issueTitle: issue.title,
     actionType,
     actionDescription,
+    issueUrl,
   });
-  const issueUrl = buildIssueUrl(issue.channelUniqueName, issue.issueNumber);
 
   // Add unsubscribe footer to notification text
   const notificationTextWithFooter = issueUrl


### PR DESCRIPTION
## Problem

Issue-subscription notifications rendered `Issue #N` as **plain text** instead of a link, even though the issue URL was already being computed in the same function (and used for the email + unsubscribe footer). Affected notifications include:

- `New reply on Issue #6: [Reported event] "test event with tag"`
- `Issue #6 was updated: Un-archived the event`
- `Issue #6 was updated: Archived the event and closed the issue`

These cover all the archive / unarchive / lock / unlock / comment-reply moderation flows, since they all route through `notifyIssueSubscribers`.

## Fix

Make the `Issue #N` label a markdown link when a URL is available, in `getIssueNotificationCopy` ([services/issueNotifications.ts](services/issueNotifications.ts)):

- `New reply on [Issue #6](…/forums/photography/issues/6): …`
- `[Issue #6](…/forums/photography/issues/6) was updated: Un-archived the event`

Details:
- Uses the existing `buildIssueUrl` helper and the same markdown link pattern already used by suspension / mod-mention notifications.
- Email **subject** and **summary** stay plain text — the email builds its own link to the issue separately.
- Falls back to plain `Issue #N` when `FRONTEND_URL` is unset (no URL), unchanged from before.

## Tests

- Added a test covering both the comment-reply and update variants, asserting the `[Issue #6](url)` markdown link is present.
- Made the existing test explicit that it runs with no `FRONTEND_URL`.
- All 3 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)