### PR TITLE
Add my-involvement filters to the site-wide issue list

### DIFF
--- a/customResolvers/cypher/getSiteWideIssuesQuery.cypher
+++ b/customResolvers/cypher/getSiteWideIssuesQuery.cypher
@@ -5,6 +5,9 @@ AND (size($selectedChannels) = 0 OR issue.channelUniqueName IN $selectedChannels
 AND ($showOnlyServerRuleViolations = false OR coalesce(issue.flaggedServerRuleViolation, false) = true)
 AND ($startDate IS NULL OR datetime(issue.createdAt) >= datetime($startDate))
 AND ($endDate IS NULL OR datetime(issue.createdAt) <= datetime($endDate))
+AND ($filterCreatedByMe = false OR issue.authorName = $loggedInUsername OR EXISTS { (issue)<-[:AUTHORED_ISSUE]-(author) WHERE author.username = $loggedInUsername OR author.displayName = $loggedInModProfileName })
+AND ($filterIAmOP = false OR issue.relatedUsername = $loggedInUsername OR issue.relatedModProfileName = $loggedInModProfileName)
+AND ($filterIReported = false OR EXISTS { (issue)-[:ACTIVITY_ON_ISSUE]->(:ModerationAction {actionType: "report"})<-[:PERFORMED_MODERATION_ACTION]-(reporter) WHERE reporter.username = $loggedInUsername OR reporter.displayName = $loggedInModProfileName })
 WITH count(issue) AS totalCount
 
 MATCH (issue:Issue)
@@ -14,6 +17,9 @@ AND (size($selectedChannels) = 0 OR issue.channelUniqueName IN $selectedChannels
 AND ($showOnlyServerRuleViolations = false OR coalesce(issue.flaggedServerRuleViolation, false) = true)
 AND ($startDate IS NULL OR datetime(issue.createdAt) >= datetime($startDate))
 AND ($endDate IS NULL OR datetime(issue.createdAt) <= datetime($endDate))
+AND ($filterCreatedByMe = false OR issue.authorName = $loggedInUsername OR EXISTS { (issue)<-[:AUTHORED_ISSUE]-(author) WHERE author.username = $loggedInUsername OR author.displayName = $loggedInModProfileName })
+AND ($filterIAmOP = false OR issue.relatedUsername = $loggedInUsername OR issue.relatedModProfileName = $loggedInModProfileName)
+AND ($filterIReported = false OR EXISTS { (issue)-[:ACTIVITY_ON_ISSUE]->(:ModerationAction {actionType: "report"})<-[:PERFORMED_MODERATION_ACTION]-(reporter) WHERE reporter.username = $loggedInUsername OR reporter.displayName = $loggedInModProfileName })
 OPTIONAL MATCH (issue)<-[:HAS_ISSUE]-(channel:Channel)
 OPTIONAL MATCH (issue)<-[:AUTHORED_ISSUE]-(authorUser:User)
 OPTIONAL MATCH (issue)<-[:AUTHORED_ISSUE]-(authorMod:ModerationProfile)

--- a/customResolvers/queries/getSiteWideIssueList.test.ts
+++ b/customResolvers/queries/getSiteWideIssueList.test.ts
@@ -37,6 +37,26 @@ const createMockContext = () =>
     },
   }) as unknown as GraphQLContext;
 
+// Pre-seeds context.user so setUserDataOnContext short-circuits (it returns the
+// existing user when a username is already present) instead of parsing a JWT.
+const createAuthedContext = (
+  username: string,
+  modProfileName: string | null = null
+) =>
+  ({
+    req: {
+      headers: {},
+    },
+    user: {
+      username,
+      email: null,
+      email_verified: true,
+      data: modProfileName
+        ? { ModerationProfile: { displayName: modProfileName } }
+        : null,
+    },
+  }) as unknown as GraphQLContext;
+
 const mockInfo = null as unknown as GraphQLResolveInfo;
 
 const baseArgs = {
@@ -174,6 +194,115 @@ test("getSiteWideIssueList returns issues and aggregate count", async () => {
     { id: "i1", title: "First", reportCount: 3 },
     { id: "i2", title: "Second", reportCount: 1 },
   ]);
+});
+
+test("getSiteWideIssueList defaults the involvement filters to false", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(null, baseArgs, createMockContext(), mockInfo);
+
+  assert.deepEqual(
+    {
+      filterCreatedByMe: driver.runCalls[0].params.filterCreatedByMe,
+      filterIAmOP: driver.runCalls[0].params.filterIAmOP,
+      filterIReported: driver.runCalls[0].params.filterIReported,
+    },
+    { filterCreatedByMe: false, filterIAmOP: false, filterIReported: false }
+  );
+});
+
+test("getSiteWideIssueList forwards the caller identity to the query", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    { ...baseArgs, filterCreatedByMe: true },
+    createAuthedContext("alice", "aliceMod"),
+    mockInfo
+  );
+
+  assert.deepEqual(
+    {
+      loggedInUsername: driver.runCalls[0].params.loggedInUsername,
+      loggedInModProfileName: driver.runCalls[0].params.loggedInModProfileName,
+      filterCreatedByMe: driver.runCalls[0].params.filterCreatedByMe,
+    },
+    {
+      loggedInUsername: "alice",
+      loggedInModProfileName: "aliceMod",
+      filterCreatedByMe: true,
+    }
+  );
+});
+
+test("getSiteWideIssueList enables filterIAmOP for an authed caller", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    { ...baseArgs, filterIAmOP: true },
+    createAuthedContext("alice"),
+    mockInfo
+  );
+
+  assert.equal(driver.runCalls[0].params.filterIAmOP, true);
+});
+
+test("getSiteWideIssueList enables filterIReported for an authed caller", async () => {
+  const driver = createMockDriver([]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  await resolver(
+    null,
+    { ...baseArgs, filterIReported: true },
+    createAuthedContext("alice"),
+    mockInfo
+  );
+
+  assert.equal(driver.runCalls[0].params.filterIReported, true);
+});
+
+test("getSiteWideIssueList returns empty without running the query when an involvement filter is requested unauthenticated", async () => {
+  const driver = createMockDriver([
+    { issue: { id: "i1" }, totalCount: 1 },
+  ]);
+  const resolver = getSiteWideIssueListResolver({ driver });
+
+  const result = await resolver(
+    null,
+    { ...baseArgs, filterCreatedByMe: true },
+    createMockContext(),
+    mockInfo
+  );
+
+  assert.deepEqual(
+    { runCalls: driver.runCalls.length, result },
+    { runCalls: 0, result: { aggregateIssueCount: 0, issues: [] } }
+  );
+});
+
+test("getSiteWideIssueList query filters by issue author for filterCreatedByMe", () => {
+  assert.match(
+    getSiteWideIssuesQuery,
+    /\$filterCreatedByMe = false OR issue\.authorName = \$loggedInUsername OR EXISTS \{ \(issue\)<-\[:AUTHORED_ISSUE\]-\(author\)/
+  );
+});
+
+test("getSiteWideIssueList query filters by reported-content author for filterIAmOP", () => {
+  assert.match(
+    getSiteWideIssuesQuery,
+    /\$filterIAmOP = false OR issue\.relatedUsername = \$loggedInUsername OR issue\.relatedModProfileName = \$loggedInModProfileName/
+  );
+});
+
+test("getSiteWideIssueList query filters by report author for filterIReported", () => {
+  assert.match(
+    getSiteWideIssuesQuery,
+    /\$filterIReported = false OR EXISTS \{ \(issue\)-\[:ACTIVITY_ON_ISSUE\]->\(:ModerationAction \{actionType: "report"\}\)<-\[:PERFORMED_MODERATION_ACTION\]-\(reporter\)/
+  );
 });
 
 test("getSiteWideIssueList query uses bound pagination params", () => {

--- a/customResolvers/queries/getSiteWideIssueList.ts
+++ b/customResolvers/queries/getSiteWideIssueList.ts
@@ -2,6 +2,7 @@ import type { GraphQLResolveInfo } from "graphql";
 import neo4j, { type Driver, type Record as Neo4jRecord } from "neo4j-driver";
 import { DateTime } from "luxon";
 import { getSiteWideIssuesQuery } from "../cypher/cypherQueries.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import type { GraphQLContext } from "../../types/context.js";
 import { logger } from "../../logger.js";
 
@@ -16,6 +17,9 @@ type Args = {
   endDate?: string | null;
   showOnlyServerRuleViolations?: boolean;
   isOpen: boolean;
+  filterCreatedByMe?: boolean | null;
+  filterIAmOP?: boolean | null;
+  filterIReported?: boolean | null;
   options?: {
     offset?: number | null;
     limit?: number | null;
@@ -78,6 +82,34 @@ const getResolver = (input: Input) => {
       ? args.options?.sort || "newest"
       : "newest";
 
+    // Resolve the caller's identity server-side so the "my involvement" filters
+    // cannot be spoofed by passing an arbitrary username from the client.
+    context.user = await setUserDataOnContext({ context });
+    const loggedInUsername = context.user?.username || null;
+    const loggedInModProfileName =
+      context.user?.data?.ModerationProfile?.displayName || null;
+
+    // A filter that needs an identity is a no-op (matches nothing) when the
+    // caller is not logged in, rather than silently returning every issue.
+    const hasIdentity = Boolean(loggedInUsername || loggedInModProfileName);
+    const filterCreatedByMe = Boolean(args.filterCreatedByMe) && hasIdentity;
+    const filterIAmOP = Boolean(args.filterIAmOP) && hasIdentity;
+    const filterIReported = Boolean(args.filterIReported) && hasIdentity;
+
+    const requestedIdentityFilter =
+      Boolean(args.filterCreatedByMe) ||
+      Boolean(args.filterIAmOP) ||
+      Boolean(args.filterIReported);
+
+    // An unauthenticated caller cannot match any identity filter, so short
+    // circuit to an empty result instead of running the query.
+    if (requestedIdentityFilter && !hasIdentity) {
+      return {
+        aggregateIssueCount: 0,
+        issues: [],
+      };
+    }
+
     const session = driver.session();
     const titleRegex = `(?i).*${searchInput}.*`;
     const bodyRegex = `(?i).*${searchInput}.*`;
@@ -94,6 +126,11 @@ const getResolver = (input: Input) => {
         startDate,
         endDate,
         isOpen: args.isOpen,
+        filterCreatedByMe,
+        filterIAmOP,
+        filterIReported,
+        loggedInUsername,
+        loggedInModProfileName,
         offset,
         limit,
         sort,

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -2151,6 +2151,12 @@ const typeDefinitions = gql`
       endDate: String
       showOnlyServerRuleViolations: Boolean
       isOpen: Boolean!
+      # Filter to issues the logged-in user authored (filed the report/issue).
+      filterCreatedByMe: Boolean
+      # Filter to issues about content authored by the logged-in user (they are the OP).
+      filterIAmOP: Boolean
+      # Filter to issues that have at least one report authored by the logged-in user.
+      filterIReported: Boolean
       options: IssueListOptions
     ): SiteWideIssueListFormat
     getSiteWideWikiList(


### PR DESCRIPTION
## What

Adds three server-side boolean filters to `getSiteWideIssueList` (the custom Cypher resolver behind the admin issue dashboard) so moderators can narrow the list to issues they are personally involved in:

- **`filterCreatedByMe`** — issues the caller authored (i.e. filed the report/issue)
- **`filterIAmOP`** — issues about content the caller authored (they are the OP of the reported content)
- **`filterIReported`** — issues that have at least one report authored by the caller

## Why

The admin issue list uses a hand-written Cypher resolver, not the Neo4j-GraphQL auto-generated `IssueWhere` filtering — so related-node filtering that the library can't express is done directly in the query. These "my involvement" cuts are a common moderator need.

## How

- **Identity is resolved server-side** from the request context via `setUserDataOnContext`, so a client cannot filter "as" another user. The resolver reads `context.user.username` and `context.user.data.ModerationProfile.displayName`.
- An involvement filter requested while **unauthenticated short-circuits to an empty result** rather than silently returning every issue.
- Filters are added as gated `AND` clauses in **both** the count block and the page block of `getSiteWideIssuesQuery.cypher`, using `EXISTS {}` subqueries so row cardinality (and the `reportCount` aggregate) stays correct. Multiple flags AND together.
  - created-by-me → `issue.authorName` / `AUTHORED_ISSUE` author
  - I-am-OP → denormalized `issue.relatedUsername` / `relatedModProfileName` (no traversal)
  - I-reported → `ACTIVITY_ON_ISSUE` → `ModerationAction{actionType:"report"}` ← `PERFORMED_MODERATION_ACTION` author

## Notes / follow-up

- `filterIAmOP` keys on `relatedUsername`/`relatedModProfileName`, which are populated by the report mutations (comment/discussion/wiki/image). Content whose report never set them won't match.
- The three checkboxes currently AND together; OR-combining would be a small Cypher tweak if desired.
- Frontend wiring (query variables, filter-bar checkboxes gated behind auth, both admin pages) lands in a separate multiforum-nuxt PR.

## Testing

- `tsc` — 0 errors
- `getSiteWideIssueList.test.ts` — 16/16 passing (adds default-off, identity forwarding, per-filter, unauthenticated-empty, and Cypher-shape cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)