### PR TITLE
Scan replacement download files

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -174,6 +174,10 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     updateDiscussionWithChannelConnections:
       updateDiscussionWithChannelConnections({
         Discussion,
+        DownloadableFile,
+        PluginRun,
+        ServerConfig,
+        ServerSecret,
         driver,
       }),
     createEventWithChannelConnections: createEventWithChannelConnections({

--- a/customResolvers/mutations/updateDiscussionDownloadScan.test.ts
+++ b/customResolvers/mutations/updateDiscussionDownloadScan.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import getResolver, {
+  getConnectedDownloadableFileIds,
+} from "./updateDiscussionWithChannelConnections.js";
+
+test("extracts only newly connected downloadable file IDs", () => {
+  assert.deepEqual(
+    getConnectedDownloadableFileIds({
+      DownloadableFiles: [{
+        connect: [
+          { where: { node: { id: "replacement-1" } } },
+          { where: { node: { id: "replacement-2" } } },
+        ],
+        disconnect: [{ where: { node: { id: "old-file" } } }],
+      }],
+    } as any),
+    ["replacement-1", "replacement-2"]
+  );
+});
+
+test("triggers the updated pipeline after connecting a replacement", async () => {
+  const calls: any[] = [];
+  const Discussion = {
+    update: async () => ({ discussions: [] }),
+    find: async () => [{ id: "discussion-1" }],
+  } as any;
+  const session = {
+    run: async () => ({ records: [] }),
+    close: async () => {},
+  };
+  const input = {
+    Discussion,
+    DownloadableFile: { name: "DownloadableFile" },
+    PluginRun: { name: "PluginRun" },
+    ServerConfig: { name: "ServerConfig" },
+    ServerSecret: { name: "ServerSecret" },
+    driver: { session: () => session },
+  } as any;
+  const resolver = getResolver(input, (async (args: unknown) => {
+    calls.push(args);
+    return [];
+  }) as any);
+
+  await resolver(
+    null,
+    {
+      where: { id: "discussion-1" },
+      discussionUpdateInput: {
+        DownloadableFiles: [{
+          connect: [{ where: { node: { id: "replacement-1" } } }],
+        }],
+      },
+    } as any,
+    {} as GraphQLContext,
+    {} as any
+  );
+
+  assert.deepEqual(
+    calls.map((call) => ({
+      downloadableFileId: call.downloadableFileId,
+      event: call.event,
+      models: call.models,
+    })),
+    [{
+      downloadableFileId: "replacement-1",
+      event: "downloadableFile.updated",
+      models: {
+        DownloadableFile: input.DownloadableFile,
+        Plugin: null,
+        PluginVersion: null,
+        PluginRun: input.PluginRun,
+        ServerConfig: input.ServerConfig,
+        ServerSecret: input.ServerSecret,
+      },
+    }]
+  );
+});
+
+test("does not retrigger scans for unrelated discussion edits", async () => {
+  let triggerCount = 0;
+  const resolver = getResolver({
+    Discussion: {
+      update: async () => ({ discussions: [] }),
+      find: async () => [{ id: "discussion-1" }],
+    },
+    DownloadableFile: {},
+    PluginRun: {},
+    ServerConfig: {},
+    ServerSecret: {},
+    driver: {
+      session: () => ({ run: async () => ({}), close: async () => {} }),
+    },
+  } as any, (async () => {
+    triggerCount += 1;
+    return [];
+  }) as any);
+
+  await resolver(
+    null,
+    {
+      where: { id: "discussion-1" },
+      discussionUpdateInput: { hasDownload: true },
+    } as any,
+    {} as GraphQLContext,
+    {} as any
+  );
+
+  assert.equal(triggerCount, 0);
+});

--- a/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
@@ -6,11 +6,22 @@ import { GraphQLError, type GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { sanitizeAlbumCreateNode, sanitizeAlbumUpdateNode } from "./utils/ownershipSanitizers.js";
 import type { GraphQLContext } from "../../types/context.js";
-import type { DiscussionModel } from "../../ogm_types.js";
+import type {
+  DiscussionModel,
+  DownloadableFileModel,
+  PluginRunModel,
+  ServerConfigModel,
+  ServerSecretModel,
+} from "../../ogm_types.js";
+import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
 import { logger } from "../../logger.js";
 
 type Input = {
   Discussion: DiscussionModel;
+  DownloadableFile: DownloadableFileModel;
+  PluginRun: PluginRunModel;
+  ServerConfig: ServerConfigModel;
+  ServerSecret: ServerSecretModel;
   driver: Driver;
 };
 
@@ -21,8 +32,30 @@ type Args = {
   channelDisconnections?: string[];
 };
 
-const getResolver = (input: Input) => {
-  const { Discussion, driver } = input;
+export const getConnectedDownloadableFileIds = (
+  updateInput: DiscussionUpdateInput
+): string[] => {
+  const updates = updateInput.DownloadableFiles || [];
+  return updates.flatMap((update) =>
+    (update?.connect || [])
+      .map((connection) => connection?.where?.node?.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0)
+  );
+};
+
+const getResolver = (
+  input: Input,
+  triggerDownloadRuns: typeof triggerPluginRunsForDownloadableFile =
+    triggerPluginRunsForDownloadableFile
+) => {
+  const {
+    Discussion,
+    DownloadableFile,
+    PluginRun,
+    ServerConfig,
+    ServerSecret,
+    driver,
+  } = input;
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const {
       where,
@@ -95,6 +128,38 @@ const getResolver = (input: Input) => {
         update: sanitizedUpdateInput,
       });
       const updatedDiscussionId = where.id;
+
+      // The edit form uploads replacement files before connecting them to the
+      // discussion. Trigger only newly connected file IDs after Discussion.update
+      // has created that relationship, so the scanner receives discussion and
+      // channel context and the replacement cannot remain PENDING indefinitely.
+      const connectedDownloadableFileIds = getConnectedDownloadableFileIds(
+        sanitizedUpdateInput
+      );
+      for (const downloadableFileId of connectedDownloadableFileIds) {
+        try {
+          await triggerDownloadRuns({
+            downloadableFileId,
+            event: "downloadableFile.updated",
+            models: {
+              DownloadableFile,
+              Plugin: null as any,
+              PluginVersion: null as any,
+              PluginRun,
+              ServerConfig,
+              ServerSecret,
+            },
+          });
+        } catch (triggerError: unknown) {
+          const message = triggerError instanceof Error
+            ? triggerError.message
+            : String(triggerError);
+          logger.error(
+            `downloadableFile.updated plugin trigger error for ${downloadableFileId}:`,
+            message
+          );
+        }
+      }
 
       const session = driver.session();
 


### PR DESCRIPTION
Closes the replacement-file rescan gap identified after multiforum-backend#169.

## What changed

- detect newly connected `DownloadableFile` IDs in discussion updates
- trigger `downloadableFile.updated` only after the replacement is connected to its discussion
- preserve discussion/channel context for the scanner
- avoid rescanning existing files during unrelated discussion edits
- log scanner trigger failures without rolling back the discussion edit, matching initial-upload behavior

## Validation

- TypeScript compile passed
- ESLint passed on changed files
- replacement/update/scanner focused tests passed (25/25)