### PR TITLE
feat: delete stored plugin secrets

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -87,6 +87,7 @@ import updateDownloadableFileSupportSettings from "./mutations/updateDownloadabl
 import createDownloadableFilesWithUploadMetadata from "./mutations/createDownloadableFilesWithUploadMetadata.js";
 import enableServerPlugin from "./mutations/enableServerPlugin.js";
 import setServerPluginSecret from "./mutations/setServerPluginSecret.js";
+import deleteServerPluginSecret from "./mutations/deleteServerPluginSecret.js";
 import updatePluginPipelines from "./mutations/updatePluginPipelines.js";
 import updateChannelPluginPipelines from "./mutations/updateChannelPluginPipelines.js";
 import createImageWithUploader from "./mutations/createImageWithUploader.js";
@@ -556,6 +557,9 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       ServerSecret
     }),
     setServerPluginSecret: setServerPluginSecret({
+      ServerSecret
+    }),
+    deleteServerPluginSecret: deleteServerPluginSecret({
       ServerSecret
     }),
     updatePluginPipelines: updatePluginPipelines({

--- a/customResolvers/mutations/deleteServerPluginSecret.test.ts
+++ b/customResolvers/mutations/deleteServerPluginSecret.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ServerSecretModel } from "../../ogm_types.js";
+import getResolver from "./deleteServerPluginSecret.js";
+
+const makeModel = (overrides: Record<string, unknown> = {}) =>
+  ({
+    find: async () => [{ id: "secret-1" }],
+    delete: async () => ({ nodesDeleted: 1, relationshipsDeleted: 0 }),
+    ...overrides,
+  }) as unknown as ServerSecretModel;
+
+test("deletes the matching plugin secret", async () => {
+  const calls: unknown[] = [];
+  const resolver = getResolver({
+    ServerSecret: makeModel({
+      delete: async (input: unknown) => {
+        calls.push(input);
+        return { nodesDeleted: 1, relationshipsDeleted: 0 };
+      },
+    }),
+  });
+
+  const result = await resolver(
+    undefined,
+    { pluginId: "scanner", key: "API_TOKEN" },
+    {} as never,
+    {} as never,
+  );
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, [{ where: { id: "secret-1" } }]);
+});
+
+test("returns false when no matching secret exists", async () => {
+  let deleteCalled = false;
+  const resolver = getResolver({
+    ServerSecret: makeModel({
+      find: async () => [],
+      delete: async () => {
+        deleteCalled = true;
+      },
+    }),
+  });
+
+  const result = await resolver(
+    undefined,
+    { pluginId: "scanner", key: "MISSING" },
+    {} as never,
+    {} as never,
+  );
+
+  assert.equal(result, false);
+  assert.equal(deleteCalled, false);
+});
+
+test("wraps model errors with mutation context", async () => {
+  const resolver = getResolver({
+    ServerSecret: makeModel({
+      find: async () => {
+        throw new Error("database unavailable");
+      },
+    }),
+  });
+
+  await assert.rejects(
+    resolver(
+      undefined,
+      { pluginId: "scanner", key: "API_TOKEN" },
+      {} as never,
+      {} as never,
+    ),
+    /Failed to delete server plugin secret: database unavailable/,
+  );
+});

--- a/customResolvers/mutations/deleteServerPluginSecret.ts
+++ b/customResolvers/mutations/deleteServerPluginSecret.ts
@@ -1,0 +1,46 @@
+import type { GraphQLResolveInfo } from "graphql";
+import type { ServerSecretModel } from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
+
+type Input = {
+  ServerSecret: ServerSecretModel;
+};
+
+type Args = {
+  pluginId: string;
+  key: string;
+};
+
+const getResolver = ({ ServerSecret }: Input) => {
+  return async (
+    _parent: unknown,
+    { pluginId, key }: Args,
+    _context: GraphQLContext,
+    _resolveInfo: GraphQLResolveInfo,
+  ) => {
+    try {
+      const existingSecrets = await ServerSecret.find({
+        where: {
+          AND: [{ pluginId }, { key }],
+        },
+      });
+
+      if (existingSecrets.length === 0) {
+        return false;
+      }
+
+      await ServerSecret.delete({
+        where: { id: existingSecrets[0].id },
+      });
+
+      return true;
+    } catch (error: unknown) {
+      logger.error("Error in deleteServerPluginSecret resolver:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to delete server plugin secret: ${message}`);
+    }
+  };
+};
+
+export default getResolver;

--- a/permissions.ts
+++ b/permissions.ts
@@ -368,6 +368,7 @@ const permissionList = shield({
       installPluginVersion: and(isAuthenticated, canManagePlugins),
       enableServerPlugin: and(isAuthenticated, canManagePlugins),
       setServerPluginSecret: and(isAuthenticated, canManagePlugins),
+      deleteServerPluginSecret: and(isAuthenticated, canManagePlugins),
       deletePluginVersions: and(isAuthenticated, canManagePlugins),
       updateChannelPluginPipelines: and(isAuthenticated, isChannelOwner),
       updateDownloadLabels: and(isAuthenticated, allow), // Permission logic handled in resolver

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1435,6 +1435,7 @@ const typeDefinitions = gql`
       key: String!
       value: String!
     ): Boolean!
+    deleteServerPluginSecret(pluginId: String!, key: String!): Boolean!
     updatePluginPipelines(
       pipelines: [EventPipelineInput!]!
     ): JSON!


### PR DESCRIPTION
## Summary

- add an admin-only `deleteServerPluginSecret` mutation
- delete secrets by plugin ID and key
- return `false` when the requested secret is already absent

## Stack

- stacked on #164
- backend prerequisite for the companion multiforum-nuxt secret-deletion PR

## Validation

- 60 plugin/configuration backend tests
- TypeScript compile
- ESLint on changed files