### PR TITLE
Fix download-plugin trigger so downloadableFile.* plugins run on upload

### DIFF
--- a/customResolvers/mutations/createDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.ts
@@ -2,7 +2,7 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLResolveInfo } from "graphql";
 import { createDiscussionChannelQuery } from "../cypher/cypherQueries.js";
 import { DiscussionCreateInput } from "../../src/generated/graphql";
-import { triggerChannelPluginPipeline } from "../../services/pluginRunner.js";
+import { triggerChannelPluginPipeline, triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
 import { GraphQLError } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { sanitizeAlbumCreateNode } from "./utils/ownershipSanitizers.js";
@@ -218,6 +218,43 @@ export const createDiscussionsFromInput = async (
           } else {
             throw error;
           }
+        }
+      }
+
+      // Trigger the downloadable-file plugin pipeline (e.g. security scan) once
+      // per created download, mirroring the channel pipeline trigger above.
+      // Without this, plugins that handle downloadableFile.created never run on
+      // upload.
+      if (hasDownload && pluginModels) {
+        try {
+          const withFile = await Discussion.find({
+            where: { id: newDiscussionId },
+            selectionSet: `{ id DownloadableFiles { id } }`,
+          });
+          const downloadableFileId = (
+            withFile?.[0] as unknown as { DownloadableFiles?: Array<{ id?: string }> }
+          )?.DownloadableFiles?.[0]?.id;
+          if (downloadableFileId) {
+            await triggerPluginRunsForDownloadableFile({
+              downloadableFileId,
+              event: "downloadableFile.created",
+              models: {
+                DownloadableFile: pluginModels.DownloadableFile,
+                Plugin: null as any, // Not used by the download trigger
+                PluginVersion: null as any, // Not used by the download trigger
+                PluginRun: pluginModels.PluginRun,
+                ServerConfig: pluginModels.ServerConfig,
+                ServerSecret: pluginModels.ServerSecret,
+              },
+            });
+          }
+        } catch (triggerError: unknown) {
+          const message =
+            triggerError instanceof Error ? triggerError.message : String(triggerError);
+          logger.error(
+            `downloadableFile.created plugin trigger error for ${newDiscussionId}:`,
+            message
+          );
         }
       }
 

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -301,8 +301,23 @@ export const triggerPluginRunsForDownloadableFile = async (
         }
       }
 
-      const settingsDefaults = pluginVersionData.settingsDefaults || {}
-      const settingsJson = edgeData.properties?.settingsJson || {}
+      // settingsJson / settingsDefaults may be stored as JSON strings; parse
+      // them before merging so plugin settings resolve to real keys instead of
+      // string character indices.
+      const parseMaybeJson = (value: unknown): Record<string, unknown> => {
+        if (typeof value === 'string') {
+          try {
+            return JSON.parse(value) as Record<string, unknown>
+          } catch {
+            return {}
+          }
+        }
+        return value && typeof value === 'object'
+          ? (value as Record<string, unknown>)
+          : {}
+      }
+      const settingsDefaults = parseMaybeJson(pluginVersionData.settingsDefaults)
+      const settingsJson = parseMaybeJson(edgeData.properties?.settingsJson)
       const runtimeSettings = mergeSettings(settingsDefaults, settingsJson)
       const attachments = getAttachmentUrls(downloadableFile)
 

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -454,6 +454,10 @@ const typeDefinitions = gql`
 
     # purchases back‑ref
     purchasers: [Purchase!]! @relationship(type: "PURCHASED_FILE", direction: IN)
+
+    # owning discussion (reverse of Discussion.DownloadableFiles); used by the
+    # downloadableFile.* plugin trigger to resolve the file's channel context.
+    Discussion: Discussion @relationship(type: "HAS_DOWNLOADABLE_FILE", direction: IN)
   }
 
   type FilterGroup {


### PR DESCRIPTION
## Summary

Makes plugins that handle `downloadableFile.*` events (e.g. `security-attachment-scan`) actually run when a file is uploaded. The whole download-plugin path had never executed, so it was broken at four points. Found via a manual end-to-end test of the security scan plugin.

## The four fixes

1. **Trigger was never invoked** — `createDiscussionWithChannelConnections` fired only the *channel* pipeline (`triggerChannelPluginPipeline`, `discussionChannel.created`). Added a call to `triggerPluginRunsForDownloadableFile({ event: 'downloadableFile.created' })` after the download is created, reading the file id via `Discussion.find` selection set `{ DownloadableFiles { id } }`.

2. **Missing schema relationship** — `downloadTrigger` queries `DownloadableFile.Discussion` to resolve the file's channel context, but `DownloadableFile` had no reverse `Discussion` field. Added `Discussion: Discussion @relationship(type: "HAS_DOWNLOADABLE_FILE", direction: IN)`.

3. **Settings never parsed** — `edgeData.properties.settingsJson` (and `settingsDefaults`) come back as JSON **strings**. They were passed to `mergeSettings` unparsed, so plugin settings became string character-index keys and configured values (e.g. `serviceUrl`) were lost — the plugin then reported itself unconfigured. Added `parseMaybeJson()`. (Secrets were unaffected.)

*(Item 1's wrong-field variant — `DownloadableFile` vs `DownloadableFiles` — was fixed along the way; the committed code uses the correct plural.)*

## Verification

Uploaded a zip containing `installer.exe` as a forum owner → the plugin fired → called the standalone scan service → returned `malicious` (`Disallowed file type: 'installer.exe'`) → `handleEvent` returns `success:false`, blocking per the plugin's `blockOn: malicious` setting. The comment-plugin path was already working; only the download path was broken.

## Notes

- No schema regen was needed to run (the runtime OGM schema is built from `typeDefs` at startup); a follow-up `pnpm run codegen` will refresh `ogm_types.ts` for the new field.
- Consider adding integration coverage for the download-plugin trigger, which had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
