### PR TITLE
Enforce download security scan verdicts

### DIFF
--- a/customResolvers/fields/downloadableFileUrl.test.ts
+++ b/customResolvers/fields/downloadableFileUrl.test.ts
@@ -6,12 +6,21 @@ type ResolverContext = Parameters<
   ReturnType<typeof createDownloadableFileUrlResolver>
 >[2];
 
-const baseContext = {
-  ogm: {},
+const buildContext = (file: Record<string, unknown> | null = {
+  url: "https://example.com/file.zip",
+  scanStatus: "CLEAN",
+  uploadedByUsername: "alice",
+  Discussion: { Author: { username: "alice" } },
+}) => ({
+  ogm: {
+    model: () => ({
+      find: async () => file ? [file] : [],
+    }),
+  },
   req: {
     headers: {},
   },
-};
+});
 
 test("returns an empty string when the request is anonymous", async () => {
   const resolver = createDownloadableFileUrlResolver(async () => ({
@@ -22,9 +31,9 @@ test("returns an empty string when the request is anonymous", async () => {
   }));
 
   const result = await resolver(
-    { url: "https://example.com/file.zip" },
+    { id: "file-1", url: "https://example.com/file.zip" },
     {},
-    { ...baseContext } as unknown as ResolverContext
+    buildContext() as unknown as ResolverContext
   );
 
   assert.equal(result, "");
@@ -36,9 +45,9 @@ test("returns an empty string when the request has a JWT error", async () => {
   });
 
   const result = await resolver(
-    { url: "https://example.com/file.zip" },
+    { id: "file-1", url: "https://example.com/file.zip" },
     {},
-    { ...baseContext, jwtError: new Error("expired") } as unknown as ResolverContext
+    { ...buildContext(), jwtError: new Error("expired") } as unknown as ResolverContext
   );
 
   assert.equal(result, "");
@@ -53,9 +62,9 @@ test("returns the file URL for authenticated requests", async () => {
   }));
 
   const result = await resolver(
-    { url: "https://example.com/file.zip" },
+    { id: "file-1", url: "https://example.com/file.zip" },
     {},
-    { ...baseContext } as unknown as ResolverContext
+    buildContext() as unknown as ResolverContext
   );
 
   assert.equal(result, "https://example.com/file.zip");
@@ -74,10 +83,10 @@ test("reuses context.user when it is already available", async () => {
   });
 
   const result = await resolver(
-    { url: "https://example.com/file.zip" },
+    { id: "file-1", url: "https://example.com/file.zip" },
     {},
     {
-      ...baseContext,
+      ...buildContext(),
       user: {
         username: "cluse",
         email: "cluse@example.com",
@@ -89,4 +98,76 @@ test("reuses context.user when it is already available", async () => {
 
   assert.equal(result, "https://example.com/file.zip");
   assert.equal(callCount, 0);
+});
+
+test("withholds a pending file URL from a regular authenticated user", async () => {
+  const resolver = createDownloadableFileUrlResolver(
+    async () => ({
+      username: "bob",
+      email: "bob@example.com",
+      email_verified: true,
+      data: null,
+    }),
+    async () => false
+  );
+
+  const result = await resolver(
+    { id: "file-1", url: "https://example.com/file.zip" },
+    {},
+    buildContext({
+      url: "https://example.com/file.zip",
+      scanStatus: "PENDING",
+      uploadedByUsername: "alice",
+      Discussion: { Author: { username: "alice" } },
+    }) as unknown as ResolverContext
+  );
+
+  assert.equal(result, "");
+});
+
+test("allows the creator to access a blocked file for review", async () => {
+  const resolver = createDownloadableFileUrlResolver(async () => ({
+    username: "alice",
+    email: "alice@example.com",
+    email_verified: true,
+    data: null,
+  }));
+
+  const result = await resolver(
+    { id: "file-1", url: "https://example.com/file.zip" },
+    {},
+    buildContext({
+      url: "https://example.com/file.zip",
+      scanStatus: "INFECTED",
+      uploadedByUsername: "alice",
+      Discussion: { Author: { username: "alice" } },
+    }) as unknown as ResolverContext
+  );
+
+  assert.equal(result, "https://example.com/file.zip");
+});
+
+test("allows an authorized moderator to access a failed file for review", async () => {
+  const resolver = createDownloadableFileUrlResolver(
+    async () => ({
+      username: "moderator",
+      email: "mod@example.com",
+      email_verified: true,
+      data: null,
+    }),
+    async () => true
+  );
+
+  const result = await resolver(
+    { id: "file-1", url: "https://example.com/file.zip" },
+    {},
+    buildContext({
+      url: "https://example.com/file.zip",
+      scanStatus: "FAILED",
+      uploadedByUsername: "alice",
+      Discussion: { Author: { username: "alice" } },
+    }) as unknown as ResolverContext
+  );
+
+  assert.equal(result, "https://example.com/file.zip");
 });

--- a/customResolvers/fields/downloadableFileUrl.ts
+++ b/customResolvers/fields/downloadableFileUrl.ts
@@ -3,20 +3,35 @@ import {
   type AuthContextForUserLookup,
   type UserDataOnContext,
 } from "../../rules/permission/userDataHelperFunctions.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import type { GraphQLContext } from "../../types/context.js";
 
 type DownloadableFileParent = {
+  id?: string | null;
   url?: string | null;
 };
 
-type DownloadableFileContext = {
-  user?: UserDataOnContext | null;
-  jwtError?: Error | null;
-} & AuthContextForUserLookup;
+type DownloadableFileAccessRecord = {
+  url?: string | null;
+  scanStatus?: string | null;
+  uploadedByUsername?: string | null;
+  Discussion?: {
+    Author?: { username?: string | null } | null;
+  } | null;
+};
+
+type DownloadableFileContext = GraphQLContext &
+  AuthContextForUserLookup & {
+    user?: UserDataOnContext | null;
+    jwtError?: Error | null;
+  };
 
 type SetUserDataOnContext = typeof setUserDataOnContext;
+type CheckServerModPermission = typeof hasServerModPermission;
 
 export const createDownloadableFileUrlResolver = (
-  getUserData: SetUserDataOnContext = setUserDataOnContext
+  getUserData: SetUserDataOnContext = setUserDataOnContext,
+  checkServerModPermission: CheckServerModPermission = hasServerModPermission
 ) => {
   return async (
     parent: DownloadableFileParent,
@@ -37,7 +52,45 @@ export const createDownloadableFileUrlResolver = (
       return "";
     }
 
-    return parent.url || "";
+    if (!parent.id) {
+      return "";
+    }
+
+    const DownloadableFile = context.ogm.model("DownloadableFile");
+    const records = await DownloadableFile.find({
+      where: { id: parent.id },
+      selectionSet: `{
+        url
+        scanStatus
+        uploadedByUsername
+        Discussion {
+          Author { username }
+        }
+      }`,
+    }) as DownloadableFileAccessRecord[];
+    const file = records[0];
+
+    if (!file) {
+      return "";
+    }
+
+    if (file.scanStatus === "CLEAN") {
+      return file.url || parent.url || "";
+    }
+
+    const username = context.user.username;
+    const isOwner =
+      file.uploadedByUsername === username ||
+      file.Discussion?.Author?.username === username;
+    if (isOwner) {
+      return file.url || parent.url || "";
+    }
+
+    const canReview = await checkServerModPermission(
+      "canPermanentlyRemoveImage",
+      context
+    );
+    return canReview === true ? file.url || parent.url || "" : "";
   };
 };
 

--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -82,6 +82,8 @@ import sendBugReport from "./mutations/sendBugReport.js";
 import refreshPlugins from "./mutations/refreshPlugins.js";
 import installPluginVersion from "./mutations/installPluginVersion.js";
 import triggerDownloadableFilePluginRuns from "./mutations/triggerDownloadableFilePluginRuns.js";
+import retryDownloadableFileScan from "./mutations/retryDownloadableFileScan.js";
+import clearDownloadableFileScan from "./mutations/clearDownloadableFileScan.js";
 import trackDownload from "./mutations/trackDownload.js";
 import updateDownloadableFileSupportSettings from "./mutations/updateDownloadableFileSupportSettings.js";
 import createDownloadableFilesWithUploadMetadata from "./mutations/createDownloadableFilesWithUploadMetadata.js";
@@ -538,6 +540,18 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       PluginRun,
       ServerConfig,
       ServerSecret
+    }),
+    retryDownloadableFileScan: retryDownloadableFileScan({
+      DownloadableFile,
+      Plugin,
+      PluginVersion,
+      PluginRun,
+      ServerConfig,
+      ServerSecret
+    }),
+    clearDownloadableFileScan: clearDownloadableFileScan({
+      DownloadableFile,
+      driver
     }),
     trackDownload: trackDownload({
       driver

--- a/customResolvers/mutations/clearDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import { createClearDownloadableFileScanResolver } from "./clearDownloadableFileScan.js";
+
+test("clears a held scan and notifies the discussion author", async () => {
+  const updates: any[] = [];
+  const runs: any[] = [];
+  let finds = 0;
+  const DownloadableFile = {
+    find: async () => {
+      finds += 1;
+      return finds === 1
+        ? [{ id: "file-1", scanStatus: "SUSPICIOUS" }]
+        : [{ id: "file-1", scanStatus: "CLEAN" }];
+    },
+    update: async (args: unknown) => {
+      updates.push(args);
+      return {};
+    },
+  } as any;
+  const driver = {
+    session: () => ({
+      run: async (...args: unknown[]) => {
+        runs.push(args);
+        return {};
+      },
+      close: async () => {},
+    }),
+  } as any;
+  const resolver = createClearDownloadableFileScanResolver({
+    DownloadableFile,
+    driver,
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", reason: "False positive" },
+    {
+      user: {
+        username: "moderator",
+        data: { ModerationProfile: { displayName: "safety-team" } },
+      },
+    } as GraphQLContext
+  );
+
+  assert.deepEqual({
+    status: updates[0].update.scanStatus,
+    reason: updates[0].update.scanReason,
+    notificationParams: runs[0][1],
+    result,
+  }, {
+    status: "CLEAN",
+    reason: "Cleared by safety-team: False positive",
+    notificationParams: {
+      downloadableFileId: "file-1",
+      notificationText: "Your downloadable file passed human security review and is now available. Cleared by safety-team: False positive",
+    },
+    result: { id: "file-1", scanStatus: "CLEAN" },
+  });
+});
+
+test("rejects a file that is already clean", async () => {
+  const resolver = createClearDownloadableFileScanResolver({
+    DownloadableFile: {
+      find: async () => [{ id: "file-1", scanStatus: "CLEAN" }],
+    } as any,
+    driver: {} as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      { user: { username: "moderator" } } as GraphQLContext
+    ),
+    /already clean/
+  );
+});

--- a/customResolvers/mutations/clearDownloadableFileScan.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.ts
@@ -1,0 +1,83 @@
+import type { Driver } from "neo4j-driver";
+import type {
+  DownloadableFileModel,
+  DownloadableFileUpdateInput,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+
+type Input = {
+  DownloadableFile: DownloadableFileModel;
+  driver: Driver;
+};
+
+export const createClearDownloadableFileScanResolver = ({
+  DownloadableFile,
+  driver,
+}: Input) => {
+  return async (
+    _parent: unknown,
+    args: { downloadableFileId: string; reason?: string | null },
+    context: GraphQLContext
+  ) => {
+    const files = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{ id scanStatus }`,
+    });
+    if (!files.length) throw new Error("Downloadable file not found");
+    if (files[0].scanStatus === "CLEAN") {
+      throw new Error("The downloadable file is already clean");
+    }
+
+    const reviewer =
+      context.user?.data?.ModerationProfile?.displayName ||
+      context.user?.username ||
+      "a moderator";
+    const explanation = args.reason?.trim();
+    const scanReason = explanation
+      ? `Cleared by ${reviewer}: ${explanation}`
+      : `Cleared by ${reviewer} after human review`;
+    const scanCheckedAt = new Date().toISOString();
+
+    await DownloadableFile.update({
+      where: { id: args.downloadableFileId },
+      update: ({
+        scanStatus: "CLEAN",
+        scanReason,
+        scanCheckedAt,
+      } as DownloadableFileUpdateInput),
+    });
+
+    const session = driver.session();
+    try {
+      await session.run(
+        `
+        MATCH (file:DownloadableFile {id: $downloadableFileId})
+        MATCH (file)<-[:HAS_DOWNLOADABLE_FILE]-(discussion:Discussion)
+        MATCH (author:User)-[:AUTHORED_DISCUSSION]->(discussion)
+        CREATE (notification:Notification {
+          id: randomUUID(),
+          createdAt: datetime(),
+          read: false,
+          text: $notificationText,
+          notificationType: 'moderation'
+        })
+        CREATE (author)-[:HAS_NOTIFICATION]->(notification)
+        `,
+        {
+          downloadableFileId: args.downloadableFileId,
+          notificationText: `Your downloadable file passed human security review and is now available. ${scanReason}`,
+        }
+      );
+    } finally {
+      await session.close();
+    }
+
+    const updated = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{ id fileName scanStatus scanReason scanCheckedAt }`,
+    });
+    return updated[0];
+  };
+};
+
+export default createClearDownloadableFileScanResolver;

--- a/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.ts
+++ b/customResolvers/mutations/createDownloadableFilesWithUploadMetadata.ts
@@ -49,6 +49,7 @@ const selectionSet = `
       supportPayPalMeUrl
       scanStatus
       scanCheckedAt
+      scanReason
     }
   }
 `;

--- a/customResolvers/mutations/retryDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import { createRetryDownloadableFileScanResolver } from "./retryDownloadableFileScan.js";
+
+const baseInput = (file: unknown) => ({
+  DownloadableFile: { find: async () => file ? [file] : [] },
+  Plugin: {},
+  PluginVersion: {},
+  PluginRun: {},
+  ServerConfig: {},
+  ServerSecret: {},
+}) as any;
+
+const contextFor = (username: string) => ({
+  user: { username },
+}) as GraphQLContext;
+
+test("lets the uploader retry a held scan", async () => {
+  const calls: unknown[] = [];
+  const resolver = createRetryDownloadableFileScanResolver(
+    baseInput({ uploadedByUsername: "alice", scanStatus: "FAILED" }),
+    async () => false,
+    (async (args: unknown) => {
+      calls.push(args);
+      return [{ id: "run-1" }];
+    }) as any
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual({ result, call: calls[0] && {
+    downloadableFileId: (calls[0] as any).downloadableFileId,
+    event: (calls[0] as any).event,
+  } }, {
+    result: [{ id: "run-1" }],
+    call: {
+      downloadableFileId: "file-1",
+      event: "downloadableFile.updated",
+    },
+  });
+});
+
+test("lets an authorized moderator retry someone else's scan", async () => {
+  let triggered = false;
+  const resolver = createRetryDownloadableFileScanResolver(
+    baseInput({ uploadedByUsername: "alice", scanStatus: "SUSPICIOUS" }),
+    async () => true,
+    (async () => {
+      triggered = true;
+      return [];
+    }) as any
+  );
+
+  await resolver(null, { downloadableFileId: "file-1" }, contextFor("mod"));
+
+  assert.equal(triggered, true);
+});
+
+test("rejects another user without review permission", async () => {
+  const resolver = createRetryDownloadableFileScanResolver(
+    baseInput({ uploadedByUsername: "alice", scanStatus: "INFECTED" }),
+    async () => false
+  );
+
+  await assert.rejects(
+    resolver(null, { downloadableFileId: "file-1" }, contextFor("bob")),
+    /Not authorized/
+  );
+});
+
+test("does not retry an already clean file", async () => {
+  const resolver = createRetryDownloadableFileScanResolver(
+    baseInput({ uploadedByUsername: "alice", scanStatus: "CLEAN" })
+  );
+
+  await assert.rejects(
+    resolver(null, { downloadableFileId: "file-1" }, contextFor("alice")),
+    /does not need another scan/
+  );
+});

--- a/customResolvers/mutations/retryDownloadableFileScan.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.ts
@@ -1,0 +1,74 @@
+import type {
+  DownloadableFileModel,
+  PluginModel,
+  PluginRunModel,
+  PluginVersionModel,
+  ServerConfigModel,
+  ServerSecretModel,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
+
+type Input = {
+  DownloadableFile: DownloadableFileModel;
+  Plugin: PluginModel;
+  PluginVersion: PluginVersionModel;
+  PluginRun: PluginRunModel;
+  ServerConfig: ServerConfigModel;
+  ServerSecret: ServerSecretModel;
+};
+
+type FileRecord = {
+  uploadedByUsername?: string | null;
+  scanStatus?: string | null;
+  Discussion?: { Author?: { username?: string | null } | null } | null;
+};
+
+export const createRetryDownloadableFileScanResolver = (
+  input: Input,
+  checkServerModPermission: typeof hasServerModPermission = hasServerModPermission,
+  triggerRuns: typeof triggerPluginRunsForDownloadableFile = triggerPluginRunsForDownloadableFile
+) => {
+  return async (
+    _parent: unknown,
+    { downloadableFileId }: { downloadableFileId: string },
+    context: GraphQLContext
+  ) => {
+    const files = await input.DownloadableFile.find({
+      where: { id: downloadableFileId },
+      selectionSet: `{
+        uploadedByUsername
+        scanStatus
+        Discussion { Author { username } }
+      }`,
+    }) as FileRecord[];
+    const file = files[0];
+
+    if (!file) throw new Error("Downloadable file not found");
+    if (file.scanStatus === "CLEAN") {
+      throw new Error("A clean downloadable file does not need another scan");
+    }
+
+    const username = context.user?.username;
+    const isCreator = Boolean(username) && (
+      file.uploadedByUsername === username ||
+      file.Discussion?.Author?.username === username
+    );
+    if (!isCreator) {
+      const canReview = await checkServerModPermission(
+        "canPermanentlyRemoveImage",
+        context
+      );
+      if (canReview !== true) throw new Error("Not authorized to retry this scan");
+    }
+
+    return triggerRuns({
+      downloadableFileId,
+      event: "downloadableFile.updated",
+      models: input,
+    });
+  };
+};
+
+export default createRetryDownloadableFileScanResolver;

--- a/customResolvers/mutations/trackDownload.test.ts
+++ b/customResolvers/mutations/trackDownload.test.ts
@@ -99,6 +99,27 @@ test('trackDownload counts anonymous downloads as total-only activity', async ()
   assert.doesNotMatch(calls.run[0][0], /OWNS_DOWNLOAD/)
 })
 
+test('trackDownload only counts anonymous downloads for clean files', async () => {
+  const { driver, calls } = buildDriver()
+  const resolver = trackDownload({
+    driver,
+    getUserData: async () => ({
+      username: null,
+      email: null,
+      email_verified: false,
+      data: null
+    })
+  })
+
+  await resolver(
+    null,
+    { downloadableFileId: 'file-1', discussionId: 'discussion-1' },
+    {} as unknown as GraphQLContext
+  )
+
+  assert.match(calls.run[0][0], /coalesce\(file\.scanStatus, 'PENDING'\) = 'CLEAN'/)
+})
+
 test('trackDownload updates counters and saves the download discussion', async () => {
   const { driver, calls } = buildDriver()
   const resolver = trackDownload({ driver })
@@ -129,6 +150,22 @@ test('trackDownload updates counters and saves the download discussion', async (
   assert.equal(
     calls.run[0][1].downloadsCollectionDescription,
     AUTO_SAVED_DOWNLOADS_COLLECTION_DESCRIPTION
+  )
+})
+
+test('trackDownload permits review tracking only for the uploader or discussion author', async () => {
+  const { driver, calls } = buildDriver()
+  const resolver = trackDownload({ driver })
+
+  await resolver(
+    null,
+    { downloadableFileId: 'file-1', discussionId: 'discussion-1' },
+    { user: { username: 'alice' } } as unknown as GraphQLContext
+  )
+
+  assert.match(
+    calls.run[0][0],
+    /file\.uploadedByUsername = \$username[\s\S]*\$username IN authorUsernames/
   )
 })
 
@@ -174,6 +211,6 @@ test('trackDownload throws when the file does not belong to the discussion', asy
     resolver(null, { downloadableFileId: 'file-1', discussionId: 'discussion-1' }, {
       user: { username: 'alice' }
     } as unknown as GraphQLContext),
-    /Downloadable file not found for this discussion/
+    /Downloadable file is unavailable or not found for this discussion/
   )
 })

--- a/customResolvers/mutations/trackDownload.ts
+++ b/customResolvers/mutations/trackDownload.ts
@@ -74,6 +74,7 @@ const trackDownload = ({
         const result = await session.run(
           `
           MATCH (discussion:Discussion {id: $discussionId})-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile {id: $downloadableFileId})
+          WHERE coalesce(file.scanStatus, 'PENDING') = 'CLEAN'
           SET file.downloadCountTotal = coalesce(file.downloadCountTotal, 0) + 1
           RETURN count(file) AS updated
           `,
@@ -96,6 +97,11 @@ const trackDownload = ({
         `
         MATCH (user:User {username: $username})
         MATCH (discussion:Discussion {id: $discussionId})-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile {id: $downloadableFileId})
+        OPTIONAL MATCH (author:User)-[:POSTED_DISCUSSION]->(discussion)
+        WITH user, discussion, file, collect(DISTINCT author.username) AS authorUsernames
+        WHERE coalesce(file.scanStatus, 'PENDING') = 'CLEAN'
+          OR file.uploadedByUsername = $username
+          OR $username IN authorUsernames
         OPTIONAL MATCH (user)-[existingDownload:DOWNLOADED_FILE]->(file)
         MERGE (user)<-[:CREATED_BY]-(downloadsCollection:Collection {
           name: $downloadsCollectionName,
@@ -137,7 +143,7 @@ const trackDownload = ({
       const updated = toNumber(result.records[0]?.get('updated'))
 
       if (updated < 1) {
-        throw new GraphQLError('Downloadable file not found for this discussion')
+        throw new GraphQLError('Downloadable file is unavailable or not found for this discussion')
       }
 
       return true

--- a/customResolvers/queries/getServerHealthDashboard.ts
+++ b/customResolvers/queries/getServerHealthDashboard.ts
@@ -184,7 +184,19 @@ const getHealthLabel = (row: Omit<ChannelHealthRow, "healthLabel">): string => {
   return "Active";
 };
 
-const buildAttentionItems = (rows: ChannelHealthRow[]): AttentionItem[] => {
+const buildAttentionItems = (
+  rows: ChannelHealthRow[],
+  failedDownloadScanCount: number
+): AttentionItem[] => {
+  const scanFailureItems: AttentionItem[] = failedDownloadScanCount > 0
+    ? [{
+        severity: "CRITICAL",
+        title: "Download security scans failing",
+        description: `${failedDownloadScanCount} downloadable file${failedDownloadScanCount === 1 ? " is" : "s are"} unavailable because the security scanner could not complete.`,
+        metric: "failedDownloadScanCount",
+        value: failedDownloadScanCount,
+      }]
+    : [];
   const staleIssueItems = rows
     .filter((row) => (row.oldestOpenIssueAgeDays || 0) >= 7)
     .sort((a, b) => (b.oldestOpenIssueAgeDays || 0) - (a.oldestOpenIssueAgeDays || 0))
@@ -224,7 +236,12 @@ const buildAttentionItems = (rows: ChannelHealthRow[]): AttentionItem[] => {
       value: row.openIssueCount,
     }));
 
-  return [...staleIssueItems, ...highPressureItems, ...underRespondedItems].slice(0, 10);
+  return [
+    ...scanFailureItems,
+    ...staleIssueItems,
+    ...highPressureItems,
+    ...underRespondedItems,
+  ].slice(0, 10);
 };
 
 const buildIssueAging = (ages: number[]) => [
@@ -555,6 +572,13 @@ const suspensionTotalQuery = `
   RETURN count(DISTINCT s) AS suspensionCount
 `;
 
+const failedDownloadScanTotalQuery = `
+  MATCH (file:DownloadableFile)
+  WHERE file.scanStatus = 'FAILED'
+    AND coalesce(file.permanentlyRemoved, false) = false
+  RETURN count(file) AS failedDownloadScanCount
+`;
+
 const runDashboardQuery = async (
   session: Session,
   name: string,
@@ -601,6 +625,12 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
       const openIssueSummaryResult = await runDashboardQuery(session, "openIssueSummary", openIssueSummaryQuery, params);
       const moderationActionTotalResult = await runDashboardQuery(session, "moderationActionTotal", moderationActionTotalQuery, params);
       const suspensionTotalResult = await runDashboardQuery(session, "suspensionTotal", suspensionTotalQuery, params);
+      const failedDownloadScanTotalResult = await runDashboardQuery(
+        session,
+        "failedDownloadScanTotal",
+        failedDownloadScanTotalQuery,
+        params
+      );
 
       const channelRecord = channelResult.records[0];
       const allChannelHealth = sanitize(channelRecord?.get("allChannelHealth") || []) as Array<Omit<ChannelHealthRow, "healthLabel">>;
@@ -627,6 +657,9 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
       const suspensionCount = toNumber(
         suspensionTotalResult.records[0]?.get("suspensionCount")
       );
+      const failedDownloadScanCount = toNumber(
+        failedDownloadScanTotalResult.records[0]?.get("failedDownloadScanCount")
+      );
       const openIssueAges = (sanitize(openIssueSummary?.get("openIssueAges") || []) as unknown[])
         .map(toNumber);
       const issueAging = buildIssueAging(openIssueAges);
@@ -645,6 +678,7 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
         archivedContentCount: allChannelHealth.reduce((total, row) => total + toNumber(row.archivedContentCount), 0),
         lockedContentCount: allChannelHealth.reduce((total, row) => total + toNumber(row.lockedContentCount), 0),
         suspensionCount,
+        failedDownloadScanCount,
         medianOpenIssueAgeDays,
       };
 
@@ -656,7 +690,7 @@ const getServerHealthDashboardResolver = ({ driver }: Input) => {
         timeSeries,
         channelHealth,
         issueAging,
-        attentionItems: buildAttentionItems(channelHealth),
+        attentionItems: buildAttentionItems(channelHealth, failedDownloadScanCount),
       };
     } catch (error) {
       logger.error("Error fetching server health dashboard:", error);

--- a/permissions.ts
+++ b/permissions.ts
@@ -334,6 +334,8 @@ const permissionList = shield({
       archiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       unarchiveImage: and(isAuthenticated, canArchiveAndUnarchiveImage),
       permanentlyRemoveImage: and(isAuthenticated, canPermanentlyRemoveImage),
+      retryDownloadableFileScan: and(isAuthenticated, allow),
+      clearDownloadableFileScan: and(isAuthenticated, canPermanentlyRemoveImage),
       permanentlyDeleteImage: and(isAuthenticated, allow),
       permanentlyDeleteDownloadableFile: and(isAuthenticated, allow),
 

--- a/services/plugin/downloadScanOutcome.test.ts
+++ b/services/plugin/downloadScanOutcome.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  failedDownloadScanOutcome,
+  resolveDownloadScanOutcome
+} from './downloadScanOutcome.js'
+
+test('maps a clean verdict to an available scan status without a reason', () => {
+  assert.deepEqual(
+    resolveDownloadScanOutcome({
+      success: true,
+      result: { verdict: 'clean', scans: [{ verdict: 'clean', summary: 'No threats' }] }
+    }),
+    { status: 'CLEAN', reason: null }
+  )
+})
+
+test('maps suspicious content and keeps only matching creator-safe summaries', () => {
+  assert.deepEqual(
+    resolveDownloadScanOutcome({
+      success: true,
+      result: {
+        verdict: 'suspicious',
+        scans: [
+          { verdict: 'clean', summary: 'First file passed' },
+          { verdict: 'suspicious', summary: 'Archive contains an installer' }
+        ]
+      }
+    }),
+    { status: 'SUSPICIOUS', reason: 'Archive contains an installer' }
+  )
+})
+
+test('maps malicious content to infected', () => {
+  assert.deepEqual(
+    resolveDownloadScanOutcome({
+      success: false,
+      error: 'Attachment scan blocked upload',
+      result: {
+        verdict: 'malicious',
+        scans: [{ verdict: 'malicious', summary: 'Known malware signature' }]
+      }
+    }),
+    { status: 'INFECTED', reason: 'Known malware signature' }
+  )
+})
+
+test('maps a scanner error verdict to a server-side failure', () => {
+  assert.deepEqual(
+    resolveDownloadScanOutcome({
+      success: false,
+      result: {
+        verdict: 'error',
+        scans: [{ verdict: 'error', summary: 'Scan service unreachable' }]
+      }
+    }),
+    { status: 'FAILED', reason: 'Scan service unreachable' }
+  )
+})
+
+test('fails closed when the scanner does not return a recognized verdict', () => {
+  assert.deepEqual(
+    resolveDownloadScanOutcome({ success: true, result: { message: 'Done' } }),
+    { status: 'FAILED', reason: 'Done' }
+  )
+})
+
+test('normalizes thrown scanner failures', () => {
+  assert.deepEqual(
+    failedDownloadScanOutcome('Plugin loader failed'),
+    { status: 'FAILED', reason: 'Plugin loader failed' }
+  )
+})

--- a/services/plugin/downloadScanOutcome.ts
+++ b/services/plugin/downloadScanOutcome.ts
@@ -1,0 +1,83 @@
+export const SECURITY_SCAN_PLUGIN_ID = 'security-attachment-scan'
+
+export type DownloadScanStatus =
+  | 'PENDING'
+  | 'CLEAN'
+  | 'INFECTED'
+  | 'SUSPICIOUS'
+  | 'FAILED'
+
+export type DownloadScanOutcome = {
+  status: Exclude<DownloadScanStatus, 'PENDING'>
+  reason: string | null
+}
+
+type ScannerVerdict = 'clean' | 'suspicious' | 'malicious' | 'error'
+
+type ScannerEventResult = {
+  success?: boolean
+  error?: unknown
+  result?: {
+    verdict?: unknown
+    message?: unknown
+    scans?: Array<{
+      verdict?: unknown
+      summary?: unknown
+    }>
+  }
+}
+
+const VERDICT_TO_STATUS: Record<ScannerVerdict, DownloadScanOutcome['status']> = {
+  clean: 'CLEAN',
+  suspicious: 'SUSPICIOUS',
+  malicious: 'INFECTED',
+  error: 'FAILED'
+}
+
+const isScannerVerdict = (value: unknown): value is ScannerVerdict =>
+  value === 'clean' ||
+  value === 'suspicious' ||
+  value === 'malicious' ||
+  value === 'error'
+
+const asNonEmptyString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+export const failedDownloadScanOutcome = (reason: unknown): DownloadScanOutcome => ({
+  status: 'FAILED',
+  reason: asNonEmptyString(reason) || 'The security scan did not complete.'
+})
+
+export const resolveDownloadScanOutcome = (
+  eventResult: unknown
+): DownloadScanOutcome => {
+  const scannerResult = eventResult && typeof eventResult === 'object'
+    ? eventResult as ScannerEventResult
+    : {}
+  const verdict = scannerResult.result?.verdict
+
+  if (!isScannerVerdict(verdict)) {
+    return failedDownloadScanOutcome(
+      scannerResult.error || scannerResult.result?.message
+    )
+  }
+
+  const status = VERDICT_TO_STATUS[verdict]
+  if (status === 'CLEAN') {
+    return { status, reason: null }
+  }
+
+  const matchingReasons = (scannerResult.result?.scans || [])
+    .filter(scan => scan.verdict === verdict)
+    .map(scan => asNonEmptyString(scan.summary))
+    .filter((reason): reason is string => Boolean(reason))
+
+  return {
+    status,
+    reason:
+      matchingReasons.join(' | ') ||
+      asNonEmptyString(scannerResult.error) ||
+      asNonEmptyString(scannerResult.result?.message) ||
+      'The security scan did not provide a reason.'
+  }
+}

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -45,6 +45,7 @@ const fileNode = {
 function makeExecModels(edges: unknown[]) {
   const updates: any[] = [];
   const creates: any[] = [];
+  const fileUpdates: any[] = [];
   let seq = 0;
   const serverConfig = {
     serverName: "s",
@@ -64,14 +65,20 @@ function makeExecModels(edges: unknown[]) {
     find: async (args: any) => [{ id: args?.where?.id ?? "run-1" }],
   };
   const models: any = {
-    DownloadableFile: model([fileNode]),
+    DownloadableFile: {
+      ...model([fileNode]),
+      update: async (args: any) => {
+        fileUpdates.push(args);
+        return {};
+      },
+    },
     ServerConfig: model([serverConfig]),
     ServerSecret: empty(),
     PluginRun,
     Plugin: empty(),
     PluginVersion: empty(),
   };
-  return { models, updates, creates };
+  return { models, updates, creates, fileUpdates };
 }
 
 const pluginReturning = (result: unknown) =>
@@ -121,4 +128,54 @@ test("skips later plugins after a failure (stopOnFirstFailure)", async () => {
   const statuses = statusesOf(updates);
   assert.ok(statuses.includes("FAILED"));
   assert.ok(statuses.includes("SKIPPED"));
+});
+
+test("persists the scanner verdict on the downloadable file", async () => {
+  const { models, fileUpdates } = makeExecModels([
+    installedEdge("security-attachment-scan"),
+  ]);
+  await execRun(
+    models,
+    loaderFor(
+      pluginReturning({
+        success: false,
+        result: {
+          verdict: "malicious",
+          scans: [
+            { verdict: "malicious", summary: "Known malware signature" },
+          ],
+        },
+      })
+    )
+  );
+
+  assert.deepEqual(fileUpdates[0], {
+    where: { id: "f-1" },
+    update: {
+      scanStatus: "INFECTED",
+      scanReason: "Known malware signature",
+      scanCheckedAt: fileUpdates[0].update.scanCheckedAt,
+    },
+  });
+});
+
+test("marks the downloadable file failed when the scanner throws", async () => {
+  const { models, fileUpdates } = makeExecModels([
+    installedEdge("security-attachment-scan"),
+  ]);
+  await execRun(
+    models,
+    (async () => {
+      throw new Error("scan service unavailable");
+    }) as any
+  );
+
+  assert.deepEqual(fileUpdates[0], {
+    where: { id: "f-1" },
+    update: {
+      scanStatus: "FAILED",
+      scanReason: "scan service unavailable",
+      scanCheckedAt: fileUpdates[0].update.scanCheckedAt,
+    },
+  });
 });

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -19,7 +19,7 @@ const installedEdge = (name: string) => ({
     repoUrl: null,
     tarballGsUri: `gs://bucket/${name}.tgz`,
     entryPath: "dist/index.js",
-    manifest: JSON.stringify({ events: [EVENT] }),
+    manifest: JSON.stringify({ events: [EVENT, "downloadableFile.updated"] }),
     settingsDefaults: null,
     uiSchema: null,
     Plugin: { id: `p-${name}`, name, displayName: name, description: "", metadata: null },
@@ -152,9 +152,17 @@ test("persists the scanner verdict on the downloadable file", async () => {
   assert.deepEqual(fileUpdates[0], {
     where: { id: "f-1" },
     update: {
+      scanStatus: "PENDING",
+      scanReason: null,
+      scanCheckedAt: null,
+    },
+  });
+  assert.deepEqual(fileUpdates[1], {
+    where: { id: "f-1" },
+    update: {
       scanStatus: "INFECTED",
       scanReason: "Known malware signature",
-      scanCheckedAt: fileUpdates[0].update.scanCheckedAt,
+      scanCheckedAt: fileUpdates[1].update.scanCheckedAt,
     },
   });
 });
@@ -170,12 +178,33 @@ test("marks the downloadable file failed when the scanner throws", async () => {
     }) as any
   );
 
-  assert.deepEqual(fileUpdates[0], {
+  assert.deepEqual(fileUpdates[1], {
     where: { id: "f-1" },
     update: {
       scanStatus: "FAILED",
       scanReason: "scan service unavailable",
-      scanCheckedAt: fileUpdates[0].update.scanCheckedAt,
+      scanCheckedAt: fileUpdates[1].update.scanCheckedAt,
     },
   });
+});
+
+test("holds a replacement before the scanner begins", async () => {
+  const { models, fileUpdates } = makeExecModels([
+    installedEdge("security-attachment-scan"),
+  ]);
+
+  await triggerPluginRunsForDownloadableFile(
+    {
+      downloadableFileId: "f-1",
+      event: "downloadableFile.updated",
+      models,
+    },
+    {
+      loadPlugin: loaderFor(
+        pluginReturning({ success: true, result: { verdict: "clean" } })
+      ),
+    }
+  );
+
+  assert.equal(fileUpdates[0].update.scanStatus, "PENDING");
 });

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -6,7 +6,13 @@ import { loadPluginImplementation } from './pluginLoader.js'
 import { generatePipelineId, shouldRunStep, mergeSettings, getAttachmentUrls, parseManifest, buildPluginVersionMaps, getPluginForStep } from './pipelineUtils.js'
 import { buildBotInvocationContext } from './buildBotInvocationContext.js'
 import { createPromptDebugLogger } from './promptDebug.js'
-import type { PluginRunCreateInput, PluginRunUpdateInput, DownloadableFile as DownloadableFileType, ServerConfig as ServerConfigType, Discussion as DiscussionType } from '../../ogm_types.js'
+import {
+  SECURITY_SCAN_PLUGIN_ID,
+  failedDownloadScanOutcome,
+  resolveDownloadScanOutcome,
+  type DownloadScanOutcome
+} from './downloadScanOutcome.js'
+import type { PluginRunCreateInput, PluginRunUpdateInput, DownloadableFile as DownloadableFileType, DownloadableFileUpdateInput, ServerConfig as ServerConfigType, Discussion as DiscussionType } from '../../ogm_types.js'
 import { logger } from "../../logger.js";
 
 export const isSupportedEvent = (event: string) => DOWNLOAD_EVENTS.has(event)
@@ -167,6 +173,11 @@ export const triggerPluginRunsForDownloadableFile = async (
   if (pluginsToRun.length === 0) {
     return []
   }
+
+  const securityScanExpected = pluginsToRun.some(
+    plugin => plugin.pluginId === SECURITY_SCAN_PLUGIN_ID
+  )
+  let securityScanOutcome: DownloadScanOutcome | null = null
 
   const runs: unknown[] = []
   const stopOnFirstFailure = eventPipeline?.stopOnFirstFailure ?? true
@@ -370,6 +381,9 @@ export const triggerPluginRunsForDownloadableFile = async (
       }
 
       const result = await pluginInstance.handleEvent(eventEnvelope)
+      if (pluginId === SECURITY_SCAN_PLUGIN_ID) {
+        securityScanOutcome = resolveDownloadScanOutcome(result)
+      }
       const runEnd = performance.now()
       const durationMs = Math.round(runEnd - runStart)
 
@@ -416,6 +430,10 @@ export const triggerPluginRunsForDownloadableFile = async (
       const durationMs = Math.round(runEnd - runStart)
       const message = (error instanceof Error ? error.message : '') || 'Plugin execution failed'
 
+      if (pluginId === SECURITY_SCAN_PLUGIN_ID) {
+        securityScanOutcome = failedDownloadScanOutcome(message)
+      }
+
       previousStatus = 'FAILED'
 
       await PluginRun.update({
@@ -451,6 +469,20 @@ export const triggerPluginRunsForDownloadableFile = async (
         runs.push(updated[0])
       }
     }
+  }
+
+  if (securityScanExpected) {
+    const outcome = securityScanOutcome || failedDownloadScanOutcome(
+      'The security scan was skipped before it could complete.'
+    )
+    await DownloadableFile.update({
+      where: { id: downloadableFileId },
+      update: ({
+        scanStatus: outcome.status,
+        scanReason: outcome.reason,
+        scanCheckedAt: new Date().toISOString()
+      } as DownloadableFileUpdateInput)
+    })
   }
 
   return runs

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -179,6 +179,20 @@ export const triggerPluginRunsForDownloadableFile = async (
   )
   let securityScanOutcome: DownloadScanOutcome | null = null
 
+  // Replacements can arrive while the previous version is CLEAN. Hold the
+  // file before starting the scanner so that old approval cannot make new
+  // bytes publicly downloadable during the rescan window.
+  if (securityScanExpected && event !== 'downloadableFile.downloaded') {
+    await DownloadableFile.update({
+      where: { id: downloadableFileId },
+      update: ({
+        scanStatus: 'PENDING',
+        scanReason: null,
+        scanCheckedAt: null
+      } as DownloadableFileUpdateInput)
+    })
+  }
+
   const runs: unknown[] = []
   const stopOnFirstFailure = eventPipeline?.stopOnFirstFailure ?? true
   let previousStatus: 'SUCCEEDED' | 'FAILED' | null = null

--- a/tests/integration/serverHealthDashboard.test.ts
+++ b/tests/integration/serverHealthDashboard.test.ts
@@ -88,6 +88,14 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
       actionDescription: 'Reviewed',
       createdAt: datetime()
     })
+    CREATE (failedFile:DownloadableFile {
+      id: 'file-failed',
+      fileName: 'failed.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/failed.zip',
+      createdAt: datetime(),
+      scanStatus: 'FAILED'
+    })
 
     CREATE (alice)-[:POSTED_DISCUSSION]->(discussion)
     CREATE (bob)-[:AUTHORED_COMMENT]->(comment)
@@ -121,6 +129,7 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
   assert.equal(result.summary.openIssueCount, 2);
   assert.equal(result.summary.issueOpenedCount, 2);
   assert.equal(result.summary.moderationActionCount, 1);
+  assert.equal(result.summary.failedDownloadScanCount, 1);
 
   const general = result.channelHealth.find(
     (row: any) => row.channelUniqueName === "general"
@@ -136,6 +145,10 @@ test("getServerHealthDashboard returns summary, time series, channel rows, and a
   assert.ok(
     result.attentionItems.some((item: any) => item.title === "Stale open issues"),
     `expected stale issue attention item, got ${JSON.stringify(result.attentionItems)}`
+  );
+  assert.ok(
+    result.attentionItems.some((item: any) => item.title === "Download security scans failing"),
+    `expected scan failure attention item, got ${JSON.stringify(result.attentionItems)}`
   );
 });
 

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1425,6 +1425,11 @@ const typeDefinitions = gql`
       downloadableFileId: ID!
       event: String!
     ): [PluginRun!]!
+    retryDownloadableFileScan(downloadableFileId: ID!): [PluginRun!]!
+    clearDownloadableFileScan(
+      downloadableFileId: ID!
+      reason: String
+    ): DownloadableFile!
     enableServerPlugin(
       pluginId: String!
       version: String!

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -2042,6 +2042,7 @@ const typeDefinitions = gql`
     archivedContentCount: Int!
     lockedContentCount: Int!
     suspensionCount: Int!
+    failedDownloadScanCount: Int!
     medianOpenIssueAgeDays: Float
   }
 

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -451,6 +451,7 @@ const typeDefinitions = gql`
     # scanning
     scanStatus: ScanStatus! @default(value: PENDING)
     scanCheckedAt: DateTime
+    scanReason: String
 
     # purchases back‑ref
     purchasers: [Purchase!]! @relationship(type: "PURCHASED_FILE", direction: IN)


### PR DESCRIPTION
Implements the backend enforcement and moderation portions of [multiforum-nuxt#321](https://github.com/gennit-project/multiforum-nuxt/pull/321).

## What changed

- persist security scanner verdicts as `scanStatus`, `scanReason`, and `scanCheckedAt`
- fail closed for missing, skipped, errored, or unrecognized scanner results
- gate downloadable URLs and download tracking on scan status and requester role
- hold replacements as `PENDING` before rescanning to close the availability race
- add creator/moderator retry and moderator human-clear operations
- notify the discussion author after a moderator clears a file
- surface failed scans in the server health summary and attention list

## Policy

Public availability requires `CLEAN`. `PENDING`, `SUSPICIOUS`, `INFECTED`, and `FAILED` remain unavailable to the public. Creators and authorized moderators may access held files for review.

## Validation

- TypeScript compile passed
- ESLint passed on all changed backend files
- scanner/download/re-review focused unit tests passed
- server health Neo4j integration suite passed (4/4)
- full unit run was started and remained green through 171 tests, then stopped because the combined cross-repo run was resource-bound