### PR TITLE
Sever the mod-profile ↔ user identity link in the GraphQL API

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -113,6 +113,16 @@ const permissionList = shield({
       purchases: isAccountOwner,
       library: isAccountOwner,
 
+      // Moderation profiles are pseudonymous by design: their activity/history
+      // is public for transparency, but the link to the real account (username,
+      // email) must not be discoverable through the API. Only the account owner
+      // may traverse their own User -> ModerationProfile edge (e.g. to learn
+      // their own mod-profile name); nobody can look up someone else's. There is
+      // deliberately no admin override — if an admin truly needs the mapping
+      // they must run a direct database query. See ModerationProfile.User below,
+      // which blocks the reverse (mod profile -> user) direction outright.
+      ModerationProfile: isAccountOwner,
+
       // Sensitive settings - only user can access
       enableSensitiveContentByDefault: isAccountOwner,
       notifyOnReplyToCommentByDefault: isAccountOwner,
@@ -126,6 +136,17 @@ const permissionList = shield({
       notificationBundleContent: isAccountOwner,
 
       // Default rule for any unspecified fields - allow public access
+      "*": allow,
+    },
+    ModerationProfile: {
+      // The reverse of User.ModerationProfile: a mod profile must never resolve
+      // back to the user behind it. No client or resolver traverses this edge;
+      // an admin who genuinely needs the mapping must use a direct DB query.
+      // Denied for everyone (including the account owner) — the pseudonymous
+      // identity is one-way from the API's perspective.
+      User: deny,
+      // Everything else on a moderation profile is public for transparency and
+      // audit: displayName, AuthoredIssues, AuthoredComments, ActivityFeed, etc.
       "*": allow,
     },
     Mutation: {

--- a/tests/integration/moderationProfileIdentityLink.test.ts
+++ b/tests/integration/moderationProfileIdentityLink.test.ts
@@ -93,8 +93,10 @@ after(async () => {
 const mockToken = (claims: Record<string, unknown>) =>
   `Bearer ${jwt.sign(claims, "mock-signing-key")}`;
 
-const exec = (source: string, authorization?: string) =>
-  graphql({
+// The executed queries return dynamically shaped data, so the result is cast
+// to `any` for indexing (matching the other integration tests).
+const exec = async (source: string, authorization?: string) => {
+  const result = await graphql({
     schema,
     source,
     contextValue: {
@@ -107,6 +109,8 @@ const exec = (source: string, authorization?: string) =>
       },
     },
   });
+  return { data: result.data as any, errors: result.errors };
+};
 
 const MOD_TO_USER = `query {
   moderationProfiles(where: { displayName: "${MOD_PROFILE}" }) {

--- a/tests/integration/moderationProfileIdentityLink.test.ts
+++ b/tests/integration/moderationProfileIdentityLink.test.ts
@@ -1,0 +1,176 @@
+// Pseudonymity guard: a ModerationProfile's activity/history is public for
+// transparency, but the link between a mod profile and the real account
+// (username, email) must not be discoverable through the API in EITHER
+// direction. This runs real queries through the wired schema + graphql-shield
+// layer and asserts:
+//   - anonymous callers cannot resolve the User behind a ModerationProfile
+//     (ModerationProfile.User: deny), nor the ModerationProfile behind a User
+//     (User.ModerationProfile: isAccountOwner)
+//   - even an authenticated non-owner cannot resolve someone else's mod profile
+//   - the account OWNER can still resolve their own mod profile (needed by the
+//     registration/self flows), proving the gate is self-scoped, not a blanket
+//     removal of the field
+//   - the mod -> user edge is one-way-denied even for the owner, so a mod
+//     profile can never be used to reach the user's email
+//
+// These paths resolve real list data, so a Neo4j container is required.
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import { graphql, type GraphQLSchema } from "graphql";
+import type { Driver } from "neo4j-driver";
+import jwt from "jsonwebtoken";
+import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
+
+const USERNAME = "linkeduser";
+const MOD_PROFILE = "PseudoMod";
+const EMAIL = "secret@e2e.test";
+const OTHER_USERNAME = "otheruser";
+
+let container: StartedNeo4jContainer;
+let schema: GraphQLSchema;
+let driver: Driver;
+let ogm: any;
+
+before(async () => {
+  container = await new Neo4jContainer("neo4j:5-community")
+    .withApoc()
+    .withStartupTimeout(240000)
+    .start();
+  process.env.NEO4J_URI = container.getBoltUri();
+  process.env.NEO4J_USER = container.getUsername();
+  process.env.NEO4J_PASSWORD = container.getPassword();
+  // Use the app's mock-auth seam so a signed test JWT is decoded for its
+  // username/email claims instead of being verified against Auth0.
+  process.env.E2E_MOCK_AUTH = "true";
+
+  const { buildPermissionedSchema } = await import(
+    "../helpers/buildPermissionedSchema.js"
+  );
+  ({ schema, driver, ogm } = await buildPermissionedSchema());
+  await ogm.init();
+
+  // The container's "ready" signal can fire a moment before Bolt actually
+  // accepts queries; poll a trivial query so the first real write doesn't race
+  // the driver's connection pool.
+  for (let attempt = 0; ; attempt += 1) {
+    const probe = driver.session();
+    try {
+      await probe.run("RETURN 1");
+      break;
+    } catch (err) {
+      if (attempt >= 30) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } finally {
+      await probe.close();
+    }
+  }
+
+  const session = driver.session();
+  try {
+    // A user whose real identity (username + email) is linked to a pseudonymous
+    // moderation profile, plus an unrelated second user used for the
+    // authenticated-non-owner case.
+    await session.run(
+      `CREATE (u:User { username: $username })
+       CREATE (mp:ModerationProfile { displayName: $modProfile, createdAt: datetime() })
+       CREATE (u)-[:MODERATION_PROFILE]->(mp)
+       CREATE (e:Email { address: $email })
+       CREATE (e)-[:HAS_EMAIL]->(u)
+       CREATE (:User { username: $other })`,
+      { username: USERNAME, modProfile: MOD_PROFILE, email: EMAIL, other: OTHER_USERNAME }
+    );
+  } finally {
+    await session.close();
+  }
+}, { timeout: 240000 });
+
+after(async () => {
+  await driver?.close();
+  await container?.stop();
+});
+
+const mockToken = (claims: Record<string, unknown>) =>
+  `Bearer ${jwt.sign(claims, "mock-signing-key")}`;
+
+const exec = (source: string, authorization?: string) =>
+  graphql({
+    schema,
+    source,
+    contextValue: {
+      driver,
+      ogm,
+      req: {
+        headers: authorization ? { authorization } : {},
+        body: {},
+        isMutation: false,
+      },
+    },
+  });
+
+const MOD_TO_USER = `query {
+  moderationProfiles(where: { displayName: "${MOD_PROFILE}" }) {
+    displayName
+    User { username }
+  }
+}`;
+
+const USER_TO_MOD = `query {
+  users(where: { username: "${USERNAME}" }) {
+    username
+    ModerationProfile { displayName }
+  }
+}`;
+
+const MOD_TO_EMAIL = `query {
+  moderationProfiles(where: { displayName: "${MOD_PROFILE}" }) {
+    User { Email { address } }
+  }
+}`;
+
+test("public transparency field on a moderation profile still resolves", async () => {
+  const result = await exec(MOD_TO_USER);
+  assert.equal(result.data?.moderationProfiles?.[0]?.displayName, MOD_PROFILE);
+});
+
+test("anonymous caller cannot resolve the user behind a moderation profile", async () => {
+  const result = await exec(MOD_TO_USER);
+  assert.equal(result.data?.moderationProfiles?.[0]?.User, null);
+});
+
+test("anonymous caller cannot resolve the moderation profile behind a user", async () => {
+  const result = await exec(USER_TO_MOD);
+  assert.equal(result.data?.users?.[0]?.ModerationProfile, null);
+});
+
+test("public username field on a user still resolves", async () => {
+  const result = await exec(USER_TO_MOD);
+  assert.equal(result.data?.users?.[0]?.username, USERNAME);
+});
+
+test("an authenticated non-owner cannot resolve someone else's moderation profile", async () => {
+  const result = await exec(
+    USER_TO_MOD,
+    mockToken({ username: OTHER_USERNAME, email: "other@e2e.test" })
+  );
+  assert.equal(result.data?.users?.[0]?.ModerationProfile, null);
+});
+
+test("the account owner can resolve their own moderation profile", async () => {
+  const result = await exec(
+    USER_TO_MOD,
+    mockToken({ username: USERNAME, email: EMAIL })
+  );
+  assert.equal(
+    result.data?.users?.[0]?.ModerationProfile?.displayName,
+    MOD_PROFILE
+  );
+});
+
+test("the mod -> user edge is denied even for the account owner (one-way)", async () => {
+  const result = await exec(
+    MOD_TO_EMAIL,
+    mockToken({ username: USERNAME, email: EMAIL })
+  );
+  assert.equal(result.data?.moderationProfiles?.[0]?.User, null);
+});


### PR DESCRIPTION
## Problem

Moderation profiles are pseudonymous by design — their activity/history is public for transparency and audit, but the link to the real account (**username, email**) is not supposed to be discoverable through the API. The schema exposed that link in **both directions, ungated**:

- `ModerationProfile.User` inherited graphql-shield's default fallback rule (**allow**), because there was no `ModerationProfile` block in the shield map.
- `User.ModerationProfile` fell under the `User` block's `"*": allow`.
- The root `moderationProfiles` / `users` queries are public (`Query."*": allow`).

So **anyone, including logged-out visitors**, could deanonymize a moderator:

```graphql
{ moderationProfiles(where: { displayName: "SomeMod" }) { User { username } } }   # mod → username
{ users(where: { username: "alice" }) { ModerationProfile { displayName } } }      # username → mod
```

(Email itself was already protected — `emails: deny`, `User.Email: isAccountOwner` — so the exposed datum was username↔mod-profile, but that's exactly the connection that must not exist.)

This is pre-existing, but became materially more important now that the public `/server/issues` transparency view (frontend #318) makes mod-profile names browsable.

## Fix (shield rules only — `permissions.ts`)

- **`ModerationProfile.User: deny`** — the mod-profile→user direction is denied for everyone, including the account owner. No client or resolver traverses it; an admin who genuinely needs the mapping must run a direct DB query.
- **`User.ModerationProfile: isAccountOwner`** — a user may traverse to their **own** mod profile (needed by the registration payload / self flows), but not anyone else's.

Public transparency fields (`displayName`, `AuthoredIssues`, `AuthoredComments`, `ActivityFeed`, …) and the public `username` field remain readable. `Email` stays `isAccountOwner` and is now **doubly** unreachable via a mod profile.

## Verified behavior

Executed against a real Neo4j instance (schema + real graphql-shield layer), seeding `(:User {username:"linkeduser"})-[:MODERATION_PROFILE]->(:ModerationProfile {displayName:"PseudoMod"})` + linked `Email`:

| Query | Caller | Result |
|---|---|---|
| `moderationProfiles { displayName, User { username } }` | anonymous | `displayName` ✅ returned, `User` → **null** (Not Authorised) |
| `users { username, ModerationProfile { displayName } }` | anonymous | `username` ✅ returned, `ModerationProfile` → **null** (not owner) |
| `users { username, ModerationProfile { displayName } }` | authed **non-owner** | `ModerationProfile` → **null** (not owner) |
| `users { username, ModerationProfile { displayName } }` | authed **owner** | `ModerationProfile.displayName` = `"PseudoMod"` ✅ (self-access preserved) |
| `moderationProfiles { User { Email { address } } }` | authed owner | `User` → **null** (one-way, even for owner) |

## Test

Adds `tests/integration/moderationProfileIdentityLink.test.ts` covering all five cases above, following the repo's standard `buildPermissionedSchema` + testcontainer pattern (and `E2E_MOCK_AUTH` for the authenticated cases).

> Note: my local Docker/testcontainers environment could not boot the Neo4j testcontainer under `node --test` (the existing integration suite hits the same local boot issue), so I verified the behavior above by running the identical seed/queries against a directly-provisioned Neo4j instead. The committed test uses the standard testcontainer harness so it runs in CI.

## Follow-up (out of scope, flagged)

The shield map has no `fallbackRule`, so graphql-shield defaults to **`allow`** — meaning any *future* type/field added without an explicit rule is public by default. Worth a separate hardening discussion (flipping to `deny` would require auditing everything that currently relies on the implicit allow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)