### PR TITLE
Add download scan moderation queue

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -84,6 +84,7 @@ import installPluginVersion from "./mutations/installPluginVersion.js";
 import triggerDownloadableFilePluginRuns from "./mutations/triggerDownloadableFilePluginRuns.js";
 import retryDownloadableFileScan from "./mutations/retryDownloadableFileScan.js";
 import clearDownloadableFileScan from "./mutations/clearDownloadableFileScan.js";
+import requestDownloadableFileReview from "./mutations/requestDownloadableFileReview.js";
 import trackDownload from "./mutations/trackDownload.js";
 import updateDownloadableFileSupportSettings from "./mutations/updateDownloadableFileSupportSettings.js";
 import createDownloadableFilesWithUploadMetadata from "./mutations/createDownloadableFilesWithUploadMetadata.js";
@@ -556,6 +557,9 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     clearDownloadableFileScan: clearDownloadableFileScan({
       DownloadableFile,
       driver
+    }),
+    requestDownloadableFileReview: requestDownloadableFileReview({
+      DownloadableFile
     }),
     trackDownload: trackDownload({
       driver

--- a/customResolvers/mutations/clearDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.test.ts
@@ -58,6 +58,15 @@ test("clears a held scan and notifies the discussion author", async () => {
     },
     result: { id: "file-1", scanStatus: "CLEAN" },
   });
+  assert.deepEqual({
+    requestedAt: updates[0].update.reviewRequestedAt,
+    requestReason: updates[0].update.reviewRequestReason,
+    requestedBy: updates[0].update.reviewRequestedByUsername,
+  }, {
+    requestedAt: null,
+    requestReason: null,
+    requestedBy: null,
+  });
 });
 
 test("rejects a file that is already clean", async () => {

--- a/customResolvers/mutations/clearDownloadableFileScan.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.ts
@@ -44,6 +44,9 @@ export const createClearDownloadableFileScanResolver = ({
         scanStatus: "CLEAN",
         scanReason,
         scanCheckedAt,
+        reviewRequestedAt: null,
+        reviewRequestReason: null,
+        reviewRequestedByUsername: null,
       } as DownloadableFileUpdateInput),
     });
 

--- a/customResolvers/mutations/requestDownloadableFileReview.test.ts
+++ b/customResolvers/mutations/requestDownloadableFileReview.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import requestDownloadableFileReview from "./requestDownloadableFileReview.js";
+
+const contextFor = (username: string) => ({
+  user: { username },
+}) as GraphQLContext;
+
+test("records a creator review request for a held file", async () => {
+  const updates: any[] = [];
+  let finds = 0;
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => {
+        finds += 1;
+        return finds === 1
+          ? [{
+              scanStatus: "SUSPICIOUS",
+              uploadedByUsername: "alice",
+              Discussion: { Author: { username: "alice" } },
+            }]
+          : [{ id: "file-1", reviewRequestedByUsername: "alice" }];
+      },
+      update: async (args: unknown) => {
+        updates.push(args);
+        return {};
+      },
+    } as any,
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", reason: "This is a false positive" },
+    contextFor("alice") as any
+  );
+
+  assert.deepEqual({
+    update: {
+      ...updates[0].update,
+      reviewRequestedAt: Boolean(updates[0].update.reviewRequestedAt),
+    },
+    result,
+  }, {
+    update: {
+      reviewRequestedAt: true,
+      reviewRequestReason: "This is a false positive",
+      reviewRequestedByUsername: "alice",
+    },
+    result: { id: "file-1", reviewRequestedByUsername: "alice" },
+  });
+});
+
+test("rejects review requests from unrelated users", async () => {
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => [{
+        scanStatus: "INFECTED",
+        uploadedByUsername: "alice",
+        Discussion: { Author: { username: "alice" } },
+      }],
+    } as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      contextFor("bob") as any
+    ),
+    /Only the file creator/
+  );
+});
+
+test("rejects review requests for files that are not held", async () => {
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => [{
+        scanStatus: "CLEAN",
+        uploadedByUsername: "alice",
+      }],
+    } as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      contextFor("alice") as any
+    ),
+    /Only held security scans/
+  );
+});

--- a/customResolvers/mutations/requestDownloadableFileReview.ts
+++ b/customResolvers/mutations/requestDownloadableFileReview.ts
@@ -1,0 +1,71 @@
+import type {
+  DownloadableFileModel,
+  DownloadableFileUpdateInput,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  setUserDataOnContext,
+  type AuthContextForUserLookup,
+} from "../../rules/permission/userDataHelperFunctions.js";
+
+type Input = { DownloadableFile: DownloadableFileModel };
+
+type FileRecord = {
+  scanStatus?: string | null;
+  uploadedByUsername?: string | null;
+  Discussion?: { Author?: { username?: string | null } | null } | null;
+};
+
+type ReviewContext = GraphQLContext & AuthContextForUserLookup;
+
+const requestDownloadableFileReview = ({ DownloadableFile }: Input) => {
+  return async (
+    _parent: unknown,
+    args: { downloadableFileId: string; reason?: string | null },
+    context: ReviewContext
+  ) => {
+    if (!context.user) {
+      context.user = await setUserDataOnContext({ context });
+    }
+    const username = context.user?.username;
+    if (!username) throw new Error("You must be logged in to request review");
+
+    const files = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{
+        scanStatus
+        uploadedByUsername
+        Discussion { Author { username } }
+      }`,
+    }) as FileRecord[];
+    const file = files[0];
+    if (!file) throw new Error("Downloadable file not found");
+
+    const isCreator = file.uploadedByUsername === username ||
+      file.Discussion?.Author?.username === username;
+    if (!isCreator) throw new Error("Only the file creator can request review");
+    if (file.scanStatus !== "SUSPICIOUS" && file.scanStatus !== "INFECTED") {
+      throw new Error("Only held security scans can be sent for human review");
+    }
+
+    await DownloadableFile.update({
+      where: { id: args.downloadableFileId },
+      update: ({
+        reviewRequestedAt: new Date().toISOString(),
+        reviewRequestReason: args.reason?.trim() || null,
+        reviewRequestedByUsername: username,
+      } as DownloadableFileUpdateInput),
+    });
+
+    const updated = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{
+        id fileName scanStatus scanReason scanCheckedAt
+        reviewRequestedAt reviewRequestReason reviewRequestedByUsername
+      }`,
+    });
+    return updated[0];
+  };
+};
+
+export default requestDownloadableFileReview;

--- a/customResolvers/queries/getDownloadScanReviewQueue.test.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import getDownloadScanReviewQueue from "./getDownloadScanReviewQueue.js";
+
+test("returns held files with creator requests first", async () => {
+  const calls: any[] = [];
+  let closed = false;
+  const resolver = getDownloadScanReviewQueue({
+    driver: {
+      session: () => ({
+        run: async (query: string, params: unknown) => {
+          calls.push({ query, params });
+          return {
+            records: [{
+              get: () => ({
+                downloadableFileId: "file-1",
+                scanStatus: "SUSPICIOUS",
+                reviewRequestedAt: "2026-07-19T00:00:00Z",
+              }),
+            }],
+          };
+        },
+        close: async () => { closed = true; },
+      }),
+    } as any,
+  });
+
+  const result = await resolver(null, { limit: 500 });
+
+  assert.deepEqual({
+    result,
+    limit: calls[0].params.limit,
+    includesHeldStatuses: calls[0].query.includes("['SUSPICIOUS', 'INFECTED']"),
+    prioritizesRequests: calls[0].query.includes("file.reviewRequestedAt IS NULL"),
+    closed,
+  }, {
+    result: [{
+      downloadableFileId: "file-1",
+      scanStatus: "SUSPICIOUS",
+      reviewRequestedAt: "2026-07-19T00:00:00Z",
+    }],
+    limit: 100,
+    includesHeldStatuses: true,
+    prioritizesRequests: true,
+    closed: true,
+  });
+});

--- a/customResolvers/queries/getDownloadScanReviewQueue.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.ts
@@ -1,0 +1,46 @@
+import type { Driver } from "neo4j-driver";
+
+type Input = { driver: Driver };
+
+const getDownloadScanReviewQueue = ({ driver }: Input) => {
+  return async (_parent: unknown, args: { limit?: number | null } = {}) => {
+    const limit = Math.min(Math.max(args.limit || 50, 1), 100);
+    const session = driver.session();
+    try {
+      const result = await session.run(
+        `
+        MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile)
+        WHERE file.scanStatus IN ['SUSPICIOUS', 'INFECTED']
+          AND coalesce(file.permanentlyRemoved, false) = false
+        OPTIONAL MATCH (author:User)-[:AUTHORED_DISCUSSION]->(discussion)
+        OPTIONAL MATCH (discussion)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)
+        WITH file, discussion, author, head(collect(dc.channelUniqueName)) AS channelUniqueName
+        ORDER BY
+          CASE WHEN file.reviewRequestedAt IS NULL THEN 1 ELSE 0 END,
+          file.reviewRequestedAt DESC,
+          file.scanCheckedAt DESC
+        LIMIT toInteger($limit)
+        RETURN {
+          downloadableFileId: file.id,
+          fileName: file.fileName,
+          scanStatus: file.scanStatus,
+          scanReason: file.scanReason,
+          scanCheckedAt: toString(file.scanCheckedAt),
+          reviewRequestedAt: toString(file.reviewRequestedAt),
+          reviewRequestReason: file.reviewRequestReason,
+          uploaderUsername: coalesce(file.uploadedByUsername, author.username),
+          discussionId: discussion.id,
+          discussionTitle: discussion.title,
+          channelUniqueName: channelUniqueName
+        } AS review
+        `,
+        { limit }
+      );
+      return result.records.map((record) => record.get("review"));
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getDownloadScanReviewQueue;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -22,6 +22,7 @@ import getPipelineRuns from "./queries/getPipelineRuns.js";
 import publicCollectionsContaining from "./queries/publicCollectionsContaining.js";
 import getOwnEmail from "./queries/getOwnEmail.js";
 import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
+import getDownloadScanReviewQueue from "./queries/getDownloadScanReviewQueue.js";
 import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
 import getImageAlbumUsage from "./queries/getImageAlbumUsage.js";
@@ -136,6 +137,7 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     getServerHealthDashboard: getServerHealthDashboard({
       driver
-    })
+    }),
+    getDownloadScanReviewQueue: getDownloadScanReviewQueue({ driver })
   };
 }

--- a/permissions.ts
+++ b/permissions.ts
@@ -79,6 +79,7 @@ const permissionList = shield({
       emails: deny,
       getUploadedDownloadableFiles: and(isAuthenticated, allow),
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
+      getDownloadScanReviewQueue: and(isAuthenticated, canPermanentlyRemoveImage),
       getPluginConfigStatus: and(isAuthenticated, canManagePlugins),
     },
     User: {
@@ -336,6 +337,7 @@ const permissionList = shield({
       permanentlyRemoveImage: and(isAuthenticated, canPermanentlyRemoveImage),
       retryDownloadableFileScan: and(isAuthenticated, allow),
       clearDownloadableFileScan: and(isAuthenticated, canPermanentlyRemoveImage),
+      requestDownloadableFileReview: and(isAuthenticated, allow),
       permanentlyDeleteImage: and(isAuthenticated, allow),
       permanentlyDeleteDownloadableFile: and(isAuthenticated, allow),
 

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -155,6 +155,9 @@ test("persists the scanner verdict on the downloadable file", async () => {
       scanStatus: "PENDING",
       scanReason: null,
       scanCheckedAt: null,
+      reviewRequestedAt: null,
+      reviewRequestReason: null,
+      reviewRequestedByUsername: null,
     },
   });
   assert.deepEqual(fileUpdates[1], {

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -188,7 +188,10 @@ export const triggerPluginRunsForDownloadableFile = async (
       update: ({
         scanStatus: 'PENDING',
         scanReason: null,
-        scanCheckedAt: null
+        scanCheckedAt: null,
+        reviewRequestedAt: null,
+        reviewRequestReason: null,
+        reviewRequestedByUsername: null
       } as DownloadableFileUpdateInput)
     })
   }

--- a/tests/integration/downloadScanReviewQueue.test.ts
+++ b/tests/integration/downloadScanReviewQueue.test.ts
@@ -1,0 +1,91 @@
+import test, { after, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+test("download scan review queue includes held files and prioritizes requests", async () => {
+  await run(`
+    CREATE (channel:Channel {uniqueName: 'general', displayName: 'General'})
+    CREATE (author:User {username: 'alice'})
+    CREATE (discussion:Discussion {
+      id: 'discussion-1',
+      title: 'Download',
+      createdAt: datetime(),
+      hasDownload: true
+    })
+    CREATE (dc:DiscussionChannel {
+      id: 'dc-1',
+      discussionId: 'discussion-1',
+      channelUniqueName: 'general',
+      createdAt: datetime()
+    })
+    CREATE (requested:DownloadableFile {
+      id: 'requested-file',
+      fileName: 'requested.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/requested.zip',
+      createdAt: datetime(),
+      scanStatus: 'SUSPICIOUS',
+      reviewRequestedAt: datetime(),
+      reviewRequestReason: 'False positive'
+    })
+    CREATE (unrequested:DownloadableFile {
+      id: 'unrequested-file',
+      fileName: 'unrequested.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/unrequested.zip',
+      createdAt: datetime(),
+      scanStatus: 'INFECTED'
+    })
+    CREATE (clean:DownloadableFile {
+      id: 'clean-file',
+      fileName: 'clean.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/clean.zip',
+      createdAt: datetime(),
+      scanStatus: 'CLEAN'
+    })
+    CREATE (author)-[:POSTED_DISCUSSION]->(discussion)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(channel)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(requested)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(unrequested)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(clean)
+  `);
+
+  const result = await env.resolvers.Query.getDownloadScanReviewQueue(
+    null,
+    { limit: 10 }
+  );
+
+  assert.deepEqual(
+    result.map((item: any) => ({
+      id: item.downloadableFileId,
+      requested: Boolean(item.reviewRequestedAt),
+      channel: item.channelUniqueName,
+    })),
+    [
+      { id: "requested-file", requested: true, channel: "general" },
+      { id: "unrequested-file", requested: false, channel: "general" },
+    ]
+  );
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -452,6 +452,9 @@ const typeDefinitions = gql`
     scanStatus: ScanStatus! @default(value: PENDING)
     scanCheckedAt: DateTime
     scanReason: String
+    reviewRequestedAt: DateTime
+    reviewRequestReason: String
+    reviewRequestedByUsername: String
 
     # purchases back‑ref
     purchasers: [Purchase!]! @relationship(type: "PURCHASED_FILE", direction: IN)
@@ -1430,6 +1433,10 @@ const typeDefinitions = gql`
       downloadableFileId: ID!
       reason: String
     ): DownloadableFile!
+    requestDownloadableFileReview(
+      downloadableFileId: ID!
+      reason: String
+    ): DownloadableFile!
     enableServerPlugin(
       pluginId: String!
       version: String!
@@ -2106,6 +2113,20 @@ const typeDefinitions = gql`
     attentionItems: [ServerHealthAttentionItem!]!
   }
 
+  type DownloadScanReviewItem @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    downloadableFileId: ID!
+    fileName: String!
+    scanStatus: ScanStatus!
+    scanReason: String
+    scanCheckedAt: DateTime
+    reviewRequestedAt: DateTime
+    reviewRequestReason: String
+    uploaderUsername: String
+    discussionId: ID!
+    discussionTitle: String
+    channelUniqueName: String
+  }
+
   type UserContributionData {
     username: String!
     displayName: String
@@ -2266,6 +2287,7 @@ const typeDefinitions = gql`
       sortBy: String
       sortDirection: String
     ): ServerHealthDashboard!
+    getDownloadScanReviewQueue(limit: Int = 50): [DownloadScanReviewItem!]!
     isOriginalPosterSuspended(issueId: String!): Boolean
     safetyCheck: SafetyCheckResponse
     getServerPluginSecrets(


### PR DESCRIPTION
Second implementation slice for the remaining download-scan design gaps.

Stacked on #170 so the review workflow is tested with reliable replacement rescanning. After #170 merges, this PR can be retargeted to `main`.

## What changed

- add creator-owned, file-specific human review requests
- expose all held `SUSPICIOUS` and `INFECTED` files through a dedicated moderation queue
- prioritize creator-requested reviews while retaining automatically queued blocked files
- authorize the queue with the same permanent-removal capability used to clear files
- clear review-request metadata after moderator approval or a replacement rescan
- retain the existing author notification when a moderator clears a file

This intentionally uses persisted scan state as the queue source of truth instead of the plugin's transient `storeFlag` payload.

## Validation

- TypeScript compile passed
- ESLint passed on changed files
- focused review/scanner unit tests passed (12/12)
- Neo4j review-queue integration test passed