### PR TITLE
Close related channel issue when unlocking

### DIFF
--- a/customResolvers/mutations/unlockChannel.ts
+++ b/customResolvers/mutations/unlockChannel.ts
@@ -151,6 +151,7 @@ const getResolver = (input: Input) => {
             ],
           },
         ],
+        isOpen: false,
       };
 
       try {

--- a/tests/integration/channelLockEdgeCases.test.ts
+++ b/tests/integration/channelLockEdgeCases.test.ts
@@ -3,7 +3,7 @@
 // cover the happy paths). These focus on cross-mutation interactions and
 // cleanup the existing suites don't assert:
 //
-//   - unlock leaves the issue OPEN, records an unlock_channel action, and
+//   - unlock closes the related issue, records an unlock_channel action, and
 //     disconnects the LockedBy ModerationProfile (lock-state cleanup)
 //   - report-then-lock funnels into a SINGLE server-scoped issue carrying both
 //     the report and lock_channel actions (issue de-duplication)
@@ -80,7 +80,7 @@ const createChannel = (admins: string[] = []) =>
 
 // --- Unlock: issue state + LockedBy cleanup ---
 
-test("unlock leaves the related issue open and records an unlock_channel action", async () => {
+test("unlock closes the related issue and records an unlock_channel action", async () => {
   await createChannel();
   await lockChannel();
   await unlockChannel();
@@ -91,7 +91,7 @@ test("unlock leaves the related issue open and records an unlock_channel action"
   );
   assert.deepEqual(
     { isOpen: issue[0].isOpen, hasLock: (issue[0].types as string[]).includes("lock_channel"), hasUnlock: (issue[0].types as string[]).includes("unlock_channel") },
-    { isOpen: true, hasLock: true, hasUnlock: true }
+    { isOpen: false, hasLock: true, hasUnlock: true }
   );
 });
 


### PR DESCRIPTION
## Summary
This updates `unlockChannel` so unlocking a previously locked channel also closes the related server-scoped issue.

## What Changed
- set `isOpen: false` when `unlockChannel` records its `unlock_channel` moderation action on the related issue
- updated the live integration test to assert that the issue is closed after unlock instead of remaining open

## Why
The current behavior leaves resolved-and-unlocked channels in the open channel-reports list until a moderator closes the issue by hand. That is inconsistent with the rest of the moderation flows, where undoing or resolving the flagged state typically closes the related issue.

## Validation
- `/Users/catherineluse/.nvm/versions/node/v22.12.0/bin/node --loader ts-node/esm --test tests/integration/channelLockEdgeCases.test.ts`

Closes #102