### PR TITLE
feat: enforce and preserve plugin configuration

### DIFF
--- a/customResolvers/mutations/enableServerPlugin.ts
+++ b/customResolvers/mutations/enableServerPlugin.ts
@@ -7,6 +7,11 @@ import type {
 } from '../../ogm_types.js'
 import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
+import {
+  buildPluginConfigStatus,
+  getBlockingConfigFields,
+  resolveSecretValidationStatus
+} from '../../services/plugin/configStatus.js'
 
 type Input = {
   Plugin: PluginModel
@@ -73,9 +78,7 @@ const getResolver = (input: Input) => {
       }
 
       // `manifest` is a JSON scalar, so it's still read as a dynamic record.
-      const manifest = (pluginVersion.manifest as Record<string, unknown>) || {}
-      const manifestSecrets = Array.isArray(manifest.secrets) ? manifest.secrets : []
-      const requiredServerSecrets = manifestSecrets.filter((secret: { scope?: string; required?: boolean }) => secret && secret.scope === 'server' && secret.required !== false)
+      const manifest = pluginVersion.manifest || {}
 
       // 2. Get server config
       const serverConfigs = await ServerConfig.find({
@@ -99,7 +102,7 @@ const getResolver = (input: Input) => {
         throw new Error(`Plugin ${pluginId} version ${version} is not installed. Please install it first.`)
       }
 
-      // 3. If enabling, validate required secrets from the manifest
+      // 3. If enabling, validate all required server-scoped configuration.
       if (enabled) {
         const secrets = await ServerSecret.find({
           where: { pluginId },
@@ -111,28 +114,21 @@ const getResolver = (input: Input) => {
           }`
         })
 
-        const secretMap = new Map(secrets.map(secret => [secret.key, secret]))
-        const requiredKeys = requiredServerSecrets.map((secret: { key: string }) => secret.key as string)
-
-        const missingKeys = requiredKeys.filter((key: string) => !secretMap.has(key))
-        if (missingKeys.length > 0) {
-          throw new Error(`Missing required secrets: ${missingKeys.join(', ')}`)
-        }
-
-        const invalidKeys = requiredKeys.filter((key: string) => {
-          const record = secretMap.get(key) as { isValid?: boolean | null; validationError?: string | null; lastValidatedAt?: string | null } | undefined
-          if (!record) return false
-          if (record.lastValidatedAt && record.isValid === false) {
-            return true
-          }
-          if (record.validationError) {
-            return true
-          }
-          return false
+        const configStatus = buildPluginConfigStatus({
+          manifest,
+          settingsJson,
+          secretStatuses: secrets.map(secret => ({
+            key: secret.key,
+            status: resolveSecretValidationStatus(secret)
+          })),
+          scope: 'server'
         })
-
-        if (invalidKeys.length > 0) {
-          throw new Error(`Cannot enable plugin: invalid or failing validation for secrets: ${invalidKeys.join(', ')}`)
+        const blockingFields = getBlockingConfigFields(configStatus)
+        if (blockingFields.length > 0) {
+          const details = blockingFields
+            .map(field => `${field.kind.toLowerCase()}:${field.key}:${field.message || 'Invalid value'}`)
+            .join(', ')
+          throw new Error(`PLUGIN_CONFIG_INCOMPLETE: ${details}`)
         }
       }
 

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -14,6 +14,7 @@ import type { GraphQLContext } from '../../types/context.js'
 import { logger } from "../../logger.js";
 import { downloadBytes, fetchMergedPluginRegistry, type RegistryVersion } from '../../services/plugin/registryService.js'
 import { getPluginVersionCompatibility } from '../../services/plugin/compatibility.js'
+import { reconcileSettings, type SettingsCarryOverReport } from '../../services/plugin/reconcileSettings.js'
 
 type Input = {
   Plugin: PluginModel
@@ -24,6 +25,16 @@ type Input = {
 type Args = {
   pluginId: string
   version: string
+  carrySettings?: boolean
+}
+
+type InstalledVersionEdge = {
+  properties?: { settingsJson?: unknown }
+  node?: {
+    id?: string
+    version?: string
+    Plugin?: { id?: string; name?: string }
+  }
 }
 
 const buildReleaseMetadataPayload = (registryVersion: RegistryVersion) => ({
@@ -39,7 +50,7 @@ const getResolver = (input: Input) => {
   const { Plugin, PluginVersion, ServerConfig } = input
 
   return async (_parent: unknown, args: Args, _context: GraphQLContext, _resolveInfo: GraphQLResolveInfo) => {
-    const { pluginId, version } = args
+    const { pluginId, version, carrySettings = false } = args
 
     try {
       // 1. Get server config to find registry URLs
@@ -299,18 +310,47 @@ const getResolver = (input: Input) => {
       const installedVersions = await ServerConfig.find({
         where: { serverName: serverConfig.serverName },
         selectionSet: `{
-          InstalledVersions(where: { id: "${pluginVersion.id}" }) {
-            id
-            version
-            Plugin {
-              id
-              name
+          InstalledVersionsConnection {
+            edges {
+              properties {
+                settingsJson
+              }
+              node {
+                id
+                version
+                Plugin {
+                  id
+                  name
+                }
+              }
             }
           }
         }`
       })
 
-      const isAlreadyInstalled = installedVersions[0]?.InstalledVersions?.length > 0
+      const installedEdges = (
+        installedVersions[0]?.InstalledVersionsConnection?.edges || []
+      ) as InstalledVersionEdge[]
+      const isAlreadyInstalled = installedEdges.some(
+        edge => edge.node?.id === pluginVersion.id
+      )
+      const previousVersionEdge = installedEdges.find(
+        edge =>
+          edge.node?.Plugin?.name === pluginSlug &&
+          edge.node?.id !== pluginVersion.id
+      )
+      let reconciledSettings: Record<string, unknown> | null = null
+      let carryOverReport: SettingsCarryOverReport | null = null
+
+      if (carrySettings && previousVersionEdge) {
+        const reconciled = reconcileSettings({
+          oldSettings: previousVersionEdge.properties?.settingsJson,
+          newManifest: artifacts.manifest,
+          scope: 'server'
+        })
+        reconciledSettings = reconciled.settings
+        carryOverReport = reconciled.report
+      }
 
       if (!isAlreadyInstalled) {
         logger.info('Installing plugin version, serverName:', serverConfig.serverName, 'pluginVersion.id:', pluginVersion.id)
@@ -322,7 +362,9 @@ const getResolver = (input: Input) => {
               where: { node: { id: String(pluginVersion.id) } },
               edge: {
                 enabled: false,
-                settingsJson: null
+                settingsJson: reconciledSettings
+                  ? JSON.stringify(reconciledSettings)
+                  : null
               }
             }]
           }
@@ -345,7 +387,8 @@ const getResolver = (input: Input) => {
         version: String(version),
         scope: 'SERVER',
         enabled: false,
-        settingsJson: null
+        settingsJson: reconciledSettings,
+        carryOverReport
       }
 
     } catch (error: unknown) {

--- a/customResolvers/queries/getPluginConfigStatus.ts
+++ b/customResolvers/queries/getPluginConfigStatus.ts
@@ -1,0 +1,81 @@
+import type { GraphQLResolveInfo } from 'graphql'
+import type {
+  PluginModel,
+  ServerConfigModel,
+  ServerSecretModel
+} from '../../ogm_types.js'
+import type { GraphQLContext } from '../../types/context.js'
+import { logger } from '../../logger.js'
+import {
+  buildPluginConfigStatus,
+  resolveSecretValidationStatus,
+  type PluginConfigScope
+} from '../../services/plugin/configStatus.js'
+
+type Input = {
+  Plugin: PluginModel
+  ServerConfig: ServerConfigModel
+  ServerSecret: ServerSecretModel
+}
+
+type Args = {
+  pluginId: string
+  version: string
+  scope?: PluginConfigScope
+}
+
+const getResolver = ({ Plugin, ServerConfig, ServerSecret }: Input) =>
+  async (_parent: unknown, args: Args, _context: GraphQLContext, _info: GraphQLResolveInfo) => {
+    const scope = args.scope || 'server'
+    try {
+      const plugins = await Plugin.find({
+        where: { name: args.pluginId },
+        selectionSet: `{
+          Versions(where: { version: "${args.version}" }) {
+            id
+            manifest
+          }
+        }`
+      })
+      const pluginVersion = plugins[0]?.Versions?.[0]
+      if (!pluginVersion) {
+        throw new Error(`Plugin ${args.pluginId} version ${args.version} not found`)
+      }
+
+      const serverConfigs = await ServerConfig.find({
+        selectionSet: `{
+          InstalledVersionsConnection(where: { node: { id: "${pluginVersion.id}" } }) {
+            edges {
+              properties { settingsJson }
+            }
+          }
+        }`
+      })
+      const edge = serverConfigs[0]?.InstalledVersionsConnection?.edges?.[0]
+      if (!edge) {
+        throw new Error(`Plugin ${args.pluginId} version ${args.version} is not installed`)
+      }
+
+      const secrets = scope === 'server'
+        ? await ServerSecret.find({
+            where: { pluginId: args.pluginId },
+            selectionSet: `{ key isValid lastValidatedAt validationError }`
+          })
+        : []
+
+      return buildPluginConfigStatus({
+        manifest: pluginVersion.manifest,
+        settingsJson: edge.properties?.settingsJson,
+        secretStatuses: secrets.map(secret => ({
+          key: secret.key,
+          status: resolveSecretValidationStatus(secret)
+        })),
+        scope
+      })
+    } catch (error) {
+      logger.error('Error in getPluginConfigStatus resolver:', error)
+      throw new Error(`Failed to get plugin config status: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+export default getResolver

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -25,6 +25,7 @@ import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
 import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
 import getImageAlbumUsage from "./queries/getImageAlbumUsage.js";
+import getPluginConfigStatus from './queries/getPluginConfigStatus.js'
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -38,6 +39,7 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     ModerationProfile,
     Channel,
     Issue,
+    Plugin,
     ServerConfig,
     ServerSecret,
     PluginRun,
@@ -103,6 +105,11 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     safetyCheck: safetyCheck,
     getServerPluginSecrets: getServerPluginSecrets({
+      ServerSecret
+    }),
+    getPluginConfigStatus: getPluginConfigStatus({
+      Plugin,
+      ServerConfig,
       ServerSecret
     }),
     getInstalledPlugins: getInstalledPlugins({

--- a/permissions.ts
+++ b/permissions.ts
@@ -79,6 +79,7 @@ const permissionList = shield({
       emails: deny,
       getUploadedDownloadableFiles: and(isAuthenticated, allow),
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
+      getPluginConfigStatus: and(isAuthenticated, canManagePlugins),
     },
     User: {
       // Public fields - anyone can access

--- a/services/plugin/configStatus.test.ts
+++ b/services/plugin/configStatus.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildPluginConfigStatus, getBlockingConfigFields } from './configStatus.js'
+
+const manifest = {
+  secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
+  settingsDefaults: { server: { retries: 3 } },
+  ui: {
+    forms: {
+      server: [{
+        title: 'Configuration',
+        fields: [
+          { key: 'serviceUrl', label: 'Service URL', type: 'text', validation: { required: true, pattern: '^https://' } },
+          { key: 'retries', label: 'Retries', type: 'number', validation: { required: true, min: 1 } },
+          { key: 'API_KEY', label: 'Duplicate API key', type: 'secret', validation: { required: true } }
+        ]
+      }]
+    }
+  }
+}
+
+test('reports missing required settings and secrets without duplicating secrets', () => {
+  const status = buildPluginConfigStatus({ manifest, settingsJson: {}, scope: 'server' })
+
+  assert.deepEqual(status, {
+    isFullyConfigured: false,
+    fields: [
+      { key: 'serviceUrl', label: 'Service URL', scope: 'server', kind: 'SETTING', required: true, isSet: false, isValid: false, message: 'Required setting is not set' },
+      { key: 'retries', label: 'Retries', scope: 'server', kind: 'SETTING', required: true, isSet: true, isValid: true, message: null },
+      { key: 'API_KEY', label: 'API_KEY', scope: 'server', kind: 'SECRET', required: true, isSet: false, isValid: false, message: 'Required secret is not set' }
+    ]
+  })
+})
+
+test('accepts valid saved settings and an untested but present secret', () => {
+  const status = buildPluginConfigStatus({
+    manifest,
+    settingsJson: { serviceUrl: 'https://scanner.example' },
+    secretStatuses: [{ key: 'API_KEY', status: 'SET_UNTESTED' }],
+    scope: 'server'
+  })
+
+  assert.equal(status.isFullyConfigured, true)
+})
+
+test('returns all blocking fields for a structured enable error', () => {
+  const status = buildPluginConfigStatus({
+    manifest,
+    settingsJson: { serviceUrl: 'http://insecure.example' },
+    secretStatuses: [{ key: 'API_KEY', status: 'INVALID' }],
+    scope: 'server'
+  })
+
+  assert.deepEqual(getBlockingConfigFields(status).map(field => field.key), ['serviceUrl', 'API_KEY'])
+})

--- a/services/plugin/configStatus.ts
+++ b/services/plugin/configStatus.ts
@@ -1,0 +1,217 @@
+export type PluginConfigScope = 'server' | 'channel'
+
+export type SecretValidationStatus =
+  | 'NOT_SET'
+  | 'SET_UNTESTED'
+  | 'VALID'
+  | 'INVALID'
+
+export type PluginConfigFieldStatus = {
+  key: string
+  label: string
+  scope: PluginConfigScope
+  kind: 'SETTING' | 'SECRET'
+  required: boolean
+  isSet: boolean
+  isValid: boolean
+  message: string | null
+}
+
+export type PluginConfigStatus = {
+  isFullyConfigured: boolean
+  fields: PluginConfigFieldStatus[]
+}
+
+type ManifestField = {
+  key?: unknown
+  label?: unknown
+  type?: unknown
+  required?: unknown
+  options?: Array<{ value?: unknown }>
+  validation?: {
+    required?: unknown
+    min?: unknown
+    max?: unknown
+    minLength?: unknown
+    maxLength?: unknown
+    pattern?: unknown
+  }
+}
+
+type ManifestSecret = {
+  key?: unknown
+  label?: unknown
+  scope?: unknown
+  required?: unknown
+}
+
+type Manifest = {
+  secrets?: unknown
+  settingsDefaults?: unknown
+  ui?: {
+    forms?: Partial<Record<PluginConfigScope, unknown>>
+  }
+}
+
+export type SecretStatusRecord = {
+  key: string
+  status: SecretValidationStatus
+}
+
+export const resolveSecretValidationStatus = (secret: {
+  isValid?: boolean | null
+  lastValidatedAt?: unknown
+  validationError?: string | null
+}): SecretValidationStatus => {
+  if (!secret.lastValidatedAt) return 'SET_UNTESTED'
+  return secret.isValid === true && !secret.validationError ? 'VALID' : 'INVALID'
+}
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+const parseRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== 'string') return asRecord(value)
+  try {
+    return asRecord(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+const isMateriallyPresent = (value: unknown): boolean => {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  return true
+}
+
+const validateSetting = (field: ManifestField, value: unknown): string | null => {
+  const required = field.required === true || field.validation?.required === true
+  if (!isMateriallyPresent(value)) {
+    return required ? 'Required setting is not set' : null
+  }
+
+  if (field.type === 'number' && (typeof value !== 'number' || !Number.isFinite(value))) {
+    return 'Value must be a number'
+  }
+  if ((field.type === 'boolean' || field.type === 'toggle') && typeof value !== 'boolean') {
+    return 'Value must be a boolean'
+  }
+  if (
+    ['text', 'textarea'].includes(String(field.type)) &&
+    typeof value !== 'string'
+  ) {
+    return 'Value must be text'
+  }
+
+  const allowedValues = Array.isArray(field.options)
+    ? field.options.map(option => option.value)
+    : []
+  if (field.type === 'select' && !allowedValues.some(option => Object.is(option, value))) {
+    return 'Value is not an allowed option'
+  }
+
+  const validation = field.validation || {}
+  if (typeof value === 'number') {
+    if (typeof validation.min === 'number' && value < validation.min) return `Value must be at least ${validation.min}`
+    if (typeof validation.max === 'number' && value > validation.max) return `Value must be at most ${validation.max}`
+  }
+  if (typeof value === 'string') {
+    if (typeof validation.minLength === 'number' && value.length < validation.minLength) return `Value must contain at least ${validation.minLength} characters`
+    if (typeof validation.maxLength === 'number' && value.length > validation.maxLength) return `Value must contain at most ${validation.maxLength} characters`
+    if (typeof validation.pattern === 'string') {
+      try {
+        if (!new RegExp(validation.pattern).test(value)) return 'Value has an invalid format'
+      } catch {
+        return 'Setting has an invalid validation pattern'
+      }
+    }
+  }
+
+  return null
+}
+
+export const buildPluginConfigStatus = (params: {
+  manifest: unknown
+  settingsJson: unknown
+  secretStatuses?: SecretStatusRecord[]
+  scope: PluginConfigScope
+}): PluginConfigStatus => {
+  const manifest = parseRecord(params.manifest) as Manifest
+  const defaults = parseRecord(asRecord(manifest.settingsDefaults)[params.scope])
+  const savedSettings = parseRecord(params.settingsJson)
+  const settings = { ...defaults, ...savedSettings }
+  const secretStatuses = new Map(
+    (params.secretStatuses || []).map(secret => [secret.key, secret.status])
+  )
+
+  const declaredSecrets = Array.isArray(manifest.secrets)
+    ? (manifest.secrets as ManifestSecret[]).filter(secret =>
+        secret &&
+        typeof secret.key === 'string' &&
+        (secret.scope === params.scope || secret.scope === undefined)
+      )
+    : []
+  const declaredSecretKeys = new Set(declaredSecrets.map(secret => String(secret.key)))
+
+  const sections = manifest.ui?.forms?.[params.scope]
+  const formFields = Array.isArray(sections)
+    ? sections.flatMap(section => {
+        const fields = asRecord(section).fields
+        return Array.isArray(fields) ? fields as ManifestField[] : []
+      })
+    : []
+
+  const settingFields: PluginConfigFieldStatus[] = formFields
+    .filter(field =>
+      typeof field?.key === 'string' &&
+      field.type !== 'secret' &&
+      !declaredSecretKeys.has(field.key)
+    )
+    .map(field => {
+      const key = String(field.key)
+      const value = settings[key]
+      const message = validateSetting(field, value)
+      return {
+        key,
+        label: typeof field.label === 'string' ? field.label : key,
+        scope: params.scope,
+        kind: 'SETTING' as const,
+        required: field.required === true || field.validation?.required === true,
+        isSet: isMateriallyPresent(value),
+        isValid: message === null,
+        message
+      }
+    })
+
+  const secretFields: PluginConfigFieldStatus[] = declaredSecrets.map(secret => {
+    const key = String(secret.key)
+    const status = secretStatuses.get(key) || 'NOT_SET'
+    const isSet = status !== 'NOT_SET'
+    const isValid = status === 'VALID' || status === 'SET_UNTESTED'
+    return {
+      key,
+      label: typeof secret.label === 'string' ? secret.label : key,
+      scope: params.scope,
+      kind: 'SECRET' as const,
+      required: secret.required !== false,
+      isSet,
+      isValid,
+      message: isValid ? null : (isSet ? 'Secret is invalid' : 'Required secret is not set')
+    }
+  })
+
+  const fields = [...settingFields, ...secretFields]
+  return {
+    fields,
+    isFullyConfigured: fields.every(field => !field.required || (field.isSet && field.isValid))
+  }
+}
+
+export const getBlockingConfigFields = (
+  status: PluginConfigStatus
+): PluginConfigFieldStatus[] => status.fields.filter(
+  field => field.required && (!field.isSet || !field.isValid)
+)

--- a/services/plugin/configStatus.ts
+++ b/services/plugin/configStatus.ts
@@ -22,7 +22,7 @@ export type PluginConfigStatus = {
   fields: PluginConfigFieldStatus[]
 }
 
-type ManifestField = {
+export type PluginManifestField = {
   key?: unknown
   label?: unknown
   type?: unknown
@@ -87,7 +87,7 @@ const isMateriallyPresent = (value: unknown): boolean => {
   return true
 }
 
-const validateSetting = (field: ManifestField, value: unknown): string | null => {
+export const validatePluginSetting = (field: PluginManifestField, value: unknown): string | null => {
   const required = field.required === true || field.validation?.required === true
   if (!isMateriallyPresent(value)) {
     return required ? 'Required setting is not set' : null
@@ -160,7 +160,7 @@ export const buildPluginConfigStatus = (params: {
   const formFields = Array.isArray(sections)
     ? sections.flatMap(section => {
         const fields = asRecord(section).fields
-        return Array.isArray(fields) ? fields as ManifestField[] : []
+        return Array.isArray(fields) ? fields as PluginManifestField[] : []
       })
     : []
 
@@ -173,7 +173,7 @@ export const buildPluginConfigStatus = (params: {
     .map(field => {
       const key = String(field.key)
       const value = settings[key]
-      const message = validateSetting(field, value)
+      const message = validatePluginSetting(field, value)
       return {
         key,
         label: typeof field.label === 'string' ? field.label : key,

--- a/services/plugin/reconcileSettings.test.ts
+++ b/services/plugin/reconcileSettings.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { reconcileSettings } from './reconcileSettings.js'
+
+const newManifest = {
+  settingsDefaults: {
+    server: { endpoint: 'https://default.example', mode: 'safe', retries: 2, added: true }
+  },
+  ui: {
+    forms: {
+      server: [{
+        title: 'Settings',
+        fields: [
+          { key: 'endpoint', type: 'text' },
+          { key: 'mode', type: 'select', options: [{ value: 'safe' }, { value: 'fast' }] },
+          { key: 'retries', type: 'number', validation: { min: 1, max: 5 } },
+          { key: 'added', type: 'toggle' },
+          { key: 'API_KEY', type: 'secret' }
+        ]
+      }]
+    }
+  }
+}
+
+test('carries compatible values, drops removed keys, and resets invalid values', () => {
+  const result = reconcileSettings({
+    oldSettings: {
+      endpoint: 'https://custom.example',
+      mode: 'removed-option',
+      retries: 4,
+      removed: 'old',
+      API_KEY: 'must-never-carry-as-a-setting'
+    },
+    newManifest,
+    scope: 'server'
+  })
+
+  assert.deepEqual(result, {
+    settings: {
+      endpoint: 'https://custom.example',
+      mode: 'safe',
+      retries: 4,
+      added: true
+    },
+    report: {
+      carried: ['endpoint', 'retries'],
+      dropped: ['removed', 'API_KEY'],
+      reset: ['mode'],
+      newDefaults: ['added']
+    }
+  })
+})
+
+test('supports JSON strings from Neo4j properties', () => {
+  const result = reconcileSettings({
+    oldSettings: '{"mode":"fast"}',
+    newManifest: JSON.stringify(newManifest),
+    scope: 'server'
+  })
+
+  assert.deepEqual(result.settings, {
+    endpoint: 'https://default.example',
+    mode: 'fast',
+    retries: 2,
+    added: true
+  })
+})

--- a/services/plugin/reconcileSettings.test.ts
+++ b/services/plugin/reconcileSettings.test.ts
@@ -4,7 +4,7 @@ import { reconcileSettings } from './reconcileSettings.js'
 
 const newManifest = {
   settingsDefaults: {
-    server: { endpoint: 'https://default.example', mode: 'safe', retries: 2, added: true }
+    server: { endpoint: 'https://default.example', mode: 'safe', retries: 2, added: true, profiles: [] }
   },
   ui: {
     forms: {
@@ -28,6 +28,7 @@ test('carries compatible values, drops removed keys, and resets invalid values',
       endpoint: 'https://custom.example',
       mode: 'removed-option',
       retries: 4,
+      profiles: [{ id: 'custom' }],
       removed: 'old',
       API_KEY: 'must-never-carry-as-a-setting'
     },
@@ -40,10 +41,11 @@ test('carries compatible values, drops removed keys, and resets invalid values',
       endpoint: 'https://custom.example',
       mode: 'safe',
       retries: 4,
-      added: true
+      added: true,
+      profiles: [{ id: 'custom' }]
     },
     report: {
-      carried: ['endpoint', 'retries'],
+      carried: ['endpoint', 'retries', 'profiles'],
       dropped: ['removed', 'API_KEY'],
       reset: ['mode'],
       newDefaults: ['added']
@@ -62,6 +64,7 @@ test('supports JSON strings from Neo4j properties', () => {
     endpoint: 'https://default.example',
     mode: 'fast',
     retries: 2,
-    added: true
+    added: true,
+    profiles: []
   })
 })

--- a/services/plugin/reconcileSettings.ts
+++ b/services/plugin/reconcileSettings.ts
@@ -1,0 +1,80 @@
+import {
+  validatePluginSetting,
+  type PluginConfigScope,
+  type PluginManifestField
+} from './configStatus.js'
+
+export type SettingsCarryOverReport = {
+  carried: string[]
+  dropped: string[]
+  reset: string[]
+  newDefaults: string[]
+}
+
+export type ReconciledSettings = {
+  settings: Record<string, unknown>
+  report: SettingsCarryOverReport
+}
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+const parseRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== 'string') return asRecord(value)
+  try {
+    return asRecord(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+const getFields = (manifest: Record<string, unknown>, scope: PluginConfigScope): PluginManifestField[] => {
+  const ui = asRecord(manifest.ui)
+  const forms = asRecord(ui.forms)
+  const sections = forms[scope]
+  if (!Array.isArray(sections)) return []
+  return sections.flatMap(section => {
+    const fields = asRecord(section).fields
+    return Array.isArray(fields) ? fields as PluginManifestField[] : []
+  }).filter(field => typeof field.key === 'string' && field.type !== 'secret')
+}
+
+export const reconcileSettings = (params: {
+  oldSettings: unknown
+  newManifest: unknown
+  scope: PluginConfigScope
+}): ReconciledSettings => {
+  const manifest = parseRecord(params.newManifest)
+  const defaults = parseRecord(asRecord(manifest.settingsDefaults)[params.scope])
+  const oldSettings = parseRecord(params.oldSettings)
+  const fields = getFields(manifest, params.scope)
+  const fieldsByKey = new Map(fields.map(field => [String(field.key), field]))
+  const settings: Record<string, unknown> = { ...defaults }
+  const carried: string[] = []
+  const dropped: string[] = []
+  const reset: string[] = []
+
+  for (const [key, value] of Object.entries(oldSettings)) {
+    const field = fieldsByKey.get(key)
+    if (!field) {
+      dropped.push(key)
+      continue
+    }
+    if (validatePluginSetting({ ...field, required: false, validation: { ...field.validation, required: false } }, value)) {
+      reset.push(key)
+      continue
+    }
+    settings[key] = value
+    carried.push(key)
+  }
+
+  const newDefaults = Object.keys(defaults).filter(
+    key => !Object.prototype.hasOwnProperty.call(oldSettings, key)
+  )
+  return {
+    settings,
+    report: { carried, dropped, reset, newDefaults }
+  }
+}

--- a/services/plugin/reconcileSettings.ts
+++ b/services/plugin/reconcileSettings.ts
@@ -58,11 +58,21 @@ export const reconcileSettings = (params: {
 
   for (const [key, value] of Object.entries(oldSettings)) {
     const field = fieldsByKey.get(key)
-    if (!field) {
+    const hasDefault = Object.prototype.hasOwnProperty.call(defaults, key)
+    if (!field && !hasDefault) {
       dropped.push(key)
       continue
     }
-    if (validatePluginSetting({ ...field, required: false, validation: { ...field.validation, required: false } }, value)) {
+    const defaultValue = defaults[key]
+    const hasCompatibleDefaultType =
+      defaultValue === null ||
+      (Array.isArray(defaultValue)
+        ? Array.isArray(value)
+        : typeof defaultValue === typeof value)
+    const isInvalid = field
+      ? validatePluginSetting({ ...field, required: false, validation: { ...field.validation, required: false } }, value)
+      : !hasCompatibleDefaultType
+    if (isInvalid) {
       reset.push(key)
       continue
     }

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1890,6 +1890,22 @@ const typeDefinitions = gql`
     validationError: String
   }
 
+  type PluginConfigFieldStatus {
+    key: String!
+    label: String!
+    scope: String!
+    kind: String!
+    required: Boolean!
+    isSet: Boolean!
+    isValid: Boolean!
+    message: String
+  }
+
+  type PluginConfigStatus {
+    isFullyConfigured: Boolean!
+    fields: [PluginConfigFieldStatus!]!
+  }
+
   type GetSortedChannelsResponse {
     channels: [Channel]
     aggregateChannelCount: Int
@@ -2246,6 +2262,11 @@ const typeDefinitions = gql`
     getServerPluginSecrets(
       pluginId: String!
     ): [PluginSecretStatus!]!
+    getPluginConfigStatus(
+      pluginId: String!
+      version: String!
+      scope: String = "server"
+    ): PluginConfigStatus!
     getInstalledPlugins: [InstalledPlugin!]!
     getPluginRunsForDownloadableFile(downloadableFileId: ID!): [PluginRun!]!
     getPipelineRuns(targetId: ID!, targetType: String!): [PluginRun!]!

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1418,6 +1418,7 @@ const typeDefinitions = gql`
     installPluginVersion(
       pluginId: String!
       version: String!
+      carrySettings: Boolean = false
     ): InstalledPlugin!
     triggerDownloadableFilePluginRuns(
       downloadableFileId: ID!
@@ -1874,6 +1875,7 @@ const typeDefinitions = gql`
     hasUpdate: Boolean
     latestVersion: String
     availableVersions: [String!]
+    carryOverReport: JSON
   }
 
   enum SecretValidationStatus {


### PR DESCRIPTION
## Summary

- add a scope-aware plugin configuration status resolver
- hard-block plugin enablement when required settings or secrets are missing or invalid
- reconcile compatible settings when installing a new plugin version
- report carried, dropped, reset, and new-default fields
- preserve settings declared only through `settingsDefaults`

## Why

Plugin configuration completeness was not represented consistently. Required non-secret settings could be bypassed during enablement, and upgrades reset per-version settings.

## Validation

- 57 plugin-service tests
- TypeScript type-check
- ESLint on changed files

Implements the backend portion of gennit-project/multiforum-nuxt#330.