### PR TITLE
Reuse recent pre-download security scans

### DIFF
--- a/customResolvers/mutations/prepareDownload.test.ts
+++ b/customResolvers/mutations/prepareDownload.test.ts
@@ -95,6 +95,179 @@ test("runs the download scanner before returning a signed read URL", async () =>
   });
 });
 
+test("reuses a recent clean scan without invoking the scanner", async () => {
+  const { input } = buildInput({
+    ...baseFile,
+    scanCheckedAt: "2026-07-19T11:55:00Z",
+  });
+  const calls = { scanned: 0, tracked: 0 };
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      calls.scanned += 1;
+      return [];
+    }) as any,
+    async () => false,
+    () => ({
+      bucket: () => ({
+        file: () => ({
+          getSignedUrl: async () => ["https://signed.example.com/file.zip"],
+        }),
+      }),
+    }) as any,
+    (async () => {
+      calls.tracked += 1;
+      return true;
+    }) as any,
+    {
+      now: () => new Date("2026-07-19T12:00:00Z"),
+      scanCacheTtlMs: 15 * 60 * 1000,
+    }
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.deepEqual({
+    ready: result.ready,
+    scanned: calls.scanned,
+    tracked: calls.tracked,
+  }, {
+    ready: true,
+    scanned: 0,
+    tracked: 1,
+  });
+});
+
+test("rescans an expired clean result", async () => {
+  const { input, updateFile } = buildInput({
+    ...baseFile,
+    storageBucket: null,
+    storageObjectName: null,
+    scanCheckedAt: "2026-07-19T11:44:59Z",
+  });
+  let scanned = 0;
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      scanned += 1;
+      updateFile({ scanCheckedAt: "2026-07-19T12:00:00Z" });
+      return [{ pluginId: "security-attachment-scan", status: "SUCCEEDED" }];
+    }) as any,
+    async () => false,
+    (() => ({})) as any,
+    (async () => true) as any,
+    {
+      now: () => new Date("2026-07-19T12:00:00Z"),
+      scanCacheTtlMs: 15 * 60 * 1000,
+    }
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.equal(result.ready, true);
+  assert.equal(scanned, 1);
+});
+
+test("shares one scan between concurrent download preparations", async () => {
+  const { input, updateFile } = buildInput(baseFile);
+  let releaseScan: (() => void) | undefined;
+  const scanGate = new Promise<void>((resolve) => {
+    releaseScan = resolve;
+  });
+  const calls = { scanned: 0, tracked: 0 };
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      calls.scanned += 1;
+      await scanGate;
+      updateFile({
+        scanStatus: "CLEAN",
+        scanCheckedAt: "2026-07-19T12:00:00Z",
+      });
+      return [{ pluginId: "security-attachment-scan", status: "SUCCEEDED" }];
+    }) as any,
+    async () => false,
+    () => ({
+      bucket: () => ({
+        file: () => ({
+          getSignedUrl: async () => ["https://signed.example.com/file.zip"],
+        }),
+      }),
+    }) as any,
+    (async () => {
+      calls.tracked += 1;
+      return true;
+    }) as any
+  );
+
+  const first = resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+  const second = resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("carol")
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls.scanned, 1);
+  releaseScan?.();
+  const results = await Promise.all([first, second]);
+
+  assert.deepEqual(results.map((result) => result.ready), [true, true]);
+  assert.equal(calls.scanned, 1);
+  assert.equal(calls.tracked, 2);
+});
+
+test("clears a failed in-flight scan so a later request can retry", async () => {
+  const { input, updateFile } = buildInput({
+    ...baseFile,
+    storageBucket: null,
+    storageObjectName: null,
+  });
+  let scanned = 0;
+  const resolver = createPrepareDownloadResolver(
+    input,
+    (async () => {
+      scanned += 1;
+      if (scanned === 1) throw new Error("scanner unavailable");
+      updateFile({ scanCheckedAt: "2026-07-19T12:00:00Z" });
+      return [{ pluginId: "security-attachment-scan", status: "SUCCEEDED" }];
+    }) as any,
+    async () => false,
+    (() => ({})) as any,
+    (async () => true) as any
+  );
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1", discussionId: "discussion-1" },
+      contextFor("bob")
+    ),
+    /scanner unavailable/
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", discussionId: "discussion-1" },
+    contextFor("bob")
+  );
+
+  assert.equal(result.ready, true);
+  assert.equal(scanned, 2);
+});
+
 test("withholds a blocked download and its private scanner reason", async () => {
   const { input, updateFile } = buildInput(baseFile);
   let tracked = false;

--- a/customResolvers/mutations/prepareDownload.ts
+++ b/customResolvers/mutations/prepareDownload.ts
@@ -50,6 +50,37 @@ type TrackDownloadResolver = ReturnType<typeof trackDownload>;
 type StorageFactory = () => Pick<Storage, "bucket">;
 
 const READ_URL_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_DOWNLOAD_SCAN_CACHE_TTL_MS = 15 * 60 * 1000;
+
+type PrepareDownloadOptions = {
+  now?: () => Date;
+  scanCacheTtlMs?: number;
+};
+
+const configuredScanCacheTtlMs = (): number => {
+  const configured = Number(process.env.DOWNLOAD_SCAN_CACHE_TTL_MS);
+  return Number.isFinite(configured) && configured >= 0
+    ? configured
+    : DEFAULT_DOWNLOAD_SCAN_CACHE_TTL_MS;
+};
+
+const hasFreshCleanScan = ({
+  file,
+  now,
+  ttlMs,
+}: {
+  file: FileRecord;
+  now: Date;
+  ttlMs: number;
+}): boolean => {
+  if (file.scanStatus !== "CLEAN" || !file.scanCheckedAt || ttlMs <= 0) {
+    return false;
+  }
+
+  const checkedAt = Date.parse(file.scanCheckedAt);
+  const ageMs = now.getTime() - checkedAt;
+  return Number.isFinite(checkedAt) && ageMs >= 0 && ageMs <= ttlMs;
+};
 
 const selectFile = async (
   DownloadableFile: DownloadableFileModel,
@@ -107,8 +138,29 @@ export const createPrepareDownloadResolver = (
   storageFactory: StorageFactory = () => new Storage(),
   trackDownloadResolver: TrackDownloadResolver = trackDownload({
     driver: input.driver,
-  })
+  }),
+  {
+    now = () => new Date(),
+    scanCacheTtlMs = configuredScanCacheTtlMs(),
+  }: PrepareDownloadOptions = {}
 ) => {
+  const inFlightScans = new Map<string, Promise<PluginRunRecord[]>>();
+
+  const runOrJoinScan = (downloadableFileId: string) => {
+    const existingScan = inFlightScans.get(downloadableFileId);
+    if (existingScan) return existingScan;
+
+    const scan = Promise.resolve(triggerRuns({
+      downloadableFileId,
+      event: "downloadableFile.downloaded",
+      models: input,
+    }) as Promise<PluginRunRecord[]>).finally(() => {
+      inFlightScans.delete(downloadableFileId);
+    });
+    inFlightScans.set(downloadableFileId, scan);
+    return scan;
+  };
+
   return async (
     _parent: unknown,
     {
@@ -139,28 +191,31 @@ export const createPrepareDownloadResolver = (
       context
     )) === true;
 
-    const runs = await triggerRuns({
-      downloadableFileId,
-      event: "downloadableFile.downloaded",
-      models: input,
-    }) as PluginRunRecord[];
-    const securityRun = runs.find(
-      (run) => run.pluginId === SECURITY_SCAN_PLUGIN_ID
-    );
+    let scannedFile: FileRecord | null = originalFile;
+    if (!hasFreshCleanScan({
+      file: originalFile,
+      now: now(),
+      ttlMs: scanCacheTtlMs,
+    })) {
+      const runs = await runOrJoinScan(downloadableFileId);
+      const securityRun = runs.find(
+        (run) => run.pluginId === SECURITY_SCAN_PLUGIN_ID
+      );
 
-    if (!securityRun) {
-      return {
-        ready: false,
-        url: null,
-        scanStatus: "FAILED",
-        scanReason: null,
-        scanCheckedAt: null,
-        reviewAccess: false,
-        message: "The download security scanner is not configured.",
-      };
+      if (!securityRun) {
+        return {
+          ready: false,
+          url: null,
+          scanStatus: "FAILED",
+          scanReason: null,
+          scanCheckedAt: null,
+          reviewAccess: false,
+          message: "The download security scanner is not configured.",
+        };
+      }
+
+      scannedFile = await selectFile(input.DownloadableFile, downloadableFileId);
     }
-
-    const scannedFile = await selectFile(input.DownloadableFile, downloadableFileId);
     if (!scannedFile) throw new Error("Downloadable file no longer exists");
 
     const scanStatus = scannedFile.scanStatus || "FAILED";

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -60,6 +60,7 @@ test/E2E environments the seeded admin test user also acts as root.
 | `GCS_BUCKET_NAME` | If uploads enabled | Google Cloud Storage bucket for uploaded images/files. |
 | `GOOGLE_CREDENTIALS_BASE64` | If uploads enabled | Base64-encoded GCP service-account JSON. At startup it is decoded to a file and `GOOGLE_APPLICATION_CREDENTIALS` is pointed at it (convenient for single-value secrets on Heroku). |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Alternative to the above | Filesystem path to a GCP service-account JSON file. Set automatically when `GOOGLE_CREDENTIALS_BASE64` is provided. |
+| `DOWNLOAD_SCAN_CACHE_TTL_MS` | No | How long a clean pre-download security verdict may be reused (default `900000`, or 15 minutes). Set to `0` to scan on every download request. Failed or held verdicts are never reused. |
 
 ## Server / app
 


### PR DESCRIPTION
## Summary

- reuse persisted `CLEAN` pre-download scan verdicts for a bounded freshness window
- deduplicate simultaneous scan requests for the same file within a backend instance
- keep URL signing, authorization, and download analytics independent per requester
- document `DOWNLOAD_SCAN_CACHE_TTL_MS` (15-minute default; `0` disables reuse)

Only clean verdicts are reusable. Failed, suspicious, infected, invalid, expired, and future-dated results continue through the scanner.

## Verification

- `pnpm run codegen`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint customResolvers/mutations/prepareDownload.ts customResolvers/mutations/prepareDownload.test.ts`
- `node --loader ts-node/esm --test customResolvers/mutations/prepareDownload.test.ts customResolvers/fields/downloadableFileUrl.test.ts customResolvers/mutations/trackDownload.test.ts` (25 passing)