### PR TITLE
Add event title/description version history

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -335,6 +335,11 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       driver,
       revisionType: 'discussion body',
     }),
+    deleteEventDescriptionRevision: redactTextVersionRevision({
+      TextVersion,
+      driver,
+      revisionType: 'event description',
+    }),
     deleteWikiRevision: redactTextVersionRevision({
       TextVersion,
       driver,

--- a/customResolvers/mutations/redactTextVersionRevision.ts
+++ b/customResolvers/mutations/redactTextVersionRevision.ts
@@ -23,7 +23,7 @@ type Args = {
   textVersionId: string
 }
 
-type RevisionType = 'comment' | 'discussion body' | 'wiki'
+type RevisionType = 'comment' | 'discussion body' | 'wiki' | 'event description'
 
 type RevisionRedactionTarget = {
   targetType: RevisionType | null
@@ -49,7 +49,8 @@ type Input = {
 const revisionPermissionByType: Record<RevisionType, ModChannelPermission> = {
   comment: ModChannelPermission.canEditComments,
   'discussion body': ModChannelPermission.canEditDiscussions,
-  wiki: ModChannelPermission.canDeleteWiki
+  wiki: ModChannelPermission.canDeleteWiki,
+  'event description': ModChannelPermission.canEditEvents
 }
 
 export const getRevisionRedactionTarget = async (input: {
@@ -84,15 +85,20 @@ export const getRevisionRedactionTarget = async (input: {
       OPTIONAL MATCH (wikiPage:WikiPage)-[:HAS_VERSION]->(version)
       OPTIONAL MATCH (wikiOriginalAuthor:User)-[:AUTHORED_WIKI_PAGE]->(wikiPage)
 
+      OPTIONAL MATCH (event:Event)-[:HAS_DESCRIPTION_VERSION]->(version)
+      OPTIONAL MATCH (eventPoster:User)-[:POSTED_BY]->(event)
+      OPTIONAL MATCH (eventChannel:EventChannel)-[:POSTED_IN_CHANNEL]->(event)
+
       RETURN
         CASE
           WHEN comment IS NOT NULL THEN 'comment'
           WHEN discussion IS NOT NULL THEN 'discussion body'
           WHEN wikiPage IS NOT NULL THEN 'wiki'
+          WHEN event IS NOT NULL THEN 'event description'
           ELSE null
         END AS targetType,
-        coalesce(comment.id, discussion.id, wikiPage.id) AS targetId,
-        coalesce(commentUser.username, discussionAuthor.username, wikiOriginalAuthor.username) AS ownerUsername,
+        coalesce(comment.id, discussion.id, wikiPage.id, event.id) AS targetId,
+        coalesce(commentUser.username, discussionAuthor.username, wikiOriginalAuthor.username, eventPoster.username) AS ownerUsername,
         commentMod.displayName AS ownerModProfileName,
         coalesce(
           commentChannel.uniqueName,
@@ -102,7 +108,8 @@ export const getRevisionRedactionTarget = async (input: {
           parentCommentDiscussionChannel.channelUniqueName,
           parentCommentEventChannel.channelUniqueName,
           discussionChannel.channelUniqueName,
-          wikiPage.channelUniqueName
+          wikiPage.channelUniqueName,
+          eventChannel.channelUniqueName
         ) AS channelUniqueName
       `,
       { textVersionId }

--- a/customResolvers/mutations/updateEventWithChannelConnections.ts
+++ b/customResolvers/mutations/updateEventWithChannelConnections.ts
@@ -7,6 +7,7 @@ import { createEventUpdateNotificationEmail } from "./shared/emailUtils.js";
 import { buildEventUpdateNotificationPayload } from "../../services/eventUpdateNotifications.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel } from "../../ogm_types.js";
+import { eventVersionHistoryHandler } from "../../hooks/eventVersionHistoryHook.js";
 import { logger } from "../../logger.js";
 
 type Input = {
@@ -70,6 +71,22 @@ const getResolver = (input: Input) => {
       const existingEvent = existingEvents[0];
       if (!existingEvent) {
         throw new Error("Event not found");
+      }
+
+      // Snapshot the previous title/description into the event's version
+      // history before applying the update. Runs before Event.update so it
+      // reads the pre-update values.
+      if (where.id) {
+        await eventVersionHistoryHandler({
+          context,
+          params: {
+            where: { id: where.id },
+            update: {
+              title: eventUpdateInput.title,
+              description: eventUpdateInput.description,
+            },
+          },
+        });
       }
 
       // Update the event

--- a/hooks/eventVersionHistoryHook.ts
+++ b/hooks/eventVersionHistoryHook.ts
@@ -1,0 +1,389 @@
+
+import {
+  createIssueActivityFeedItems,
+  getAttributionFromContext,
+  getIssueIdsForRelated,
+} from './issueActivityFeedHelpers.js';
+import { createInAppNotification } from './notificationHelpers.js';
+import type { GraphQLContext } from '../types/context.js';
+import { logger } from "../logger.js";
+import type {
+  EventModel,
+  EventUpdateInput,
+  TextVersionModel,
+  UserModel,
+} from '../ogm_types.js';
+
+export type EventSnapshot = {
+  id?: string;
+  title?: string | null;
+  description?: string | null;
+  Poster?: { username?: string | null } | null;
+  DescriptionLastEditedBy?: { username?: string | null } | null;
+  EventChannels?: Array<{ channelUniqueName?: string | null }> | null;
+  PastTitleVersions?: Array<{ id?: string; body?: string | null; createdAt?: string | null }> | null;
+  PastDescriptionVersions?: Array<{ id?: string; body?: string | null; createdAt?: string | null }> | null;
+};
+
+type EventVersionHistoryHandlerInput = {
+  context: GraphQLContext;
+  params: {
+    where?: { id?: string | null };
+    update?: { title?: string | null; description?: string | null } | null;
+  };
+  eventSnapshot?: EventSnapshot | null;
+};
+
+/**
+ * Hook to track event version history when an event is updated.
+ * This captures the old title and description before the update is applied,
+ * mirroring the discussion version history behavior.
+ */
+export const eventVersionHistoryHandler = async ({
+  context,
+  params,
+  eventSnapshot,
+}: EventVersionHistoryHandlerInput) => {
+  try {
+    logger.info('Event version history hook running...');
+
+    const { where, update } = params;
+    const eventId = where?.id;
+
+    if (!eventId || !update) {
+      logger.info('Missing event ID or update data');
+      return;
+    }
+
+    // Check if title or description is being updated
+    const isTitleUpdated =
+      update.title !== undefined && update.title !== eventSnapshot?.title;
+    const isDescriptionUpdated =
+      update.description !== undefined &&
+      update.description !== eventSnapshot?.description;
+
+    if (!isTitleUpdated && !isDescriptionUpdated) {
+      logger.info(
+        'No title or description updates detected, skipping version history'
+      );
+      return;
+    }
+
+    logger.info('Processing version history for event:', eventId);
+
+    const { ogm } = context;
+    const EventModel = ogm.model('Event');
+    const TextVersionModel = ogm.model('TextVersion');
+    const UserModel = ogm.model('User');
+    const IssueModel = ogm.model('Issue');
+
+    let event: EventSnapshot | null | undefined = eventSnapshot;
+
+    if (!event) {
+      const events = await EventModel.find({
+        where: { id: eventId },
+        selectionSet: `{
+          id
+          title
+          description
+          Poster {
+            username
+          }
+          DescriptionLastEditedBy {
+            username
+          }
+          EventChannels {
+            channelUniqueName
+          }
+          PastTitleVersions {
+            id
+            body
+            createdAt
+          }
+          PastDescriptionVersions {
+            id
+            body
+            createdAt
+          }
+        }`
+      });
+
+      if (!events.length) {
+        logger.info('Event not found');
+        return;
+      }
+
+      event = events[0] as EventSnapshot;
+    }
+
+    // The editor making this change (for updating DescriptionLastEditedBy after)
+    const editorUsername = context?.user?.username;
+
+    // The author of the current description content (who we attribute the
+    // TextVersion to). Use DescriptionLastEditedBy if set, otherwise fall back
+    // to the original Poster (OP).
+    const descriptionContentAuthor =
+      event.DescriptionLastEditedBy?.username || event.Poster?.username;
+
+    // For title, we attribute the replaced version to the editor.
+    const titleEditor = editorUsername || event.Poster?.username;
+
+    if (!titleEditor) {
+      logger.info('Author username not found');
+      return;
+    }
+
+    const createdRevisionIds: Array<{ id: string; type: 'title' | 'description' }> = [];
+
+    if (isTitleUpdated && update.title !== event.title) {
+      const titleRevisionId = await trackTitleVersionHistory(
+        eventId,
+        event.title ?? '',
+        titleEditor,
+        EventModel,
+        TextVersionModel,
+        UserModel
+      );
+      if (titleRevisionId) {
+        createdRevisionIds.push({ id: titleRevisionId, type: 'title' });
+      }
+    }
+
+    if (isDescriptionUpdated && update.description !== event.description) {
+      const descriptionRevisionId = await trackDescriptionVersionHistory(
+        eventId,
+        event.description,
+        descriptionContentAuthor || '[Unknown]',
+        EventModel,
+        TextVersionModel,
+        UserModel
+      );
+      if (descriptionRevisionId) {
+        createdRevisionIds.push({ id: descriptionRevisionId, type: 'description' });
+      }
+
+      // Update DescriptionLastEditedBy to the current editor
+      if (editorUsername) {
+        await EventModel.update({
+          where: { id: eventId },
+          update: {
+            DescriptionLastEditedBy: {
+              disconnect: {},
+              connect: { where: { node: { username: editorUsername } } }
+            }
+          }
+        });
+      }
+    }
+
+    if (!createdRevisionIds.length) {
+      return;
+    }
+
+    const issueIds = await getIssueIdsForRelated(IssueModel, {
+      eventId,
+    });
+    if (!issueIds.length) {
+      return;
+    }
+
+    const attribution = getAttributionFromContext(context);
+    for (const revision of createdRevisionIds) {
+      await createIssueActivityFeedItems({
+        IssueModel,
+        driver: context?.driver,
+        issueIds,
+        actionDescription:
+          revision.type === 'title'
+            ? 'edited the event title'
+            : 'edited the event description',
+        actionType: 'edit',
+        attribution,
+        actorUsername: context?.user?.username || null,
+        revisionId: revision.id,
+      });
+    }
+  } catch (error) {
+    logger.error('Error in event version history hook:', error);
+    // Don't re-throw the error, so we don't affect the mutation
+  }
+};
+
+export const eventEditNotificationHandler = async ({
+  context,
+  params,
+  eventSnapshot,
+}: EventVersionHistoryHandlerInput) => {
+  try {
+    const { where, update } = params;
+    const eventId = where?.id;
+
+    if (!eventId || !update || !eventSnapshot) {
+      return;
+    }
+
+    const isTitleUpdated = update.title !== undefined;
+    const isDescriptionUpdated = update.description !== undefined;
+
+    if (!isTitleUpdated && !isDescriptionUpdated) {
+      return;
+    }
+
+    const editorUsername = context?.user?.username || null;
+    const editorLabel =
+      context?.user?.data?.ModerationProfile?.displayName ||
+      editorUsername ||
+      'A moderator';
+    const authorUsername = eventSnapshot?.Poster?.username || null;
+
+    if (!authorUsername || !editorUsername || authorUsername === editorUsername) {
+      return;
+    }
+
+    const channelName =
+      eventSnapshot?.EventChannels?.[0]?.channelUniqueName || null;
+
+    if (!channelName) {
+      return;
+    }
+
+    const notificationUrl = `${process.env.FRONTEND_URL}/forums/${channelName}/events/${eventId}`;
+    const eventTitle = eventSnapshot?.title || 'event';
+    const notificationText = `${editorLabel} edited your event [${eventTitle}](${notificationUrl})`;
+
+    const UserModel = context.ogm.model('User');
+    await createInAppNotification({
+      UserModel,
+      username: authorUsername,
+      text: notificationText,
+    });
+  } catch (error) {
+    logger.error('Error in event edit notification hook:', error);
+  }
+};
+
+/**
+ * Track title version history for an event
+ */
+async function trackTitleVersionHistory(
+  eventId: string,
+  previousTitle: string,
+  username: string,
+  EventModel: EventModel,
+  TextVersionModel: TextVersionModel,
+  UserModel: UserModel
+): Promise<string | null> {
+  logger.info(`Tracking title version history for event ${eventId}`);
+
+  try {
+    const users = await UserModel.find({
+      where: { username },
+      selectionSet: `{ username }`
+    });
+
+    if (!users.length) {
+      logger.info('User not found');
+      return null;
+    }
+
+    const textVersionResult = await TextVersionModel.create({
+      input: [{
+        body: previousTitle,
+        Author: {
+          connect: { where: { node: { username } } }
+        }
+      }]
+    });
+
+    if (!textVersionResult.textVersions.length) {
+      logger.info('Failed to create TextVersion');
+      return null;
+    }
+
+    const textVersionId = textVersionResult.textVersions[0].id;
+
+    await EventModel.update({
+      where: { id: eventId },
+      update: {
+        PastTitleVersions: {
+          connect: [{
+            where: {
+              node: { id: textVersionId }
+            }
+          }]
+        }
+      } as unknown as EventUpdateInput
+    });
+
+    logger.info(`Successfully added title version history for event ${eventId}`);
+    return textVersionId;
+  } catch (error) {
+    logger.error('Error tracking title version history:', error);
+    return null;
+  }
+}
+
+/**
+ * Track description version history for an event
+ */
+async function trackDescriptionVersionHistory(
+  eventId: string,
+  previousDescription: string | null | undefined,
+  username: string,
+  EventModel: EventModel,
+  TextVersionModel: TextVersionModel,
+  UserModel: UserModel
+): Promise<string | null> {
+  logger.info(`Tracking description version history for event ${eventId}`);
+
+  try {
+    // Normalize null/undefined to empty string so mod edits of an empty
+    // description are still attributed in the revision history.
+    const descriptionToTrack = previousDescription ?? '';
+
+    const users = await UserModel.find({
+      where: { username },
+      selectionSet: `{ username }`
+    });
+
+    if (!users.length) {
+      logger.info('User not found');
+      return null;
+    }
+
+    const textVersionResult = await TextVersionModel.create({
+      input: [{
+        body: descriptionToTrack,
+        Author: {
+          connect: { where: { node: { username } } }
+        }
+      }]
+    });
+
+    if (!textVersionResult.textVersions.length) {
+      logger.info('Failed to create TextVersion');
+      return null;
+    }
+
+    const textVersionId = textVersionResult.textVersions[0].id;
+
+    await EventModel.update({
+      where: { id: eventId },
+      update: {
+        PastDescriptionVersions: {
+          connect: [{
+            where: {
+              node: { id: textVersionId }
+            }
+          }]
+        }
+      } as unknown as EventUpdateInput
+    });
+
+    logger.info(`Successfully added description version history for event ${eventId}`);
+    return textVersionId;
+  } catch (error) {
+    logger.error('Error tracking description version history:', error);
+    return null;
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ import typesDefinitions from "./typeDefs.js";
 import permissions from "./permissions.js";
 import discussionVersionHistoryMiddleware from "./middleware/discussionVersionHistoryMiddleware.js";
 import commentVersionHistoryMiddleware from "./middleware/commentVersionHistoryMiddleware.js";
+import eventVersionHistoryMiddleware from "./middleware/eventVersionHistoryMiddleware.js";
 import commentMentionsMiddleware from "./middleware/commentMentionsMiddleware.js";
 import commentPluginPipelineMiddleware from "./middleware/commentPluginPipelineMiddleware.js";
 import commentUserMentionsMiddleware from "./middleware/commentUserMentionsMiddleware.js";
@@ -182,6 +183,7 @@ async function initializeServer() {
       discussionVersionHistoryMiddleware as AppMiddleware,
       discussionMentionsMiddleware as AppMiddleware,
       commentVersionHistoryMiddleware as AppMiddleware,
+      eventVersionHistoryMiddleware as AppMiddleware,
       commentMentionsMiddleware as AppMiddleware,
       commentUserMentionsMiddleware as AppMiddleware,
       commentPluginPipelineMiddleware as AppMiddleware,

--- a/middleware/eventVersionHistoryMiddleware.ts
+++ b/middleware/eventVersionHistoryMiddleware.ts
@@ -1,0 +1,104 @@
+/**
+ * Middleware for tracking event version history.
+ * This middleware runs before event update operations to capture the previous
+ * values of title and description before they are updated. It mirrors the
+ * discussion version history middleware.
+ */
+
+import {
+  eventEditNotificationHandler,
+  eventVersionHistoryHandler,
+  type EventSnapshot,
+} from "../hooks/eventVersionHistoryHook.js";
+import { GraphQLResolveInfo } from 'graphql';
+import type { GraphQLContext } from "../types/context.js";
+
+interface UpdateEventsArgs {
+  where?: {
+    id?: string;
+  };
+  update?: {
+    title?: string;
+    description?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+const eventSnapshotSelectionSet = `{
+  id
+  title
+  description
+  Poster {
+    username
+  }
+  DescriptionLastEditedBy {
+    username
+  }
+  EventChannels {
+    channelUniqueName
+  }
+  PastTitleVersions {
+    id
+    body
+    createdAt
+  }
+  PastDescriptionVersions {
+    id
+    body
+    createdAt
+  }
+}`;
+
+const eventVersionHistoryMiddleware = {
+  Mutation: {
+    // Apply to the auto-generated updateEvents mutation
+    updateEvents: async (
+      resolve: (parent: unknown, args: UpdateEventsArgs, context: GraphQLContext, info: GraphQLResolveInfo) => Promise<unknown>,
+      parent: unknown,
+      args: UpdateEventsArgs,
+      context: GraphQLContext,
+      info: GraphQLResolveInfo
+    ) => {
+      const { where, update } = args;
+      if (!update) {
+        return resolve(parent, args, context, info);
+      }
+      const eventId = where?.id;
+      let eventSnapshot: EventSnapshot | null = null;
+
+      if (update.title !== undefined || update.description !== undefined) {
+        if (eventId) {
+          const EventModel = context.ogm.model("Event");
+          const events = await EventModel.find({
+            where: { id: eventId },
+            selectionSet: eventSnapshotSelectionSet,
+          });
+          eventSnapshot = (events[0] as unknown as EventSnapshot) ?? null;
+        }
+
+        if (eventSnapshot) {
+          await eventVersionHistoryHandler({
+            context,
+            params: { where, update },
+            eventSnapshot,
+          });
+        }
+      }
+
+      const result = await resolve(parent, args, context, info);
+
+      if (eventSnapshot && eventId) {
+        await eventEditNotificationHandler({
+          context,
+          params: { where, update },
+          eventSnapshot,
+        });
+      }
+
+      return result;
+    },
+  },
+};
+
+export default eventVersionHistoryMiddleware;

--- a/permissions.ts
+++ b/permissions.ts
@@ -189,6 +189,7 @@ const permissionList = shield({
       deleteTextVersions: deny,
       deleteCommentRevision: and(isAuthenticated, allow),
       deleteDiscussionBodyRevision: and(isAuthenticated, allow),
+      deleteEventDescriptionRevision: and(isAuthenticated, allow),
       deleteWikiRevision: and(isAuthenticated, allow),
       deleteWikiPages: and(isAuthenticated, canDeleteWikiPages),
       createWikiPages: and(isAuthenticated, canEditWikiPages),

--- a/tests/integration/revisionRedaction.test.ts
+++ b/tests/integration/revisionRedaction.test.ts
@@ -116,6 +116,49 @@ test("a wiki page original author can redact a wiki revision", async () => {
   assert.equal(await bodyOf("v-wiki"), REDACTED_REVISION_BODY);
 });
 
+test("an event OP can redact their own event description revision", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (e:Event { id: 'e1', title: 'My Event', createdAt: datetime() })
+     CREATE (ec:EventChannel { id: 'ec1', eventId: 'e1', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-event', body: 'old description', createdAt: datetime() })
+     CREATE (e)-[:HAS_DESCRIPTION_VERSION]->(v)
+     CREATE (ec)-[:POSTED_IN_CHANNEL]->(e)
+     CREATE (alice)-[:POSTED_BY]->(e)`
+  );
+
+  await env.resolvers.Mutation.deleteEventDescriptionRevision(
+    null,
+    { textVersionId: "v-event" },
+    ctxFor("alice"),
+    info
+  );
+
+  assert.equal(await bodyOf("v-event"), REDACTED_REVISION_BODY);
+});
+
+test("calling deleteEventDescriptionRevision with a discussion revision id is rejected", async () => {
+  await run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (d:Discussion { id: 'd1', title: 'My Discussion', createdAt: datetime() })
+     CREATE (v:TextVersion { id: 'v-discussion', body: 'old body', createdAt: datetime() })
+     CREATE (d)-[:HAS_BODY_VERSION]->(v)
+     CREATE (alice)-[:POSTED_DISCUSSION]->(d)`
+  );
+
+  await assert.rejects(
+    env.resolvers.Mutation.deleteEventDescriptionRevision(
+      null,
+      { textVersionId: "v-discussion" },
+      ctxFor("alice"),
+      info
+    ),
+    /event description revision not found/
+  );
+
+  assert.equal(await bodyOf("v-discussion"), "old body");
+});
+
 test("calling deleteCommentRevision with a wiki revision id is rejected", async () => {
   await run(
     `CREATE (alice:User { username: 'alice', createdAt: datetime() })

--- a/tests/integration/versionHistoryHooks.test.ts
+++ b/tests/integration/versionHistoryHooks.test.ts
@@ -14,6 +14,10 @@ import {
   discussionVersionHistoryHandler,
   discussionEditNotificationHandler,
 } from "../../hooks/discussionVersionHistoryHook.js";
+import {
+  eventVersionHistoryHandler,
+  eventEditNotificationHandler,
+} from "../../hooks/eventVersionHistoryHook.js";
 import { wikiPageVersionHistoryHandler } from "../../hooks/wikiPageVersionHistoryHook.js";
 import { notifyArchivedContentAuthor } from "../../hooks/archivedContentNotificationHook.js";
 import {
@@ -174,6 +178,144 @@ test("discussionEditNotificationHandler does not notify when the author edits th
     discussionSnapshot: {
       Author: { username: "alice" },
       DiscussionChannels: [{ channelUniqueName: "cats" }],
+      title: "Old Title",
+    },
+  });
+
+  assert.equal((await notificationsFor("alice")).length, 0);
+});
+
+// --- event version history hook ---
+
+const seedEvent = () =>
+  run(
+    `CREATE (alice:User { username: 'alice', createdAt: datetime() })
+     CREATE (mod:User { username: 'mod', createdAt: datetime() })
+     CREATE (ch:Channel { uniqueName: 'cats', createdAt: datetime() })
+     CREATE (e:Event { id: 'e1', title: 'Old Title', description: 'Old description', createdAt: datetime() })
+     CREATE (ec:EventChannel { id: 'ec1', eventId: 'e1', channelUniqueName: 'cats', createdAt: datetime() })
+     CREATE (ec)-[:POSTED_IN_CHANNEL]->(e)
+     CREATE (alice)-[:POSTED_BY]->(e)`
+  );
+
+test("eventVersionHistoryHandler saves pre-edit title and description versions and updates DescriptionLastEditedBy", async () => {
+  await seedEvent();
+
+  await eventVersionHistoryHandler({
+    context: editorCtx("mod"),
+    params: {
+      where: { id: "e1" },
+      update: { title: "New Title", description: "New description" },
+    },
+  });
+
+  const titleV = await run(
+    `MATCH (:Event { id: 'e1' })-[:HAS_TITLE_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, u.username AS author`
+  );
+  assert.equal(titleV.length, 1);
+  assert.equal(titleV[0].body, "Old Title");
+  assert.equal(titleV[0].author, "mod", "title revision is attributed to the editor");
+
+  const descV = await run(
+    `MATCH (:Event { id: 'e1' })-[:HAS_DESCRIPTION_VERSION]->(tv:TextVersion)<-[:AUTHORED_VERSION]-(u:User)
+     RETURN tv.body AS body, u.username AS author`
+  );
+  assert.equal(descV.length, 1);
+  assert.equal(descV[0].body, "Old description");
+  assert.equal(descV[0].author, "alice", "description revision is attributed to the content author");
+
+  const lastEdited = await run(
+    `MATCH (:Event { id: 'e1' })-[:DESCRIPTION_LAST_EDITED_BY]->(u:User) RETURN u.username AS username`
+  );
+  assert.equal(lastEdited.length, 1);
+  assert.equal(lastEdited[0].username, "mod");
+});
+
+test("eventVersionHistoryHandler saves only a title version when only the title changes", async () => {
+  await seedEvent();
+
+  await eventVersionHistoryHandler({
+    context: editorCtx("mod"),
+    params: {
+      where: { id: "e1" },
+      update: { title: "New Title", description: "Old description" },
+    },
+  });
+
+  const versions = await run(
+    `MATCH (:Event { id: 'e1' })-[r]->(tv:TextVersion)
+     RETURN type(r) AS rel, tv.body AS body`
+  );
+  assert.deepEqual(
+    versions.map((v: any) => ({ rel: v.rel, body: v.body })),
+    [{ rel: "HAS_TITLE_VERSION", body: "Old Title" }]
+  );
+});
+
+test("eventVersionHistoryHandler saves only a description version when only the description changes", async () => {
+  await seedEvent();
+
+  await eventVersionHistoryHandler({
+    context: editorCtx("mod"),
+    params: {
+      where: { id: "e1" },
+      update: { title: "Old Title", description: "New description" },
+    },
+  });
+
+  const versions = await run(
+    `MATCH (:Event { id: 'e1' })-[r]->(tv:TextVersion)
+     RETURN type(r) AS rel, tv.body AS body`
+  );
+  assert.deepEqual(
+    versions.map((v: any) => ({ rel: v.rel, body: v.body })),
+    [{ rel: "HAS_DESCRIPTION_VERSION", body: "Old description" }]
+  );
+});
+
+test("eventVersionHistoryHandler is a no-op when title and description are unchanged", async () => {
+  await seedEvent();
+
+  await eventVersionHistoryHandler({
+    context: editorCtx("alice"),
+    params: {
+      where: { id: "e1" },
+      update: { title: "Old Title", description: "Old description" },
+    },
+  });
+
+  const versions = await run(`MATCH (tv:TextVersion) RETURN count(tv) AS n`);
+  assert.equal(Number(versions[0].n), 0);
+});
+
+test("eventEditNotificationHandler notifies the event author of a moderator edit", async () => {
+  await run(`CREATE (:User { username: 'alice', createdAt: datetime() })`);
+
+  await eventEditNotificationHandler({
+    context: editorCtx("mod"),
+    params: { where: { id: "e1" }, update: { title: "New Title" } },
+    eventSnapshot: {
+      Poster: { username: "alice" },
+      EventChannels: [{ channelUniqueName: "cats" }],
+      title: "Old Title",
+    },
+  });
+
+  const notifs = await notificationsFor("alice");
+  assert.equal(notifs.length, 1);
+  assert.match(notifs[0].text, /edited your event/i);
+});
+
+test("eventEditNotificationHandler does not notify when the author edits their own event", async () => {
+  await run(`CREATE (:User { username: 'alice', createdAt: datetime() })`);
+
+  await eventEditNotificationHandler({
+    context: editorCtx("alice"),
+    params: { where: { id: "e1" }, update: { title: "New Title" } },
+    eventSnapshot: {
+      Poster: { username: "alice" },
+      EventChannels: [{ channelUniqueName: "cats" }],
       title: "Old Title",
     },
   });

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -801,6 +801,12 @@ const typeDefinitions = gql`
     isAllDay: Boolean
     coverImageURL: String
     locked: Boolean
+    PastTitleVersions: [TextVersion!]!
+      @relationship(type: "HAS_TITLE_VERSION", direction: OUT)
+    PastDescriptionVersions: [TextVersion!]!
+      @relationship(type: "HAS_DESCRIPTION_VERSION", direction: OUT)
+    DescriptionLastEditedBy: User
+      @relationship(type: "DESCRIPTION_LAST_EDITED_BY", direction: OUT)
     # Series-related fields
     occurrenceIndex: Int # Position in series (0-based), null for standalone events
     overrideSeriesTitle: Boolean # True if title diverged from series
@@ -1285,6 +1291,7 @@ const typeDefinitions = gql`
     ): Issue
     deleteCommentRevision(textVersionId: ID!): TextVersion
     deleteDiscussionBodyRevision(textVersionId: ID!): TextVersion
+    deleteEventDescriptionRevision(textVersionId: ID!): TextVersion
     deleteWikiRevision(textVersionId: ID!): TextVersion
     reportChannel(
       channelUniqueName: String!


### PR DESCRIPTION
## Summary

Adds edit-history (revision) support for **event titles and descriptions**, mirroring the existing Discussion version-history pattern. This is the backend half of roadmap item #16 (Event edit history). The frontend PR (query fields + revision UI) is stacked on top.

## Changes

- **Schema** (`typeDefs.ts`): add `PastTitleVersions` (`HAS_TITLE_VERSION`), `PastDescriptionVersions` (`HAS_DESCRIPTION_VERSION`), and `DescriptionLastEditedBy` (`DESCRIPTION_LAST_EDITED_BY`) to `Event`, reusing the existing `TextVersion` type. Add `deleteEventDescriptionRevision` mutation.
- **Hook** (`hooks/eventVersionHistoryHook.ts`): snapshot the pre-edit title/description into `TextVersion` nodes on update; attribute the title revision to the editor and the description revision to the content author; update `DescriptionLastEditedBy`; emit issue activity-feed items and notify the OP on a moderator edit.
- **Middleware** (`middleware/eventVersionHistoryMiddleware.ts`): intercept the generated `updateEvents` mutation; also wired into the custom `updateEventWithChannelConnections` resolver.
- **Redaction**: extend `redactTextVersionRevision` to cover `event description` revisions (Cypher branch resolving OP + channel via `EventChannel`, `canEditEvents` permission), register the resolver + shield rule.

## Scope

- Redaction covers **description** revisions (mirrors discussion body); titles are non-redactable, consistent with discussions.
- **Series edits** (`updateEventInSeries`) are intentionally out of scope for this slice — that path applies updates across multiple occurrences/scopes and warrants its own change. Single-event edits via `updateEventWithChannelConnections` and generated `updateEvents` are covered.

## Tests

Integration tests (live Neo4j via testcontainers), all green locally (20/20 in the two touched files):
- title-only, description-only, combined, and no-op edits
- author attribution (editor vs content author) and `DescriptionLastEditedBy`
- moderator edit notification + self-edit no-op
- event description revision redaction (OP allowed) and mismatched-mutation rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)