### PR TITLE
Gate downloads with a last-minute security scan

### DIFF
--- a/customResolvers/fields/downloadableFileUrl.test.ts
+++ b/customResolvers/fields/downloadableFileUrl.test.ts
@@ -53,7 +53,7 @@ test("returns an empty string when the request has a JWT error", async () => {
   assert.equal(result, "");
 });
 
-test("returns the file URL for authenticated requests", async () => {
+test("withholds the stored file URL from regular authenticated requests", async () => {
   const resolver = createDownloadableFileUrlResolver(async () => ({
     username: "cluse",
     email: "cluse@example.com",
@@ -67,7 +67,7 @@ test("returns the file URL for authenticated requests", async () => {
     buildContext() as unknown as ResolverContext
   );
 
-  assert.equal(result, "https://example.com/file.zip");
+  assert.equal(result, "");
 });
 
 test("reuses context.user when it is already available", async () => {
@@ -96,7 +96,7 @@ test("reuses context.user when it is already available", async () => {
     } as unknown as ResolverContext
   );
 
-  assert.equal(result, "https://example.com/file.zip");
+  assert.equal(result, "");
   assert.equal(callCount, 0);
 });
 

--- a/customResolvers/fields/downloadableFileUrl.ts
+++ b/customResolvers/fields/downloadableFileUrl.ts
@@ -74,10 +74,6 @@ export const createDownloadableFileUrlResolver = (
       return "";
     }
 
-    if (file.scanStatus === "CLEAN") {
-      return file.url || parent.url || "";
-    }
-
     const username = context.user.username;
     const isOwner =
       file.uploadedByUsername === username ||

--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -85,6 +85,7 @@ import triggerDownloadableFilePluginRuns from "./mutations/triggerDownloadableFi
 import retryDownloadableFileScan from "./mutations/retryDownloadableFileScan.js";
 import clearDownloadableFileScan from "./mutations/clearDownloadableFileScan.js";
 import trackDownload from "./mutations/trackDownload.js";
+import prepareDownload from "./mutations/prepareDownload.js";
 import updateDownloadableFileSupportSettings from "./mutations/updateDownloadableFileSupportSettings.js";
 import createDownloadableFilesWithUploadMetadata from "./mutations/createDownloadableFilesWithUploadMetadata.js";
 import enableServerPlugin from "./mutations/enableServerPlugin.js";
@@ -558,6 +559,15 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
       driver
     }),
     trackDownload: trackDownload({
+      driver
+    }),
+    prepareDownload: prepareDownload({
+      DownloadableFile,
+      Plugin,
+      PluginVersion,
+      PluginRun,
+      ServerConfig,
+      ServerSecret,
       driver
     }),
     updateDownloadableFileSupportSettings: updateDownloadableFileSupportSettings({

--- a/customResolvers/mutations/prepareDownload.test.ts
+++ b/customResolvers/mutations/prepareDownload.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import { createPrepareDownloadResolver } from "./prepareDownload.js";
+
+const buildInput = (initialFile: Record<string, unknown>) => {
+  let file = initialFile;
+  return {
+    input: {
+      DownloadableFile: { find: async () => [file] },
+      Plugin: {},
+      PluginVersion: {},
+      PluginRun: {},
+      ServerConfig: {},
+      ServerSecret: {},
+      driver: {},
+    } as any,
+    updateFile: (updates: Record<string, unknown>) => {
+      file = { ...file, ...updates };
+    },
+  };
+};
+
+const baseFile = {
+  id: "file-1",
+  url: "https://storage.example.com/file.zip",
+  storageBucket: "downloads",
+  storageObjectName: "uploads/alice/file.zip",
+  scanStatus: "CLEAN",
+  uploadedByUsername: "alice",
+  Discussion: {
+    id: "discussion-1",
+    Author: { username: "alice" },
+  },
+};
+
+const contextFor = (username: string) => ({
+  user: {
+    username,
+    email: `${username}@example.com`,
+    email_verified: true,
+    data: null,
+  },
+}) as GraphQLContext;
+
+test("runs the download scanner before returning a signed read URL", async () => {
+  const { input, updateFile } = buildInput(baseFile);
+  const calls = { tracked: 0, signedOptions: null as unknown };
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      updateFile({
+        scanStatus: "CLEAN",
+        scanCheckedAt: "2026-07-19T12:00:00Z",
+      });
+      return [{ pluginId: "security-attachment-scan", status: "SUCCEEDED" }];
+    }) as any,
+    async () => false,
+    () => ({
+      bucket: () => ({
+        file: () => ({
+          getSignedUrl: async (options: unknown) => {
+            calls.signedOptions = options;
+            return ["https://signed.example.com/file.zip"];
+          },
+        }),
+      }),
+    }) as any,
+    (async () => {
+      calls.tracked += 1;
+      return true;
+    }) as any
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.deepEqual({
+    ready: result.ready,
+    url: result.url,
+    status: result.scanStatus,
+    message: result.message,
+    tracked: calls.tracked,
+    signedAction: (calls.signedOptions as { action?: string })?.action,
+  }, {
+    ready: true,
+    url: "https://signed.example.com/file.zip",
+    status: "CLEAN",
+    message: "No threats found. Your download is ready.",
+    tracked: 1,
+    signedAction: "read",
+  });
+});
+
+test("withholds a blocked download and its private scanner reason", async () => {
+  const { input, updateFile } = buildInput(baseFile);
+  let tracked = false;
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      updateFile({ scanStatus: "INFECTED", scanReason: "Private signature" });
+      return [{ pluginId: "security-attachment-scan", status: "FAILED" }];
+    }) as any,
+    async () => false,
+    (() => ({})) as any,
+    (async () => {
+      tracked = true;
+      return true;
+    }) as any
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.deepEqual({
+    ready: result.ready,
+    url: result.url,
+    status: result.scanStatus,
+    reason: result.scanReason,
+    tracked,
+  }, {
+    ready: false,
+    url: null,
+    status: "INFECTED",
+    reason: null,
+    tracked: false,
+  });
+});
+
+test("lets the creator prepare a held file for human review", async () => {
+  const { input, updateFile } = buildInput({
+    ...baseFile,
+    storageBucket: null,
+    storageObjectName: null,
+  });
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      updateFile({ scanStatus: "SUSPICIOUS", scanReason: "Archive heuristic" });
+      return [{ pluginId: "security-attachment-scan", status: "FAILED" }];
+    }) as any,
+    async () => false,
+    (() => ({})) as any,
+    (async () => true) as any
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual({
+    ready: result.ready,
+    url: result.url,
+    status: result.scanStatus,
+    reason: result.scanReason,
+    reviewAccess: result.reviewAccess,
+  }, {
+    ready: true,
+    url: "https://storage.example.com/file.zip",
+    status: "SUSPICIOUS",
+    reason: "Archive heuristic",
+    reviewAccess: true,
+  });
+});
+
+test("fails closed when no pre-download security scanner is configured", async () => {
+  const { input } = buildInput(baseFile);
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => []) as any,
+    async () => false
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.deepEqual({
+    ready: result.ready,
+    status: result.scanStatus,
+    message: result.message,
+  }, {
+    ready: false,
+    status: "FAILED",
+    message: "The download security scanner is not configured.",
+  });
+});
+
+test("rejects a file that does not belong to the requested discussion", async () => {
+  const { input } = buildInput(baseFile);
+  const resolver = createPrepareDownloadResolver(input);
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1", discussionId: "discussion-2" },
+      contextFor("bob")
+    ),
+    /Downloadable file not found for this discussion/
+  );
+});

--- a/customResolvers/mutations/prepareDownload.ts
+++ b/customResolvers/mutations/prepareDownload.ts
@@ -1,0 +1,216 @@
+import { Storage, type GetSignedUrlConfig } from "@google-cloud/storage";
+import type { Driver } from "neo4j-driver";
+import type {
+  DownloadableFileModel,
+  PluginModel,
+  PluginRunModel,
+  PluginVersionModel,
+  ServerConfigModel,
+  ServerSecretModel,
+} from "../../ogm_types.js";
+import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import { SECURITY_SCAN_PLUGIN_ID } from "../../services/plugin/downloadScanOutcome.js";
+import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
+import type { GraphQLContext } from "../../types/context.js";
+import trackDownload from "./trackDownload.js";
+
+type Input = {
+  DownloadableFile: DownloadableFileModel;
+  Plugin: PluginModel;
+  PluginVersion: PluginVersionModel;
+  PluginRun: PluginRunModel;
+  ServerConfig: ServerConfigModel;
+  ServerSecret: ServerSecretModel;
+  driver: Driver;
+};
+
+type FileRecord = {
+  id: string;
+  url?: string | null;
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+  scanStatus?: string | null;
+  scanReason?: string | null;
+  scanCheckedAt?: string | null;
+  uploadedByUsername?: string | null;
+  Discussion?: {
+    id?: string | null;
+    Author?: { username?: string | null } | null;
+  } | null;
+};
+
+type PluginRunRecord = {
+  pluginId?: string | null;
+  status?: string | null;
+};
+
+type TrackDownloadResolver = ReturnType<typeof trackDownload>;
+
+type StorageFactory = () => Pick<Storage, "bucket">;
+
+const READ_URL_TTL_MS = 5 * 60 * 1000;
+
+const selectFile = async (
+  DownloadableFile: DownloadableFileModel,
+  downloadableFileId: string
+): Promise<FileRecord | null> => {
+  const files = await DownloadableFile.find({
+    where: { id: downloadableFileId },
+    selectionSet: `{
+      id
+      url
+      storageBucket
+      storageObjectName
+      scanStatus
+      scanReason
+      scanCheckedAt
+      uploadedByUsername
+      Discussion { id Author { username } }
+    }`,
+  }) as FileRecord[];
+
+  return files[0] || null;
+};
+
+const createReadUrl = async ({
+  file,
+  storageFactory,
+}: {
+  file: FileRecord;
+  storageFactory: StorageFactory;
+}): Promise<string> => {
+  if (!file.storageBucket || !file.storageObjectName) {
+    return file.url || "";
+  }
+
+  const options: GetSignedUrlConfig = {
+    version: "v4",
+    action: "read",
+    expires: Date.now() + READ_URL_TTL_MS,
+    responseDisposition: "attachment",
+  };
+  const [url] = await storageFactory()
+    .bucket(file.storageBucket)
+    .file(file.storageObjectName)
+    .getSignedUrl(options);
+
+  return url || "";
+};
+
+export const createPrepareDownloadResolver = (
+  input: Input,
+  triggerRuns: typeof triggerPluginRunsForDownloadableFile =
+    triggerPluginRunsForDownloadableFile,
+  checkServerModPermission: typeof hasServerModPermission =
+    hasServerModPermission,
+  storageFactory: StorageFactory = () => new Storage(),
+  trackDownloadResolver: TrackDownloadResolver = trackDownload({
+    driver: input.driver,
+  })
+) => {
+  return async (
+    _parent: unknown,
+    {
+      downloadableFileId,
+      discussionId,
+    }: { downloadableFileId: string; discussionId: string },
+    context: GraphQLContext
+  ) => {
+    if (!downloadableFileId) throw new Error("Downloadable file ID is required");
+    if (!discussionId) throw new Error("Discussion ID is required");
+
+    if (!context.user) {
+      context.user = await setUserDataOnContext({ context });
+    }
+    const username = context.user?.username;
+    if (!username) throw new Error("You must be logged in to download files");
+
+    const originalFile = await selectFile(input.DownloadableFile, downloadableFileId);
+    if (!originalFile || originalFile.Discussion?.id !== discussionId) {
+      throw new Error("Downloadable file not found for this discussion");
+    }
+
+    const isCreator =
+      originalFile.uploadedByUsername === username ||
+      originalFile.Discussion?.Author?.username === username;
+    const canReview = isCreator || (await checkServerModPermission(
+      "canPermanentlyRemoveImage",
+      context
+    )) === true;
+
+    const runs = await triggerRuns({
+      downloadableFileId,
+      event: "downloadableFile.downloaded",
+      models: input,
+    }) as PluginRunRecord[];
+    const securityRun = runs.find(
+      (run) => run.pluginId === SECURITY_SCAN_PLUGIN_ID
+    );
+
+    if (!securityRun) {
+      return {
+        ready: false,
+        url: null,
+        scanStatus: "FAILED",
+        scanReason: null,
+        scanCheckedAt: null,
+        reviewAccess: false,
+        message: "The download security scanner is not configured.",
+      };
+    }
+
+    const scannedFile = await selectFile(input.DownloadableFile, downloadableFileId);
+    if (!scannedFile) throw new Error("Downloadable file no longer exists");
+
+    const scanStatus = scannedFile.scanStatus || "FAILED";
+    const reviewAccess = scanStatus !== "CLEAN" && canReview;
+    const ready = scanStatus === "CLEAN" || reviewAccess;
+    if (!ready) {
+      return {
+        ready: false,
+        url: null,
+        scanStatus,
+        scanReason: null,
+        scanCheckedAt: scannedFile.scanCheckedAt || null,
+        reviewAccess: false,
+        message: scanStatus === "FAILED"
+          ? "The security check could not be completed. Please try again."
+          : "This download was blocked by the security check.",
+      };
+    }
+
+    const url = await createReadUrl({ file: scannedFile, storageFactory });
+    if (!url) {
+      return {
+        ready: false,
+        url: null,
+        scanStatus: "FAILED",
+        scanReason: null,
+        scanCheckedAt: scannedFile.scanCheckedAt || null,
+        reviewAccess: false,
+        message: "The download URL could not be prepared. Please try again.",
+      };
+    }
+
+    await trackDownloadResolver(
+      null,
+      { downloadableFileId, discussionId },
+      context
+    );
+
+    return {
+      ready: true,
+      url,
+      scanStatus,
+      scanReason: reviewAccess ? scannedFile.scanReason || null : null,
+      scanCheckedAt: scannedFile.scanCheckedAt || null,
+      reviewAccess,
+      message: reviewAccess
+        ? "The file is still held for review. Reviewer download prepared."
+        : "No threats found. Your download is ready.",
+    };
+  };
+};
+
+export default createPrepareDownloadResolver;

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1005,6 +1005,16 @@ const typeDefinitions = gql`
     uploadedAt: DateTime
   }
 
+  type PrepareDownloadResult {
+    ready: Boolean!
+    url: String
+    scanStatus: ScanStatus!
+    scanReason: String
+    scanCheckedAt: DateTime
+    reviewAccess: Boolean!
+    message: String!
+  }
+
   type DropDataResponse {
     success: Boolean
     message: String
@@ -1115,6 +1125,7 @@ const typeDefinitions = gql`
 
     # Library management
     trackDownload(downloadableFileId: ID!, discussionId: ID!): Boolean!
+    prepareDownload(downloadableFileId: ID!, discussionId: ID!): PrepareDownloadResult!
     updateDownloadableFileSupportSettings(
       downloadableFileId: ID!
       discussionId: ID!


### PR DESCRIPTION
## Summary

- add a `prepareDownload` mutation that runs the existing `downloadableFile.downloaded` plugin pipeline before releasing a file
- fail closed when the security scanner is missing, fails, or blocks an ordinary download
- preserve creator and authorized moderator access for human review
- return a five-minute signed GCS read URL only after approval and record download analytics afterward
- stop exposing stored clean-file URLs through ordinary authenticated detail queries

This reuses the existing `security-attachment-scan` VirusTotal integration; no scan-plugin or scan-service changes are required.

## Validation

- `pnpm run codegen`
- `pnpm exec tsc --noEmit --pretty false`
- `node --loader ts-node/esm --test customResolvers/mutations/prepareDownload.test.ts customResolvers/fields/downloadableFileUrl.test.ts customResolvers/mutations/trackDownload.test.ts` (21 passing)

## Frontend

Coordinated frontend PR: gennit-project/multiforum-nuxt#402.