### PR TITLE
Parameterize hot ranking settings

### DIFF
--- a/customResolvers/cypher/getCommentRepliesQuery.cypher
+++ b/customResolvers/cypher/getCommentRepliesQuery.cypher
@@ -51,7 +51,7 @@ WITH parentComment, child, author, serverRoles, channelRoles, GrandchildComments
 
 WITH parentComment, child, author, serverRoles, channelRoles, UpvotedByUsers, SuperUpvotedByUsers, ageInMonths, weightedVotesCount,
      GrandchildCommentsCount, FilteredFeedbackComments, FilteredPastVersions, isFavoritedByUser,
-     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
+     log10(weightedVotesCount + 1) / ((ageInMonths + $hotAgeOffsetMonths) ^ $hotGravity) AS hotRank
 
 // Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
 // @cypher field + server-admin membership), so the author's roles are no longer

--- a/customResolvers/cypher/getCommentsQuery.cypher
+++ b/customResolvers/cypher/getCommentsQuery.cypher
@@ -46,7 +46,7 @@ WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByU
     FeedbackComments
 
 WITH c, author, serverRole, channelRole, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, FeedbackComments, FilteredPastVersions, ageInMonths, weightedVotesCount, isFavoritedByUser,
-    10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
+    log10(weightedVotesCount + 1) / ((ageInMonths + $hotAgeOffsetMonths) ^ $hotGravity) AS hotRank
 
 // Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
 // @cypher field + server-admin membership), so the author's roles are no longer

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -159,7 +159,7 @@ WITH dc, d, author, serverRole, channelRole, COLLECT(c) AS comments, tagsText, l
      duration.between(dc.createdAt, datetime()).days / 30.0 AS ageInMonths
 
 WITH dc, d, author, serverRole, channelRole, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters, weightedVotesCount, comments, totalCount,
-     10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
+     log10(weightedVotesCount + 1) / ((ageInMonths + $hotAgeOffsetMonths) ^ $hotGravity) AS hotRank
 
 // Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
 // @cypher field + server-admin membership), so the author's roles are no longer

--- a/customResolvers/cypher/getEventCommentsQuery.cypher
+++ b/customResolvers/cypher/getEventCommentsQuery.cypher
@@ -36,7 +36,7 @@ WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, weighted
 
 WITH c, author, parent, UpvotedByUsers, SuperUpvotedByUsers, parentIds, ChildComments, weightedVotesCount, serverRole, channelRole, ageInMonths, PastVersions, isFavoritedByUser,
     [version IN PastVersions WHERE version.id IS NOT NULL] AS FilteredPastVersions,
-    10000 * log10(weightedVotesCount + 1) / ((ageInMonths + 2) ^ 1.8) AS hotRank
+    log10(weightedVotesCount + 1) / ((ageInMonths + $hotAgeOffsetMonths) ^ $hotGravity) AS hotRank
 
 // Author ADMIN/MOD badges are now membership-derived (the authorIsChannelModerator
 // @cypher field + server-admin membership), so the author's roles are no longer

--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -129,7 +129,7 @@ WITH d, totalCount,
     serverRole,
     discussionChannels,
     CASE WHEN score < 0 THEN 0 ELSE score END AS score, 
-    CASE WHEN $sortOption = "hot" THEN 10000 * log10(score + 1) / ((ageInMonths + 2) ^ 1.8) ELSE NULL END AS rank
+    CASE WHEN $sortOption = "hot" THEN log10(score + 1) / ((ageInMonths + $hotAgeOffsetMonths) ^ $hotGravity) ELSE NULL END AS rank
 
 WITH d, totalCount, tagsText, author, discussionChannels, score, rank,
     COLLECT(DISTINCT serverRole) AS serverRoles

--- a/customResolvers/cypher/rankingParameters.test.ts
+++ b/customResolvers/cypher/rankingParameters.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getCommentRepliesQuery,
+  getCommentsQuery,
+  getDiscussionChannelsQuery,
+  getEventCommentsQuery,
+  getSiteWideDiscussionsQuery,
+} from "./cypherQueries.js";
+
+const rankingQueries = {
+  sitewideDiscussions: getSiteWideDiscussionsQuery,
+  channelDiscussions: getDiscussionChannelsQuery,
+  discussionComments: getCommentsQuery,
+  commentReplies: getCommentRepliesQuery,
+  eventComments: getEventCommentsQuery,
+};
+
+for (const [name, query] of Object.entries(rankingQueries)) {
+  test(`${name} hot ranking uses server-controlled query parameters`, () => {
+    assert.match(
+      query,
+      /log10\([^)]+ \+ 1\) \/ \(\(ageInMonths \+ \$hotAgeOffsetMonths\) \^ \$hotGravity\)/
+    );
+  });
+}

--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -120,6 +120,7 @@ import {
   unlockWikiPage,
 } from "./mutations/wikiPageLocks.js";
 import { setFeaturedWikiPages } from "./mutations/setFeaturedWikiPages.js";
+import setRankingSettings from "./mutations/setRankingSettings.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -654,6 +655,9 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     setFeaturedWikiPages: setFeaturedWikiPages({
       ServerConfig,
       WikiPage,
+    }),
+    setRankingSettings: setRankingSettings({
+      driver,
     }),
     updateDownloadLabels: updateDownloadLabels({
       Discussion,

--- a/customResolvers/mutations/setRankingSettings.test.ts
+++ b/customResolvers/mutations/setRankingSettings.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import { setRankingSettings } from "./setRankingSettings.js";
+
+const buildDriver = ({
+  settingsJson,
+}: {
+  settingsJson?: string | null;
+} = {}) => {
+  const updateParams: Array<Record<string, unknown>> = [];
+  let closed = false;
+
+  const transaction = {
+    run: async (query: string, params: Record<string, unknown>) => {
+      if (query.includes("RETURN serverConfig.rankingSettingsJson")) {
+        return {
+          records: [
+            {
+              get: (key: string) => {
+                if (key === "settingsJson") return settingsJson ?? null;
+                return null;
+              },
+            },
+          ],
+        };
+      }
+
+      updateParams.push(params);
+      return { records: [] };
+    },
+  };
+
+  return {
+    updateParams,
+    wasClosed: () => closed,
+    driver: {
+      session: () => ({
+        executeWrite: async (
+          callback: (tx: typeof transaction) => Promise<unknown>
+        ) => callback(transaction),
+        close: async () => {
+          closed = true;
+        },
+      }),
+    },
+  };
+};
+
+const context = {
+  user: {
+    username: "server-admin",
+  },
+} as GraphQLContext;
+
+test("setRankingSettings merges, validates, serializes, and audits a patch", async () => {
+  const models = buildDriver();
+  const resolver = setRankingSettings({
+    driver: models.driver as never,
+    now: () => new Date("2026-07-30T12:00:00.000Z"),
+  });
+
+  const result = await resolver(
+    null,
+    {
+      serverName: "test-server",
+      input: {
+        discussionHot: {
+          gravity: 2.4,
+        },
+      },
+    },
+    context
+  );
+
+  assert.deepEqual(result, {
+    version: 1,
+    discussionHot: {
+      ageOffsetMonths: 2,
+      gravity: 2.4,
+    },
+    commentHot: {
+      ageOffsetMonths: 2,
+      gravity: 1.8,
+    },
+    updatedAt: "2026-07-30T12:00:00.000Z",
+    updatedBy: "server-admin",
+  });
+  assert.deepEqual(models.updateParams[0], {
+    serverName: "test-server",
+    settingsJson: JSON.stringify({
+      version: 1,
+      discussionHot: {
+        ageOffsetMonths: 2,
+        gravity: 2.4,
+      },
+      commentHot: {
+        ageOffsetMonths: 2,
+        gravity: 1.8,
+      },
+    }),
+    updatedAt: "2026-07-30T12:00:00.000Z",
+    updatedBy: "server-admin",
+  });
+  assert.equal(models.wasClosed(), true);
+});
+
+test("setRankingSettings rejects empty and invalid patches before writing", async () => {
+  const models = buildDriver();
+  const resolver = setRankingSettings({
+    driver: models.driver as never,
+  });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        {
+          serverName: "test-server",
+          input: {},
+        },
+        context
+      ),
+    /At least one ranking setting/
+  );
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        {
+          serverName: "test-server",
+          input: {
+            commentHot: {
+              gravity: 0,
+            },
+          },
+        },
+        context
+      ),
+    /gravity must be between/
+  );
+
+  assert.equal(models.updateParams.length, 0);
+});

--- a/customResolvers/mutations/setRankingSettings.ts
+++ b/customResolvers/mutations/setRankingSettings.ts
@@ -1,0 +1,96 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import { logger } from "../../logger.js";
+import {
+  applyRankingSettingsPatch,
+  serializeRankingSettings,
+  type RankingSettingsPatch,
+} from "../../services/rankingSettings.js";
+import { findRankingSettings } from "../../services/rankingSettingsStore.js";
+
+type Input = {
+  driver: Driver;
+  now?: () => Date;
+};
+
+type Args = {
+  serverName: string;
+  input: RankingSettingsPatch;
+};
+
+const hasValues = (patch: RankingSettingsPatch) =>
+  Object.values(patch.discussionHot ?? {}).length > 0 ||
+  Object.values(patch.commentHot ?? {}).length > 0;
+
+export const setRankingSettings = ({
+  driver,
+  now = () => new Date(),
+}: Input) => {
+  return async (
+    _parent: unknown,
+    { serverName, input }: Args,
+    context: GraphQLContext
+  ) => {
+    if (!hasValues(input)) {
+      throw new GraphQLError("At least one ranking setting must be provided.");
+    }
+
+    const session = driver.session();
+
+    try {
+      return await session.executeWrite(async (transaction) => {
+        const stored = await findRankingSettings({
+          executor: transaction,
+          serverName,
+        });
+        if (!stored) {
+          throw new GraphQLError("Server configuration not found.");
+        }
+
+        let updatedSettings;
+        try {
+          updatedSettings = applyRankingSettingsPatch(stored.settings, input);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new GraphQLError(message);
+        }
+
+        const updatedAt = now().toISOString();
+        const updatedBy = context.user?.username ?? null;
+
+        await transaction.run(
+          `
+            MATCH (serverConfig:ServerConfig {serverName: $serverName})
+            SET serverConfig.rankingSettingsJson = $settingsJson,
+                serverConfig.rankingSettingsUpdatedAt = datetime($updatedAt),
+                serverConfig.rankingSettingsUpdatedBy = $updatedBy
+          `,
+          {
+            serverName,
+            settingsJson: serializeRankingSettings(updatedSettings),
+            updatedAt,
+            updatedBy,
+          }
+        );
+
+        logger.info("Ranking settings updated", {
+          serverName,
+          updatedBy,
+          previous: stored.settings,
+          next: updatedSettings,
+        });
+
+        return {
+          ...updatedSettings,
+          updatedAt,
+          updatedBy,
+        };
+      });
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default setRankingSettings;

--- a/customResolvers/queries/commentRankingParams.test.ts
+++ b/customResolvers/queries/commentRankingParams.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import getCommentReplies from "./getCommentReplies.js";
+import getCommentSection from "./getCommentSection.js";
+import getEventComments from "./getEventComments.js";
+
+const settingsJson = JSON.stringify({
+  version: 1,
+  discussionHot: {
+    ageOffsetMonths: 2,
+    gravity: 1.8,
+  },
+  commentHot: {
+    ageOffsetMonths: 0.5,
+    gravity: 2.25,
+  },
+});
+
+const createDriver = () => {
+  const runCalls: Array<{
+    query: string;
+    params: Record<string, unknown>;
+  }> = [];
+
+  return {
+    runCalls,
+    driver: {
+      session: () => ({
+        run: async (query: string, params: Record<string, unknown>) => {
+          runCalls.push({ query, params });
+          if (query.includes("RETURN serverConfig.rankingSettingsJson")) {
+            return {
+              records: [
+                {
+                  get: (key: string) =>
+                    key === "settingsJson" ? settingsJson : null,
+                },
+              ],
+            };
+          }
+          return { records: [] };
+        },
+        close: async () => {},
+      }),
+    },
+  };
+};
+
+const context = {
+  user: {
+    username: "test-user",
+  },
+} as GraphQLContext;
+
+const assertCommentRankingParams = (
+  runCalls: Array<{ params: Record<string, unknown> }>
+) => {
+  const rankingCall = runCalls.find(
+    (call) => call.params.sortOption === "hot"
+  );
+  assert.ok(rankingCall);
+  assert.equal(rankingCall.params.hotAgeOffsetMonths, 0.5);
+  assert.equal(rankingCall.params.hotGravity, 2.25);
+};
+
+test("getCommentSection passes stored comment ranking settings to Cypher", async () => {
+  const mock = createDriver();
+  const resolver = getCommentSection({
+    driver: mock.driver as never,
+    serverName: "test-server",
+    DiscussionChannel: {
+      find: async () => [
+        {
+          id: "discussion-channel-1",
+          SubscribedToNotifications: [],
+        },
+      ],
+    } as never,
+  });
+
+  await resolver(
+    null,
+    {
+      channelUniqueName: "general",
+      discussionId: "discussion-1",
+      modName: "",
+      offset: "0",
+      limit: "20",
+      sort: "hot",
+    },
+    context,
+    null as never
+  );
+
+  assertCommentRankingParams(mock.runCalls);
+});
+
+test("getEventComments passes stored comment ranking settings to Cypher", async () => {
+  const mock = createDriver();
+  const resolver = getEventComments({
+    driver: mock.driver as never,
+    serverName: "test-server",
+    Event: {
+      find: async () => [{ id: "event-1" }],
+    } as never,
+  });
+
+  await resolver(
+    null,
+    {
+      eventId: "event-1",
+      offset: "0",
+      limit: "20",
+      sort: "hot",
+    },
+    context,
+    null as never
+  );
+
+  assertCommentRankingParams(mock.runCalls);
+});
+
+test("getCommentReplies passes stored comment ranking settings to Cypher", async () => {
+  const mock = createDriver();
+  const resolver = getCommentReplies({
+    driver: mock.driver as never,
+    serverName: "test-server",
+    Comment: {
+      aggregate: async () => ({ count: 0 }),
+    } as never,
+  });
+
+  await resolver(
+    null,
+    {
+      commentId: "comment-1",
+      modName: "",
+      offset: "0",
+      limit: "20",
+      sort: "hot",
+    },
+    context,
+    null as never
+  );
+
+  assertCommentRankingParams(mock.runCalls);
+});

--- a/customResolvers/queries/discussionRankingParams.test.ts
+++ b/customResolvers/queries/discussionRankingParams.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import getDiscussionsInChannel from "./getDiscussionsInChannel.js";
+import getSiteWideDiscussionList from "./getSiteWideDiscussionList.js";
+
+const settingsJson = JSON.stringify({
+  version: 1,
+  discussionHot: {
+    ageOffsetMonths: 3.5,
+    gravity: 2.75,
+  },
+  commentHot: {
+    ageOffsetMonths: 2,
+    gravity: 1.8,
+  },
+});
+
+const createDriver = () => {
+  const runCalls: Array<{
+    query: string;
+    params: Record<string, unknown>;
+  }> = [];
+
+  return {
+    runCalls,
+    driver: {
+      session: () => ({
+        run: async (query: string, params: Record<string, unknown>) => {
+          runCalls.push({ query, params });
+          if (query.includes("RETURN serverConfig.rankingSettingsJson")) {
+            return {
+              records: [
+                {
+                  get: (key: string) =>
+                    key === "settingsJson" ? settingsJson : null,
+                },
+              ],
+            };
+          }
+          return { records: [] };
+        },
+        close: async () => {},
+      }),
+    },
+  };
+};
+
+const assertDiscussionRankingParams = (
+  runCalls: Array<{ params: Record<string, unknown> }>
+) => {
+  const rankingCall = runCalls.find(
+    (call) => call.params.sortOption === "hot"
+  );
+  assert.ok(rankingCall);
+  assert.equal(rankingCall.params.hotAgeOffsetMonths, 3.5);
+  assert.equal(rankingCall.params.hotGravity, 2.75);
+};
+
+test("getSiteWideDiscussionList passes stored discussion ranking settings to Cypher", async () => {
+  const mock = createDriver();
+  const resolver = getSiteWideDiscussionList({
+    driver: mock.driver as never,
+    serverName: "test-server",
+    Discussion: {} as never,
+  });
+
+  await resolver(
+    null,
+    {
+      searchInput: "",
+      selectedChannels: [],
+      selectedTags: [],
+      showArchived: false,
+      hasDownload: false,
+      options: {
+        offset: "0",
+        limit: "20",
+        resultsOrder: "desc",
+        sort: "hot",
+        timeFrame: "week",
+      },
+    },
+    {} as GraphQLContext,
+    null as never
+  );
+
+  assertDiscussionRankingParams(mock.runCalls);
+});
+
+test("getDiscussionsInChannel passes stored discussion ranking settings to Cypher", async () => {
+  const mock = createDriver();
+  const resolver = getDiscussionsInChannel({
+    driver: mock.driver as never,
+    serverName: "test-server",
+    DiscussionChannel: {} as never,
+  });
+
+  await resolver(
+    null,
+    {
+      channelUniqueName: "general",
+      selectedTags: [],
+      searchInput: "",
+      showArchived: false,
+      showUnanswered: false,
+      hasDownload: null,
+      labelFilters: [],
+      options: {
+        offset: "0",
+        limit: "20",
+        sort: "hot",
+        timeFrame: "week",
+      },
+    },
+    {
+      user: {
+        username: "test-user",
+      },
+    } as GraphQLContext,
+    null as never
+  );
+
+  assertDiscussionRankingParams(mock.runCalls);
+});

--- a/customResolvers/queries/discussionRankingParams.test.ts
+++ b/customResolvers/queries/discussionRankingParams.test.ts
@@ -78,7 +78,8 @@ test("getSiteWideDiscussionList passes stored discussion ranking settings to Cyp
         limit: "20",
         resultsOrder: "desc",
         sort: "hot",
-        timeFrame: "week",
+        timeFrame:
+          "week" as Parameters<typeof resolver>[1]["options"]["timeFrame"],
       },
     },
     {} as GraphQLContext,
@@ -110,7 +111,8 @@ test("getDiscussionsInChannel passes stored discussion ranking settings to Cyphe
         offset: "0",
         limit: "20",
         sort: "hot",
-        timeFrame: "week",
+        timeFrame:
+          "week" as Parameters<typeof resolver>[1]["options"]["timeFrame"],
       },
     },
     {

--- a/customResolvers/queries/getCommentReplies.ts
+++ b/customResolvers/queries/getCommentReplies.ts
@@ -6,10 +6,12 @@ import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.j
 import type { GraphQLContext } from "../../types/context.js";
 import type { CommentModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import { getHotRankingQueryParams } from "../../services/rankingSettingsStore.js";
 
 type Input = {
   Comment: CommentModel;
   driver: Driver;
+  serverName?: string;
 };
 
 type Args = {
@@ -21,7 +23,7 @@ type Args = {
 };
 
 const getResolver = (input: Input) => {
-  const { driver, Comment } = input;
+  const { driver, Comment, serverName } = input;
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { commentId, modName, offset, limit, sort } = args;
     context.user = await setUserDataOnContext({
@@ -34,14 +36,23 @@ const getResolver = (input: Input) => {
     try {
       let commentsResult = [];
       let aggregateCount = 0;
+      const effectiveSort =
+        sort === "top" ? "top" : sort === "hot" ? "hot" : "new";
+      const rankingParams = await getHotRankingQueryParams({
+        executor: session,
+        profile: "comment",
+        sortOption: effectiveSort,
+        serverName,
+      });
 
       const commentRepliesResult = await session.run(getCommentRepliesQuery, {
         commentId,
         modName,
         offset: parseInt(offset, 10),
         limit: parseInt(limit, 10),
-        sortOption: sort === "top" ? "top" : sort === "hot" ? "hot" : "new",
+        sortOption: effectiveSort,
         loggedInUsername,
+        ...rankingParams,
       });
 
       if (commentRepliesResult.records.length === 0) {

--- a/customResolvers/queries/getCommentSection.ts
+++ b/customResolvers/queries/getCommentSection.ts
@@ -9,6 +9,7 @@ import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.j
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import { getHotRankingQueryParams } from "../../services/rankingSettingsStore.js";
 
 const discussionChannelSelectionSet = `
 {
@@ -76,6 +77,7 @@ const discussionChannelSelectionSet = `
 type Input = {
   driver: Driver
   DiscussionChannel: DiscussionChannelModel
+  serverName?: string
 }
 
 type Args = {
@@ -88,7 +90,7 @@ type Args = {
 }
 
 const getResolver = (input: Input) => {
-  const { driver, DiscussionChannel } = input
+  const { driver, DiscussionChannel, serverName } = input
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { channelUniqueName, discussionId, modName, offset, limit, sort } =
       args
@@ -120,6 +122,13 @@ const getResolver = (input: Input) => {
 
       const discussionChannel = result[0]
       const discussionChannelId = discussionChannel.id
+      const effectiveSort = sort === 'top' ? 'top' : sort === 'new' ? 'new' : 'hot'
+      const rankingParams = await getHotRankingQueryParams({
+        executor: session,
+        profile: "comment",
+        sortOption: effectiveSort,
+        serverName,
+      })
 
       // Filter SubscribedToNotifications to only show current user's subscription status
       if (loggedInUsername && discussionChannel.SubscribedToNotifications) {
@@ -157,7 +166,8 @@ const getResolver = (input: Input) => {
           offset: parseInt(offset, 10),
           limit: parseInt(limit, 10),
           sortOption: 'top',
-          loggedInUsername
+          loggedInUsername,
+          ...rankingParams,
         })
 
         commentsResult = queryResult.records.map((record: Neo4jRecord) => {
@@ -172,7 +182,8 @@ const getResolver = (input: Input) => {
           offset: parseInt(offset, 10),
           limit: parseInt(limit, 10),
           sortOption: 'hot',
-          loggedInUsername
+          loggedInUsername,
+          ...rankingParams,
         })
 
         commentsResult = queryResult.records.map((record: Neo4jRecord) => {

--- a/customResolvers/queries/getDiscussionsInChannel.test.ts
+++ b/customResolvers/queries/getDiscussionsInChannel.test.ts
@@ -316,6 +316,8 @@ test("getDiscussionsInChannel sorts by hot with sortOption=hot as default", asyn
   );
 
   assert.equal(driver.runCalls[0].params.sortOption, "hot");
+  assert.equal(driver.runCalls[0].params.hotAgeOffsetMonths, 2);
+  assert.equal(driver.runCalls[0].params.hotGravity, 1.8);
 });
 
 test("getDiscussionsInChannel defaults to hot sort for unknown sort option", async () => {

--- a/customResolvers/queries/getDiscussionsInChannel.ts
+++ b/customResolvers/queries/getDiscussionsInChannel.ts
@@ -6,6 +6,7 @@ import { timeFrameOptions } from "./utils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionChannelModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import { getHotRankingQueryParams } from "../../services/rankingSettingsStore.js";
 
 enum timeFrameOptionKeys {
   year = "year",
@@ -17,6 +18,7 @@ enum timeFrameOptionKeys {
 type Input = {
   DiscussionChannel: DiscussionChannelModel;
   driver: Driver;
+  serverName?: string;
 };
 
 type LabelFilter = {
@@ -41,7 +43,7 @@ type Args = {
 };
 
 const getResolver = (input: Input) => {
-  const { driver } = input;
+  const { driver, serverName } = input;
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { channelUniqueName, options, selectedTags, searchInput, showArchived, showUnanswered, hasDownload, labelFilters } = args;
     const { offset, limit, sort, timeFrame } = options || {};
@@ -60,6 +62,14 @@ const getResolver = (input: Input) => {
 
     try {
       let aggregateCount = 0;
+      const effectiveSort =
+        sort === "new" || sort === "top" ? sort : "hot";
+      const rankingParams = await getHotRankingQueryParams({
+        executor: session,
+        profile: "discussion",
+        sortOption: effectiveSort,
+        serverName,
+      });
       const queryParams = {
         searchInput: searchValue,
         showArchived,
@@ -74,7 +84,8 @@ const getResolver = (input: Input) => {
         limit: parseInt(limit, 10),
         startOfTimeFrame: null,
         sortOption: "new",
-        loggedInUsername
+        loggedInUsername,
+        ...rankingParams,
       };
 
       switch (sort) {

--- a/customResolvers/queries/getEventComments.ts
+++ b/customResolvers/queries/getEventComments.ts
@@ -8,6 +8,7 @@ import { populateCommentSubscriptionStatus } from "./commentSubscriptionStatus.j
 import type { GraphQLContext } from "../../types/context.js";
 import type { EventModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import { getHotRankingQueryParams } from "../../services/rankingSettingsStore.js";
 
 const eventSelectionSet = `
   {
@@ -36,6 +37,7 @@ const eventSelectionSet = `
 type Input = {
   Event: EventModel;
   driver: Driver;
+  serverName?: string;
 };
 
 type Args = {
@@ -46,7 +48,7 @@ type Args = {
 };
 
 const getResolver = (input: Input) => {
-  const { driver, Event } = input;
+  const { driver, Event, serverName } = input;
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { eventId, offset, limit, sort } = args;
     context.user = await setUserDataOnContext({
@@ -71,13 +73,22 @@ const getResolver = (input: Input) => {
       }
 
       const event = result[0];
+      const effectiveSort =
+        sort === "top" ? "top" : sort === "hot" ? "hot" : "new";
+      const rankingParams = await getHotRankingQueryParams({
+        executor: session,
+        profile: "comment",
+        sortOption: effectiveSort,
+        serverName,
+      });
 
       const commentsResult = await session.run(getEventCommentsQuery, {
         eventId,
         offset: parseInt(offset, 10),
         limit: parseInt(limit, 10),
-        sortOption: sort === "top" ? "top" : sort === "hot" ? "hot" : "new",
+        sortOption: effectiveSort,
         loggedInUsername,
+        ...rankingParams,
       });
 
       let comments = commentsResult.records.map((record: Neo4jRecord) => {

--- a/customResolvers/queries/getRankingSettings.test.ts
+++ b/customResolvers/queries/getRankingSettings.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getRankingSettings } from "./getRankingSettings.js";
+
+test("getRankingSettings returns defaults and audit metadata", async () => {
+  let closed = false;
+  const driver = {
+    session: () => ({
+      run: async () => ({
+        records: [
+          {
+            get: (key: string) => {
+              if (key === "settingsJson") return null;
+              if (key === "updatedAt") return "2026-07-30T12:00:00.000Z";
+              if (key === "updatedBy") return "server-admin";
+              return null;
+            },
+          },
+        ],
+      }),
+      close: async () => {
+        closed = true;
+      },
+    }),
+  };
+
+  const resolver = getRankingSettings({ driver: driver as never });
+  const result = await resolver(null, { serverName: "test-server" });
+
+  assert.deepEqual(result, {
+    version: 1,
+    discussionHot: {
+      ageOffsetMonths: 2,
+      gravity: 1.8,
+    },
+    commentHot: {
+      ageOffsetMonths: 2,
+      gravity: 1.8,
+    },
+    updatedAt: "2026-07-30T12:00:00.000Z",
+    updatedBy: "server-admin",
+  });
+  assert.equal(closed, true);
+});

--- a/customResolvers/queries/getRankingSettings.ts
+++ b/customResolvers/queries/getRankingSettings.ts
@@ -1,0 +1,34 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { findRankingSettings } from "../../services/rankingSettingsStore.js";
+
+type Input = {
+  driver: Driver;
+};
+
+type Args = {
+  serverName: string;
+};
+
+export const getRankingSettings = ({ driver }: Input) => {
+  return async (_parent: unknown, { serverName }: Args) => {
+    const session = driver.session();
+
+    try {
+      const stored = await findRankingSettings({ executor: session, serverName });
+      if (!stored) {
+        throw new GraphQLError("Server configuration not found.");
+      }
+
+      return {
+        ...stored.settings,
+        updatedAt: stored.updatedAt,
+        updatedBy: stored.updatedBy,
+      };
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getRankingSettings;

--- a/customResolvers/queries/getSiteWideDiscussionList.test.ts
+++ b/customResolvers/queries/getSiteWideDiscussionList.test.ts
@@ -283,6 +283,8 @@ test("getSiteWideDiscussionList sorts by hot with sortOption=hot as default", as
   );
 
   assert.equal(driver.runCalls[0].params.sortOption, "hot");
+  assert.equal(driver.runCalls[0].params.hotAgeOffsetMonths, 2);
+  assert.equal(driver.runCalls[0].params.hotGravity, 1.8);
 });
 
 test("getSiteWideDiscussionList defaults to hot sort for unknown sort option", async () => {

--- a/customResolvers/queries/getSiteWideDiscussionList.ts
+++ b/customResolvers/queries/getSiteWideDiscussionList.ts
@@ -5,10 +5,12 @@ import { timeFrameOptions } from "./utils.js";
 import type { GraphQLContext } from "../../types/context.js";
 import type { DiscussionModel } from "../../ogm_types.js";
 import { logger } from "../../logger.js";
+import { getHotRankingQueryParams } from "../../services/rankingSettingsStore.js";
 
 type Input = {
   Discussion: DiscussionModel;
   driver: Driver;
+  serverName?: string;
 };
 
 enum timeFrameOptionKeys {
@@ -35,7 +37,7 @@ type Args = {
 };
 
 const getResolver = (input: Input) => {
-  const { driver, Discussion } = input;
+  const { driver, Discussion, serverName } = input;
 
   return async (parent: unknown, args: Args, context: GraphQLContext, info: GraphQLResolveInfo) => {
     const { searchInput, selectedChannels, selectedTags, showArchived, hasDownload, loggedInUsername, options } = args;
@@ -47,6 +49,15 @@ const getResolver = (input: Input) => {
     let totalCount = 0;
 
     try {
+      const effectiveSort =
+        sort === "new" || sort === "top" ? sort : "hot";
+      const rankingParams = await getHotRankingQueryParams({
+        executor: session,
+        profile: "discussion",
+        sortOption: effectiveSort,
+        serverName,
+      });
+
       switch (sort) {
         case "new":
           let newDiscussionResult = await session.run(
@@ -65,6 +76,7 @@ const getResolver = (input: Input) => {
               startOfTimeFrame: null,
               sortOption: "new",
               loggedInUsername: loggedInUsername || null,
+              ...rankingParams,
             }
           );
 
@@ -108,6 +120,7 @@ const getResolver = (input: Input) => {
               startOfTimeFrame: selectedTimeFrame,
               sortOption: "top",
               loggedInUsername: loggedInUsername || null,
+              ...rankingParams,
             }
           );
 
@@ -144,6 +157,7 @@ const getResolver = (input: Input) => {
               startOfTimeFrame: null,
               sortOption: "hot",
               loggedInUsername: loggedInUsername || null,
+              ...rankingParams,
             }
           );
 

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -26,6 +26,7 @@ import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
 import getImageAlbumUsage from "./queries/getImageAlbumUsage.js";
 import getPluginConfigStatus from './queries/getPluginConfigStatus.js'
+import getRankingSettings from "./queries/getRankingSettings.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -49,6 +50,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
   return {
     getSiteWideDiscussionList: getSiteWideDiscussionList({
       Discussion,
+      driver,
+    }),
+    getRankingSettings: getRankingSettings({
       driver,
     }),
     getSiteWideIssueList: getSiteWideIssueList({

--- a/permissions.ts
+++ b/permissions.ts
@@ -80,6 +80,7 @@ const permissionList = shield({
       getUploadedDownloadableFiles: and(isAuthenticated, allow),
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
       getPluginConfigStatus: and(isAuthenticated, canManagePlugins),
+      getRankingSettings: and(isAuthenticated, canManageServerSettings),
     },
     User: {
       // Public fields - anyone can access
@@ -317,6 +318,7 @@ const permissionList = shield({
       lockWikiPage: and(isAuthenticated, allow),
       unlockWikiPage: and(isAuthenticated, allow),
       setFeaturedWikiPages: and(isAuthenticated, canManageServerSettings),
+      setRankingSettings: and(isAuthenticated, canManageServerSettings),
       suspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       suspendUser: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       unsuspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),

--- a/services/rankingSettings.test.ts
+++ b/services/rankingSettings.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyRankingSettingsPatch,
+  DEFAULT_RANKING_SETTINGS,
+  getCommentHotRankingParams,
+  getDiscussionHotRankingParams,
+  readRankingSettings,
+  serializeRankingSettings,
+  validateRankingSettings,
+} from "./rankingSettings.js";
+
+test("readRankingSettings uses behavior-preserving defaults when no settings are stored", () => {
+  assert.deepEqual(readRankingSettings(null), DEFAULT_RANKING_SETTINGS);
+  assert.deepEqual(readRankingSettings(undefined), DEFAULT_RANKING_SETTINGS);
+});
+
+test("readRankingSettings accepts stored JSON strings", () => {
+  const stored = JSON.stringify({
+    version: 1,
+    discussionHot: {
+      ageOffsetMonths: 3,
+      gravity: 2.1,
+    },
+    commentHot: {
+      ageOffsetMonths: 1,
+      gravity: 1.4,
+    },
+  });
+
+  assert.deepEqual(readRankingSettings(stored), JSON.parse(stored));
+});
+
+test("readRankingSettings safely falls back when stored settings are malformed", () => {
+  assert.deepEqual(readRankingSettings("{not-json"), DEFAULT_RANKING_SETTINGS);
+  assert.deepEqual(
+    readRankingSettings({
+      version: 1,
+      discussionHot: { ageOffsetMonths: 0, gravity: 1.8 },
+      commentHot: { ageOffsetMonths: 2, gravity: 1.8 },
+    }),
+    DEFAULT_RANKING_SETTINGS
+  );
+});
+
+test("validateRankingSettings rejects unsupported versions and unsafe values", () => {
+  assert.throws(
+    () =>
+      validateRankingSettings({
+        ...DEFAULT_RANKING_SETTINGS,
+        version: 2,
+      }),
+    /version must be 1/
+  );
+  assert.throws(
+    () =>
+      validateRankingSettings({
+        ...DEFAULT_RANKING_SETTINGS,
+        discussionHot: {
+          ...DEFAULT_RANKING_SETTINGS.discussionHot,
+          gravity: Number.POSITIVE_INFINITY,
+        },
+      }),
+    /gravity must be a finite number/
+  );
+  assert.throws(
+    () =>
+      validateRankingSettings({
+        ...DEFAULT_RANKING_SETTINGS,
+        commentHot: {
+          ...DEFAULT_RANKING_SETTINGS.commentHot,
+          ageOffsetMonths: 0,
+        },
+      }),
+    /ageOffsetMonths must be between/
+  );
+});
+
+test("applyRankingSettingsPatch merges a partial update over current settings", () => {
+  const updated = applyRankingSettingsPatch(DEFAULT_RANKING_SETTINGS, {
+    discussionHot: {
+      gravity: 2.5,
+    },
+  });
+
+  assert.deepEqual(updated, {
+    version: 1,
+    discussionHot: {
+      ageOffsetMonths: 2,
+      gravity: 2.5,
+    },
+    commentHot: {
+      ageOffsetMonths: 2,
+      gravity: 1.8,
+    },
+  });
+});
+
+test("serialized settings round-trip and produce scoped query parameters", () => {
+  const settings = applyRankingSettingsPatch(DEFAULT_RANKING_SETTINGS, {
+    discussionHot: { ageOffsetMonths: 4, gravity: 2 },
+    commentHot: { ageOffsetMonths: 0.5, gravity: 1.2 },
+  });
+
+  assert.deepEqual(readRankingSettings(serializeRankingSettings(settings)), settings);
+  assert.deepEqual(getDiscussionHotRankingParams(settings), {
+    hotAgeOffsetMonths: 4,
+    hotGravity: 2,
+  });
+  assert.deepEqual(getCommentHotRankingParams(settings), {
+    hotAgeOffsetMonths: 0.5,
+    hotGravity: 1.2,
+  });
+});

--- a/services/rankingSettings.ts
+++ b/services/rankingSettings.ts
@@ -1,0 +1,172 @@
+export const RANKING_SETTINGS_VERSION = 1;
+
+export type HotRankingSettings = {
+  ageOffsetMonths: number;
+  gravity: number;
+};
+
+export type RankingSettings = {
+  version: typeof RANKING_SETTINGS_VERSION;
+  discussionHot: HotRankingSettings;
+  commentHot: HotRankingSettings;
+};
+
+export type HotRankingSettingsPatch = Partial<HotRankingSettings>;
+
+export type RankingSettingsPatch = {
+  discussionHot?: HotRankingSettingsPatch;
+  commentHot?: HotRankingSettingsPatch;
+};
+
+export const DEFAULT_RANKING_SETTINGS: RankingSettings = {
+  version: RANKING_SETTINGS_VERSION,
+  discussionHot: {
+    ageOffsetMonths: 2,
+    gravity: 1.8,
+  },
+  commentHot: {
+    ageOffsetMonths: 2,
+    gravity: 1.8,
+  },
+};
+
+const MIN_AGE_OFFSET_MONTHS = 0.01;
+const MAX_AGE_OFFSET_MONTHS = 120;
+const MIN_GRAVITY = 0.1;
+const MAX_GRAVITY = 10;
+
+const cloneDefaults = (): RankingSettings => ({
+  version: RANKING_SETTINGS_VERSION,
+  discussionHot: { ...DEFAULT_RANKING_SETTINGS.discussionHot },
+  commentHot: { ...DEFAULT_RANKING_SETTINGS.commentHot },
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseJsonObject = (value: unknown): Record<string, unknown> | null => {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return isRecord(value) ? value : null;
+};
+
+const validateFiniteNumber = ({
+  value,
+  path,
+  min,
+  max,
+}: {
+  value: unknown;
+  path: string;
+  min: number;
+  max: number;
+}) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${path} must be a finite number.`);
+  }
+  if (value < min || value > max) {
+    throw new Error(`${path} must be between ${min} and ${max}.`);
+  }
+  return value;
+};
+
+const validateHotRankingSettings = (
+  value: unknown,
+  path: string
+): HotRankingSettings => {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object.`);
+  }
+
+  return {
+    ageOffsetMonths: validateFiniteNumber({
+      value: value.ageOffsetMonths,
+      path: `${path}.ageOffsetMonths`,
+      min: MIN_AGE_OFFSET_MONTHS,
+      max: MAX_AGE_OFFSET_MONTHS,
+    }),
+    gravity: validateFiniteNumber({
+      value: value.gravity,
+      path: `${path}.gravity`,
+      min: MIN_GRAVITY,
+      max: MAX_GRAVITY,
+    }),
+  };
+};
+
+export const validateRankingSettings = (value: unknown): RankingSettings => {
+  const parsed = parseJsonObject(value);
+  if (!parsed) {
+    throw new Error("Ranking settings must be a JSON object.");
+  }
+  if (parsed.version !== RANKING_SETTINGS_VERSION) {
+    throw new Error(
+      `Ranking settings version must be ${RANKING_SETTINGS_VERSION}.`
+    );
+  }
+
+  return {
+    version: RANKING_SETTINGS_VERSION,
+    discussionHot: validateHotRankingSettings(
+      parsed.discussionHot,
+      "discussionHot"
+    ),
+    commentHot: validateHotRankingSettings(parsed.commentHot, "commentHot"),
+  };
+};
+
+export const readRankingSettings = (value: unknown): RankingSettings => {
+  if (value === null || value === undefined || value === "") {
+    return cloneDefaults();
+  }
+
+  try {
+    return validateRankingSettings(value);
+  } catch {
+    return cloneDefaults();
+  }
+};
+
+const mergeHotRankingPatch = (
+  current: HotRankingSettings,
+  patch: HotRankingSettingsPatch | undefined
+): HotRankingSettings => ({
+  ...current,
+  ...(patch ?? {}),
+});
+
+export const applyRankingSettingsPatch = (
+  currentValue: unknown,
+  patch: RankingSettingsPatch
+): RankingSettings =>
+  validateRankingSettings({
+    version: RANKING_SETTINGS_VERSION,
+    discussionHot: mergeHotRankingPatch(
+      readRankingSettings(currentValue).discussionHot,
+      patch.discussionHot
+    ),
+    commentHot: mergeHotRankingPatch(
+      readRankingSettings(currentValue).commentHot,
+      patch.commentHot
+    ),
+  });
+
+export const serializeRankingSettings = (settings: RankingSettings) =>
+  JSON.stringify(validateRankingSettings(settings));
+
+export const getDiscussionHotRankingParams = (settings: RankingSettings) => ({
+  hotAgeOffsetMonths: settings.discussionHot.ageOffsetMonths,
+  hotGravity: settings.discussionHot.gravity,
+});
+
+export const getCommentHotRankingParams = (settings: RankingSettings) => ({
+  hotAgeOffsetMonths: settings.commentHot.ageOffsetMonths,
+  hotGravity: settings.commentHot.gravity,
+});

--- a/services/rankingSettingsStore.test.ts
+++ b/services/rankingSettingsStore.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getHotRankingQueryParams } from "./rankingSettingsStore.js";
+
+test("non-hot sorts use defaults without reading stored settings", async () => {
+  let calls = 0;
+  const executor = {
+    run: async () => {
+      calls += 1;
+      return { records: [] };
+    },
+  };
+
+  const params = await getHotRankingQueryParams({
+    executor: executor as never,
+    profile: "discussion",
+    sortOption: "new",
+    serverName: "test-server",
+  });
+
+  assert.deepEqual(params, {
+    hotAgeOffsetMonths: 2,
+    hotGravity: 1.8,
+  });
+  assert.equal(calls, 0);
+});
+
+test("hot sorts load the selected profile from stored server settings", async () => {
+  const settingsJson = JSON.stringify({
+    version: 1,
+    discussionHot: {
+      ageOffsetMonths: 4,
+      gravity: 2.5,
+    },
+    commentHot: {
+      ageOffsetMonths: 0.75,
+      gravity: 1.2,
+    },
+  });
+  const executor = {
+    run: async () => ({
+      records: [
+        {
+          get: (key: string) => (key === "settingsJson" ? settingsJson : null),
+        },
+      ],
+    }),
+  };
+
+  assert.deepEqual(
+    await getHotRankingQueryParams({
+      executor: executor as never,
+      profile: "discussion",
+      sortOption: "hot",
+      serverName: "test-server",
+    }),
+    {
+      hotAgeOffsetMonths: 4,
+      hotGravity: 2.5,
+    }
+  );
+  assert.deepEqual(
+    await getHotRankingQueryParams({
+      executor: executor as never,
+      profile: "comment",
+      sortOption: "hot",
+      serverName: "test-server",
+    }),
+    {
+      hotAgeOffsetMonths: 0.75,
+      hotGravity: 1.2,
+    }
+  );
+});
+
+test("hot sorts fall back to defaults when the server config is absent", async () => {
+  const executor = {
+    run: async () => ({ records: [] }),
+  };
+
+  assert.deepEqual(
+    await getHotRankingQueryParams({
+      executor: executor as never,
+      profile: "comment",
+      sortOption: "hot",
+      serverName: "missing-server",
+    }),
+    {
+      hotAgeOffsetMonths: 2,
+      hotGravity: 1.8,
+    }
+  );
+});

--- a/services/rankingSettingsStore.ts
+++ b/services/rankingSettingsStore.ts
@@ -1,5 +1,8 @@
 import type { ManagedTransaction, Session } from "neo4j-driver";
 import {
+  DEFAULT_RANKING_SETTINGS,
+  getCommentHotRankingParams,
+  getDiscussionHotRankingParams,
   readRankingSettings,
   type RankingSettings,
 } from "./rankingSettings.js";
@@ -49,4 +52,27 @@ export const findRankingSettings = async ({
   );
 
   return readRecord(result.records[0]);
+};
+
+export const getHotRankingQueryParams = async ({
+  executor,
+  profile,
+  sortOption,
+  serverName = process.env.SERVER_CONFIG_NAME,
+}: {
+  executor: Session | ManagedTransaction;
+  profile: "discussion" | "comment";
+  sortOption: string;
+  serverName?: string;
+}) => {
+  let settings = DEFAULT_RANKING_SETTINGS;
+
+  if (sortOption === "hot" && serverName) {
+    const stored = await findRankingSettings({ executor, serverName });
+    settings = stored?.settings ?? DEFAULT_RANKING_SETTINGS;
+  }
+
+  return profile === "discussion"
+    ? getDiscussionHotRankingParams(settings)
+    : getCommentHotRankingParams(settings);
 };

--- a/services/rankingSettingsStore.ts
+++ b/services/rankingSettingsStore.ts
@@ -1,0 +1,52 @@
+import type { ManagedTransaction, Session } from "neo4j-driver";
+import {
+  readRankingSettings,
+  type RankingSettings,
+} from "./rankingSettings.js";
+
+export type StoredRankingSettings = {
+  settings: RankingSettings;
+  updatedAt: string | null;
+  updatedBy: string | null;
+};
+
+const readRecord = (
+  record:
+    | {
+        get: (key: string) => unknown;
+      }
+    | undefined
+): StoredRankingSettings | null => {
+  if (!record) {
+    return null;
+  }
+
+  const updatedAt = record.get("updatedAt");
+  const updatedBy = record.get("updatedBy");
+
+  return {
+    settings: readRankingSettings(record.get("settingsJson")),
+    updatedAt: updatedAt == null ? null : String(updatedAt),
+    updatedBy: updatedBy == null ? null : String(updatedBy),
+  };
+};
+
+export const findRankingSettings = async ({
+  executor,
+  serverName,
+}: {
+  executor: Session | ManagedTransaction;
+  serverName: string;
+}): Promise<StoredRankingSettings | null> => {
+  const result = await executor.run(
+    `
+      MATCH (serverConfig:ServerConfig {serverName: $serverName})
+      RETURN serverConfig.rankingSettingsJson AS settingsJson,
+             serverConfig.rankingSettingsUpdatedAt AS updatedAt,
+             serverConfig.rankingSettingsUpdatedBy AS updatedBy
+    `,
+    { serverName }
+  );
+
+  return readRecord(result.records[0]);
+};

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1118,6 +1118,10 @@ const typeDefinitions = gql`
     lockWikiPage(channelUniqueName: String!, wikiPageId: ID!, reason: String!): WikiPage!
     unlockWikiPage(channelUniqueName: String!, wikiPageId: ID!): WikiPage!
     setFeaturedWikiPages(serverName: String!, wikiPageIds: [ID!]!): ServerConfig!
+    setRankingSettings(
+      serverName: String!
+      input: RankingSettingsPatchInput!
+    ): RankingSettings!
 
     # Share collection as discussion
     shareCollectionAsDiscussion(
@@ -1834,6 +1838,15 @@ const typeDefinitions = gql`
     serverDescription: String
     serverIconURL: String
     rules: JSON
+    rankingSettingsJson: String
+      @selectable(onRead: false, onAggregate: false)
+      @settable(onCreate: false, onUpdate: false)
+    rankingSettingsUpdatedAt: DateTime
+      @selectable(onRead: false, onAggregate: false)
+      @settable(onCreate: false, onUpdate: false)
+    rankingSettingsUpdatedBy: String
+      @selectable(onRead: false, onAggregate: false)
+      @settable(onCreate: false, onUpdate: false)
     allowedFileTypes: [String]
     featuredWikiPageIds: [ID]
     enableDownloads: Boolean
@@ -1876,6 +1889,35 @@ const typeDefinitions = gql`
   type EnvironmentInfo {
     isTestEnvironment: Boolean
     currentDatabase: String
+  }
+
+  type HotRankingSettings
+    @query(read: false, aggregate: false)
+    @mutation(operations: [])
+    @subscription(events: []) {
+    ageOffsetMonths: Float!
+    gravity: Float!
+  }
+
+  type RankingSettings
+    @query(read: false, aggregate: false)
+    @mutation(operations: [])
+    @subscription(events: []) {
+    version: Int!
+    discussionHot: HotRankingSettings!
+    commentHot: HotRankingSettings!
+    updatedAt: DateTime
+    updatedBy: String
+  }
+
+  input HotRankingSettingsPatchInput {
+    ageOffsetMonths: Float
+    gravity: Float
+  }
+
+  input RankingSettingsPatchInput {
+    discussionHot: HotRankingSettingsPatchInput
+    commentHot: HotRankingSettingsPatchInput
   }
 
   type SafetyCheckResponse {
@@ -2201,6 +2243,7 @@ const typeDefinitions = gql`
       options: DiscussionListOptions
       loggedInUsername: String
     ): SiteWideDiscussionListFormat
+    getRankingSettings(serverName: String!): RankingSettings!
     getSiteWideIssueList(
       searchInput: String
       selectedChannels: [String]


### PR DESCRIPTION
## Summary
- add versioned, validated server ranking settings with behavior-preserving defaults
- expose capability-gated `getRankingSettings` and `setRankingSettings` operations with audit metadata
- parameterize discussion and comment hot-ranking formulas across all five Cypher paths
- avoid configuration reads for new/top sorts and safely fall back when stored settings are missing or malformed

## Motivation
Hot-ranking constants (the two-month age offset and 1.8 gravity) were duplicated in Cypher, so tuning ranking behavior required code deployments. This introduces an extensible `ServerConfig`-backed configuration seam. The existing `10000` scale factor was removed because it did not affect ordering.

## Impact
The defaults preserve the existing ranking order. Admins with `canManageServerSettings` can independently tune `discussionHot` and `commentHot` age offsets and gravity without changing list request inputs. Raw storage fields remain excluded from generated CRUD operations.

## Validation
- schema/codegen passed
- `npm run tsc` passed
- 67 focused ranking tests passed
- broad unit suite: 791 tests passed under Node 22 transpile-only; four type-export loader artifacts were rerun under the normal Node 22 loader with 18/18 assertions passing
- `git diff --check` passed