### PR TITLE
Store downloadable files in private storage

### DIFF
--- a/build_scripts/migratePrivateDownloads.ts
+++ b/build_scripts/migratePrivateDownloads.ts
@@ -1,0 +1,155 @@
+import { Storage } from "@google-cloud/storage";
+import dotenv from "dotenv";
+import neo4j from "neo4j-driver";
+import { buildStorageUrl } from "../services/uploadStorageMetadata.js";
+
+dotenv.config();
+
+const apply = process.argv.includes("--apply");
+const uri = process.env.NEO4J_URI || "bolt://localhost:7687";
+const user = process.env.NEO4J_USER || "neo4j";
+const password = process.env.NEO4J_PASSWORD;
+const targetBucket = process.env.GCS_PRIVATE_DOWNLOAD_BUCKET_NAME;
+
+if (!password) {
+  throw new Error("NEO4J_PASSWORD is required to migrate downloads");
+}
+if (!targetBucket) {
+  throw new Error("GCS_PRIVATE_DOWNLOAD_BUCKET_NAME is required to migrate downloads");
+}
+
+const credentials = process.env.GOOGLE_CREDENTIALS_BASE64
+  ? JSON.parse(
+      Buffer.from(process.env.GOOGLE_CREDENTIALS_BASE64, "base64").toString("utf8")
+    )
+  : undefined;
+const storage = new Storage(credentials ? { credentials } : undefined);
+const driver = neo4j.driver(uri, neo4j.auth.basic(user, password));
+
+type DownloadRecord = {
+  id: string;
+  storageBucket: string;
+  storageObjectName: string;
+};
+
+const loadDownloadsToMigrate = async (): Promise<DownloadRecord[]> => {
+  const session = driver.session({ defaultAccessMode: "READ" });
+  try {
+    const result = await session.run(
+      `
+      MATCH (file:DownloadableFile)
+      WHERE file.storageBucket IS NOT NULL
+        AND file.storageObjectName IS NOT NULL
+        AND file.storageBucket <> $targetBucket
+      RETURN
+        file.id AS id,
+        file.storageBucket AS storageBucket,
+        file.storageObjectName AS storageObjectName
+      ORDER BY file.id
+      `,
+      { targetBucket }
+    );
+
+    return result.records.map((record) => ({
+      id: record.get("id"),
+      storageBucket: record.get("storageBucket"),
+      storageObjectName: record.get("storageObjectName"),
+    }));
+  } finally {
+    await session.close();
+  }
+};
+
+const updateDownloadMetadata = async (download: DownloadRecord): Promise<void> => {
+  const storageUrl = buildStorageUrl({
+    storageBucket: targetBucket,
+    storageObjectName: download.storageObjectName,
+  });
+  const session = driver.session({ defaultAccessMode: "WRITE" });
+  try {
+    const result = await session.run(
+      `
+      MATCH (file:DownloadableFile {id: $id})
+      WHERE file.storageBucket = $sourceBucket
+        AND file.storageObjectName = $storageObjectName
+      SET
+        file.storageBucket = $targetBucket,
+        file.storageUrl = $storageUrl,
+        file.url = $storageUrl
+      WITH file
+      OPTIONAL MATCH (audit:UploadedFileAudit {
+        claimedByType: 'DownloadableFile',
+        claimedById: $id
+      })
+      SET
+        audit.storageBucket = $targetBucket,
+        audit.storageUrl = $storageUrl
+      RETURN count(DISTINCT file) AS updated
+      `,
+      {
+        id: download.id,
+        sourceBucket: download.storageBucket,
+        storageObjectName: download.storageObjectName,
+        targetBucket,
+        storageUrl,
+      }
+    );
+
+    if (result.records[0]?.get("updated").toNumber() !== 1) {
+      throw new Error(`Download ${download.id} changed while it was being migrated`);
+    }
+  } finally {
+    await session.close();
+  }
+};
+
+const migrateDownload = async (download: DownloadRecord): Promise<void> => {
+  const source = storage
+    .bucket(download.storageBucket)
+    .file(download.storageObjectName);
+  const destination = storage
+    .bucket(targetBucket)
+    .file(download.storageObjectName);
+  const [destinationExists] = await destination.exists();
+
+  if (!destinationExists) {
+    await source.copy(destination);
+  }
+
+  // Remove the publicly-addressable source before switching database metadata.
+  // If the database update fails, rerunning is safe because the destination is
+  // retained and source deletion ignores a missing object.
+  await source.delete({ ignoreNotFound: true });
+  await updateDownloadMetadata(download);
+};
+
+const run = async (): Promise<void> => {
+  const downloads = await loadDownloadsToMigrate();
+  console.log(`${apply ? "Migrating" : "Would migrate"} ${downloads.length} downloads`);
+
+  if (!apply) {
+    for (const download of downloads) {
+      console.log(
+        `${download.id}: gs://${download.storageBucket}/${download.storageObjectName} -> gs://${targetBucket}/${download.storageObjectName}`
+      );
+    }
+    console.log("Dry run only. Re-run with --apply during a maintenance window.");
+    return;
+  }
+
+  for (const download of downloads) {
+    await migrateDownload(download);
+    console.log(`Migrated ${download.id}`);
+  }
+};
+
+run()
+  .then(async () => {
+    await driver.close();
+    console.log("Private download migration complete");
+  })
+  .catch(async (error) => {
+    await driver.close();
+    console.error("Private download migration failed", error);
+    process.exitCode = 1;
+  });

--- a/customResolvers/mutations/createSignedStorageURL.test.ts
+++ b/customResolvers/mutations/createSignedStorageURL.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { validateFile } from "./createSignedStorageURL.js";
+import {
+  resolveUploadBucketName,
+  validateFile,
+} from "./createSignedStorageURL.js";
 import { ModelStub } from "../../tests/testUtils.js";
 
 const createContext = ({
@@ -72,4 +75,34 @@ test("download upload validation rejects disallowed channel file types", async (
     ),
     /File type 'zip' is not allowed in channel 'cats'/
   );
+});
+
+test("routes downloadable files to the private bucket", () => {
+  const bucketName = resolveUploadBucketName({
+    uploadTarget: "PRIVATE_DOWNLOAD",
+    env: {
+      GCS_BUCKET_NAME: "public-media",
+      GCS_PRIVATE_DOWNLOAD_BUCKET_NAME: "private-downloads",
+    },
+  });
+
+  assert.equal(bucketName, "private-downloads");
+});
+
+test("fails closed when the private download bucket is not configured", () => {
+  assert.throws(
+    () => resolveUploadBucketName({
+      uploadTarget: "PRIVATE_DOWNLOAD",
+      env: { GCS_BUCKET_NAME: "public-media" },
+    }),
+    /GCS_PRIVATE_DOWNLOAD_BUCKET_NAME environment variable not set/
+  );
+});
+
+test("keeps existing upload callers on the public media bucket", () => {
+  const bucketName = resolveUploadBucketName({
+    env: { GCS_BUCKET_NAME: "public-media" },
+  });
+
+  assert.equal(bucketName, "public-media");
 });

--- a/customResolvers/mutations/createSignedStorageURL.ts
+++ b/customResolvers/mutations/createSignedStorageURL.ts
@@ -14,6 +14,7 @@ type Args = {
   filename: string;
   contentType: string;
   channelConnections?: string[]; // Optional array of channel names
+  uploadTarget?: "PUBLIC_MEDIA" | "PRIVATE_DOWNLOAD";
 };
 
 interface ValidationContext {
@@ -156,9 +157,35 @@ export const validateFile = async (
   await validateFileType(filename, channelConnections, ctx);
 };
 
+export const resolveUploadBucketName = ({
+  uploadTarget,
+  env = process.env,
+}: {
+  uploadTarget?: Args["uploadTarget"];
+  env?: Partial<
+    Pick<NodeJS.ProcessEnv, "GCS_BUCKET_NAME" | "GCS_PRIVATE_DOWNLOAD_BUCKET_NAME">
+  >;
+}): string => {
+  const environmentVariable = uploadTarget === "PRIVATE_DOWNLOAD"
+    ? "GCS_PRIVATE_DOWNLOAD_BUCKET_NAME"
+    : "GCS_BUCKET_NAME";
+  const bucketName = env[environmentVariable];
+
+  if (!bucketName) {
+    throw new Error(`${environmentVariable} environment variable not set`);
+  }
+
+  return bucketName;
+};
+
 const createSignedStorageURL = () => {
   return async (parent: unknown, args: Args, ctx: ResolverContext) => {
-    let { filename, contentType, channelConnections = [] } = args;
+    const {
+      filename,
+      contentType,
+      channelConnections = [],
+      uploadTarget,
+    } = args;
 
     if (!filename?.trim()) {
       throw new Error("Filename is required");
@@ -175,11 +202,7 @@ const createSignedStorageURL = () => {
     await validateFile(filename, contentType, channelConnections, ctx);
 
     const storage = new Storage();
-    const bucketName = process.env.GCS_BUCKET_NAME;
-
-    if (!bucketName) {
-      throw new Error("GCS_BUCKET_NAME environment variable not set");
-    }
+    const bucketName = resolveUploadBucketName({ uploadTarget });
 
     const uploadedAt = new Date().toISOString();
     const storageObjectName = buildStorageObjectName({

--- a/customResolvers/mutations/prepareDownload.ts
+++ b/customResolvers/mutations/prepareDownload.ts
@@ -1,4 +1,4 @@
-import { Storage, type GetSignedUrlConfig } from "@google-cloud/storage";
+import { Storage } from "@google-cloud/storage";
 import type { Driver } from "neo4j-driver";
 import type {
   DownloadableFileModel,
@@ -12,6 +12,7 @@ import { hasServerModPermission } from "../../rules/permission/hasServerModPermi
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
 import { SECURITY_SCAN_PLUGIN_ID } from "../../services/plugin/downloadScanOutcome.js";
 import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
+import { createDownloadReadUrl } from "../../services/downloadStorage.js";
 import type { GraphQLContext } from "../../types/context.js";
 import trackDownload from "./trackDownload.js";
 
@@ -49,7 +50,6 @@ type TrackDownloadResolver = ReturnType<typeof trackDownload>;
 
 type StorageFactory = () => Pick<Storage, "bucket">;
 
-const READ_URL_TTL_MS = 5 * 60 * 1000;
 export const DEFAULT_DOWNLOAD_SCAN_CACHE_TTL_MS = 15 * 60 * 1000;
 
 type PrepareDownloadOptions = {
@@ -102,31 +102,6 @@ const selectFile = async (
   }) as FileRecord[];
 
   return files[0] || null;
-};
-
-const createReadUrl = async ({
-  file,
-  storageFactory,
-}: {
-  file: FileRecord;
-  storageFactory: StorageFactory;
-}): Promise<string> => {
-  if (!file.storageBucket || !file.storageObjectName) {
-    return file.url || "";
-  }
-
-  const options: GetSignedUrlConfig = {
-    version: "v4",
-    action: "read",
-    expires: Date.now() + READ_URL_TTL_MS,
-    responseDisposition: "attachment",
-  };
-  const [url] = await storageFactory()
-    .bucket(file.storageBucket)
-    .file(file.storageObjectName)
-    .getSignedUrl(options);
-
-  return url || "";
 };
 
 export const createPrepareDownloadResolver = (
@@ -235,7 +210,10 @@ export const createPrepareDownloadResolver = (
       };
     }
 
-    const url = await createReadUrl({ file: scannedFile, storageFactory });
+    const url = await createDownloadReadUrl({
+      file: scannedFile,
+      storage: storageFactory(),
+    });
     if (!url) {
       return {
         ready: false,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -57,7 +57,8 @@ test/E2E environments the seeded admin test user also acts as root.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `GCS_BUCKET_NAME` | If uploads enabled | Google Cloud Storage bucket for uploaded images/files. |
+| `GCS_BUCKET_NAME` | If media uploads enabled | Google Cloud Storage bucket for publicly rendered image/media uploads. |
+| `GCS_PRIVATE_DOWNLOAD_BUCKET_NAME` | If downloadable-file uploads enabled | Dedicated non-public Google Cloud Storage bucket for downloadable files. Do not grant `allUsers` or `allAuthenticatedUsers` object access; downloads and plugin scans use short-lived signed read URLs. |
 | `GOOGLE_CREDENTIALS_BASE64` | If uploads enabled | Base64-encoded GCP service-account JSON. At startup it is decoded to a file and `GOOGLE_APPLICATION_CREDENTIALS` is pointed at it (convenient for single-value secrets on Heroku). |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Alternative to the above | Filesystem path to a GCP service-account JSON file. Set automatically when `GOOGLE_CREDENTIALS_BASE64` is provided. |
 | `DOWNLOAD_SCAN_CACHE_TTL_MS` | No | How long a clean pre-download security verdict may be reused (default `900000`, or 15 minutes). Set to `0` to scan on every download request. Failed or held verdicts are never reused. |

--- a/docs/private-download-storage.md
+++ b/docs/private-download-storage.md
@@ -1,0 +1,37 @@
+# Private download storage
+
+Downloadable files use a dedicated private Google Cloud Storage bucket. Publicly
+rendered images and media remain in `GCS_BUCKET_NAME`; downloads are uploaded to
+`GCS_PRIVATE_DOWNLOAD_BUCKET_NAME` and are read only through short-lived signed
+URLs after the download security gate succeeds.
+
+## Bucket setup
+
+Create a bucket for downloads and grant the backend service account permission
+to create, read, copy, and delete objects. Do not grant `allUsers` or
+`allAuthenticatedUsers` access. Set `GCS_PRIVATE_DOWNLOAD_BUCKET_NAME` on every
+backend instance before deploying the frontend that requests private download
+uploads.
+
+The scanner receives a five-minute signed read URL. Signed URLs are not written
+to `PluginRun` payloads; stored payloads retain only the canonical, non-public
+object URL.
+
+## Existing downloads
+
+The migration command is a dry run unless `--apply` is supplied:
+
+```sh
+pnpm run migrate:private-downloads
+pnpm run migrate:private-downloads -- --apply
+```
+
+Run the apply command in a maintenance window so uploads and replacements are
+paused. For each `DownloadableFile` with storage metadata, it copies the object
+to the private bucket, removes the source object, and conditionally updates the
+file and upload-audit metadata. It is safe to rerun after interruption because
+an existing destination object is reused and missing source objects are ignored.
+
+URL-only legacy downloads cannot be migrated automatically because the backend
+does not own their storage. They continue to use their existing URL and should
+be reviewed separately.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:circular": "madge --circular --extensions ts --exclude 'ogm_types.ts|src/generated' index.ts customResolvers.ts permissions.ts",
     "tsc": "tsc",
     "logSchema": "node build_scripts/logSchema.js",
+    "migrate:private-downloads": "node --loader ts-node/esm build_scripts/migratePrivateDownloads.ts",
     "provision": "node --loader ts-node/esm build_scripts/provisionServerDefaults.ts",
     "build": "pnpm run codegen && tsc && node build_scripts/copyCypherFiles.js",
     "heroku-postbuild": "pnpm run build",

--- a/services/downloadStorage.test.ts
+++ b/services/downloadStorage.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDownloadReadUrl,
+  DOWNLOAD_READ_URL_TTL_MS,
+} from "./downloadStorage.js";
+
+test("signs stored download objects for short-lived read access", async () => {
+  let signedOptions: unknown;
+  const url = await createDownloadReadUrl({
+    file: {
+      url: "https://storage.googleapis.com/private-bucket/file.zip",
+      storageBucket: "private-bucket",
+      storageObjectName: "uploads/alice/file.zip",
+    },
+    storage: {
+      bucket: () => ({
+        file: () => ({
+          getSignedUrl: async (options: unknown) => {
+            signedOptions = options;
+            return ["https://signed.example.com/file.zip"];
+          },
+        }),
+      }),
+    } as any,
+    now: () => 1_000,
+  });
+
+  assert.deepEqual({ url, signedOptions }, {
+    url: "https://signed.example.com/file.zip",
+    signedOptions: {
+      version: "v4",
+      action: "read",
+      expires: 1_000 + DOWNLOAD_READ_URL_TTL_MS,
+      responseDisposition: "attachment",
+    },
+  });
+});
+
+test("preserves legacy URL-backed downloads", async () => {
+  const url = await createDownloadReadUrl({
+    file: { url: "https://legacy.example.com/file.zip" },
+  });
+
+  assert.equal(url, "https://legacy.example.com/file.zip");
+});

--- a/services/downloadStorage.ts
+++ b/services/downloadStorage.ts
@@ -1,0 +1,38 @@
+import { Storage, type GetSignedUrlConfig } from "@google-cloud/storage";
+
+export const DOWNLOAD_READ_URL_TTL_MS = 5 * 60 * 1000;
+
+export type StoredDownloadFile = {
+  url?: string | null;
+  storageBucket?: string | null;
+  storageObjectName?: string | null;
+};
+
+type StorageClient = Pick<Storage, "bucket">;
+
+export const createDownloadReadUrl = async ({
+  file,
+  storage = new Storage(),
+  now = Date.now,
+}: {
+  file: StoredDownloadFile;
+  storage?: StorageClient;
+  now?: () => number;
+}): Promise<string> => {
+  if (!file.storageBucket || !file.storageObjectName) {
+    return file.url || "";
+  }
+
+  const options: GetSignedUrlConfig = {
+    version: "v4",
+    action: "read",
+    expires: now() + DOWNLOAD_READ_URL_TTL_MS,
+    responseDisposition: "attachment",
+  };
+  const [url] = await storage
+    .bucket(file.storageBucket)
+    .file(file.storageObjectName)
+    .getSignedUrl(options);
+
+  return url || "";
+};

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -42,7 +42,7 @@ const fileNode = {
   },
 };
 
-function makeExecModels(edges: unknown[]) {
+function makeExecModels(edges: unknown[], file = fileNode) {
   const updates: any[] = [];
   const creates: any[] = [];
   const fileUpdates: any[] = [];
@@ -66,7 +66,7 @@ function makeExecModels(edges: unknown[]) {
   };
   const models: any = {
     DownloadableFile: {
-      ...model([fileNode]),
+      ...model([file]),
       update: async (args: any) => {
         fileUpdates.push(args);
         return {};
@@ -91,10 +91,10 @@ const pluginReturning = (result: unknown) =>
 const loaderFor = (cls: unknown) => (async () => cls) as any;
 const statusesOf = (updates: any[]) => updates.map((u) => u.update.status);
 
-const execRun = (models: any, loadPlugin: any) =>
+const execRun = (models: any, loadPlugin: any, storage?: any) =>
   triggerPluginRunsForDownloadableFile(
     { downloadableFileId: "f-1", event: EVENT, models },
-    { loadPlugin }
+    { loadPlugin, storage }
   );
 
 test("runs a matching plugin to SUCCEEDED", async () => {
@@ -107,6 +107,54 @@ test("runs a matching plugin to SUCCEEDED", async () => {
   assert.ok(statuses.includes("RUNNING"));
   assert.ok(statuses.includes("SUCCEEDED"));
   assert.equal(runs.length, 1);
+});
+
+test("gives plugins signed access to private objects without persisting the signature", async () => {
+  const privateFile = {
+    ...fileNode,
+    url: "https://storage.googleapis.com/private-downloads/a.zip",
+    storageBucket: "private-downloads",
+    storageObjectName: "uploads/alice/a.zip",
+  };
+  const { models, updates } = makeExecModels(
+    [installedEdge("security-attachment-scan")],
+    privateFile
+  );
+  let receivedEvent: any;
+  const Plugin = class {
+    async handleEvent(event: unknown) {
+      receivedEvent = event;
+      return { success: true, result: { verdict: "clean" } };
+    }
+  };
+  const storage = {
+    bucket: (bucketName: string) => ({
+      file: (objectName: string) => ({
+        getSignedUrl: async () => [
+          `https://signed.example.com/${bucketName}/${objectName}?signature=secret`,
+        ],
+      }),
+    }),
+  };
+
+  await execRun(models, loaderFor(Plugin), storage);
+
+  const completedPayload = JSON.parse(
+    updates.find((update) => update.update.status === "SUCCEEDED").update.payload
+  );
+  assert.deepEqual({
+    pluginAttachments: receivedEvent.payload.attachmentUrls,
+    storedAttachments: completedPayload.attachments,
+    storedPayloadContainsSignature: completedPayload.attachments.some(
+      (url: string) => url.includes("signature=")
+    ),
+  }, {
+    pluginAttachments: [
+      "https://signed.example.com/private-downloads/uploads/alice/a.zip?signature=secret",
+    ],
+    storedAttachments: [privateFile.url],
+    storedPayloadContainsSignature: false,
+  });
 });
 
 test("marks the run FAILED when the plugin reports failure", async () => {

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -1,4 +1,5 @@
 import { performance } from 'perf_hooks'
+import { Storage } from '@google-cloud/storage'
 import type { TriggerArgs, PluginEdgeData, EventPipeline, PipelineStep, PluginToRun, PendingRun } from './types.js'
 import { DOWNLOAD_EVENTS } from './constants.js'
 import { decryptSecret } from './encryption.js'
@@ -12,6 +13,7 @@ import {
   resolveDownloadScanOutcome,
   type DownloadScanOutcome
 } from './downloadScanOutcome.js'
+import { createDownloadReadUrl } from '../downloadStorage.js'
 import type { PluginRunCreateInput, PluginRunUpdateInput, DownloadableFile as DownloadableFileType, DownloadableFileUpdateInput, ServerConfig as ServerConfigType, Discussion as DiscussionType } from '../../ogm_types.js'
 import { logger } from "../../logger.js";
 
@@ -25,7 +27,13 @@ export const triggerPluginRunsForDownloadableFile = async (
   }: TriggerArgs,
   // Injectable plugin loader so the execution path can be tested without
   // downloading/running a real plugin tarball. Defaults to the real loader.
-  { loadPlugin = loadPluginImplementation }: { loadPlugin?: typeof loadPluginImplementation } = {}
+  {
+    loadPlugin = loadPluginImplementation,
+    storage = new Storage()
+  }: {
+    loadPlugin?: typeof loadPluginImplementation
+    storage?: Pick<Storage, 'bucket'>
+  } = {}
 ) => {
   if (!DOWNLOAD_EVENTS.has(event)) {
     throw new Error(`Unsupported plugin event: ${event}`)
@@ -41,6 +49,8 @@ export const triggerPluginRunsForDownloadableFile = async (
       url
       kind
       size
+      storageBucket
+      storageObjectName
       Discussion {
         id
         title
@@ -67,6 +77,8 @@ export const triggerPluginRunsForDownloadableFile = async (
   // the generated DownloadableFile type doesn't model yet, so extend the
   // generated type with that queried field.
   const fileData = downloadableFile as DownloadableFileType & {
+    storageBucket?: string | null
+    storageObjectName?: string | null
     Discussion?: DiscussionType | null
   }
   const discussionChannel = fileData.Discussion?.DiscussionChannels?.[0] || null
@@ -197,6 +209,16 @@ export const triggerPluginRunsForDownloadableFile = async (
   const stopOnFirstFailure = eventPipeline?.stopOnFirstFailure ?? true
   let previousStatus: 'SUCCEEDED' | 'FAILED' | null = null
   let pipelineStopped = false
+  let attachmentPromise: Promise<string[]> | null = null
+  const getPluginAttachments = (): Promise<string[]> => {
+    if (!attachmentPromise) {
+      attachmentPromise = createDownloadReadUrl({
+        file: fileData,
+        storage
+      }).then(url => url ? [url] : [])
+    }
+    return attachmentPromise
+  }
 
   // Create PENDING records for all plugins first (for UI visibility)
   const pendingRuns: PendingRun[] = []
@@ -344,7 +366,8 @@ export const triggerPluginRunsForDownloadableFile = async (
       const settingsDefaults = parseMaybeJson(pluginVersionData.settingsDefaults)
       const settingsJson = parseMaybeJson(edgeData.properties?.settingsJson)
       const runtimeSettings = mergeSettings(settingsDefaults, settingsJson)
-      const attachments = getAttachmentUrls(downloadableFile)
+      const attachments = await getPluginAttachments()
+      const storedAttachments = getAttachmentUrls(downloadableFile)
 
       const context = {
         scope: 'SERVER' as const,
@@ -414,7 +437,8 @@ export const triggerPluginRunsForDownloadableFile = async (
           durationMs,
           payload: JSON.stringify({
             event,
-            attachments,
+            attachments: storedAttachments,
+            attachmentCount: attachments.length,
             flags,
             logs,
             result

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -33,6 +33,11 @@ const typeDefinitions = gql`
     FAILED
   }
 
+  enum StorageUploadTarget {
+    PUBLIC_MEDIA
+    PRIVATE_DOWNLOAD
+  }
+
   enum ChannelImageType {
     ICON
     BANNER
@@ -1220,7 +1225,12 @@ const typeDefinitions = gql`
       scratchpadEntryId: ID!
     ): Boolean
 
-    createSignedStorageURL(filename: String!, contentType: String!, channelConnections: [String!]): SignedURL
+    createSignedStorageURL(
+      filename: String!
+      contentType: String!
+      channelConnections: [String!]
+      uploadTarget: StorageUploadTarget = PUBLIC_MEDIA
+    ): SignedURL
     createEmailAndUser(emailAddress: String!, username: String!): User
     dropDataForCypressTests: DropDataResponse
     seedDataForCypressTests(


### PR DESCRIPTION
## Summary

- add an explicit private-download upload target backed by `GCS_PRIVATE_DOWNLOAD_BUCKET_NAME`
- sign short-lived read URLs for both scan plugins and approved user downloads
- keep signed scanner credentials out of persisted `PluginRun` payloads
- preserve URL-backed legacy downloads
- add a dry-run-first migration command and deployment runbook for existing storage-backed files

## Deployment order

1. Create a non-public GCS bucket and configure `GCS_PRIVATE_DOWNLOAD_BUCKET_NAME`.
2. Deploy this backend change.
3. Dry-run and apply `pnpm run migrate:private-downloads -- --apply` during a maintenance window.
4. Merge/deploy the companion frontend PR that requests the private upload target.

## Verification

- `pnpm run codegen`
- `pnpm exec tsc --noEmit --pretty false`
- focused ESLint
- 31 focused unit tests covering bucket routing, fail-closed configuration, signed plugin access, credential persistence, legacy URLs, and pre-download behavior