### PR TITLE
Add channel discussion flair foundation

### DIFF
--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -128,6 +128,7 @@ import {
 } from "./mutations/wikiPageLocks.js";
 import { setFeaturedWikiPages } from "./mutations/setFeaturedWikiPages.js";
 import setRankingSettings from "./mutations/setRankingSettings.js";
+import setChannelDiscussionFlairConfig from "./mutations/setChannelDiscussionFlairConfig.js";
 
 export default function buildMutationResolvers(deps: ResolverDeps) {
   const {
@@ -167,6 +168,9 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
   } = deps;
 
   return {
+    setChannelDiscussionFlairConfig: setChannelDiscussionFlairConfig({
+      driver,
+    }),
     createDiscussionWithChannelConnections:
       createDiscussionWithChannelConnections({
         Discussion,

--- a/customResolvers/mutations/setChannelDiscussionFlairConfig.test.ts
+++ b/customResolvers/mutations/setChannelDiscussionFlairConfig.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import { setChannelDiscussionFlairConfig } from "./setChannelDiscussionFlairConfig.js";
+
+const record = (values: Record<string, unknown>) => ({
+  get: (key: string) => values[key],
+});
+
+const configRecord = ({
+  flairRequired,
+  flairs,
+}: {
+  flairRequired: boolean;
+  flairs: Array<Record<string, unknown>>;
+}) =>
+  record({
+    channelUniqueName: "gardening",
+    flairRequired,
+    flairs,
+  });
+
+const existingFlairs = [
+  {
+    id: "existing",
+    channelUniqueName: "gardening",
+    displayName: "Question",
+    color: "#2563EB",
+    order: 0,
+    archived: false,
+  },
+  {
+    id: "omitted",
+    channelUniqueName: "gardening",
+    displayName: "Old category",
+    color: null,
+    order: 1,
+    archived: false,
+  },
+];
+
+const context = {
+  user: { username: "channel-owner" },
+} as GraphQLContext;
+
+test("updates, creates, and archives omitted flairs atomically", async () => {
+  const writeCalls: Array<{
+    query: string;
+    params?: Record<string, unknown>;
+  }> = [];
+  let configReads = 0;
+  let closed = false;
+
+  const transaction = {
+    run: async (query: string, params?: Record<string, unknown>) => {
+      if (query.includes("AS flairs")) {
+        configReads += 1;
+        return {
+          records: [
+            configReads === 1
+              ? configRecord({ flairRequired: false, flairs: existingFlairs })
+              : configRecord({
+                  flairRequired: true,
+                  flairs: [
+                    {
+                      ...existingFlairs[0],
+                      displayName: "Help",
+                      color: "#DC2626",
+                    },
+                    { ...existingFlairs[1], archived: true },
+                    {
+                      id: "generated-id",
+                      channelUniqueName: "gardening",
+                      displayName: "Showcase",
+                      color: null,
+                      order: 1,
+                      archived: false,
+                    },
+                  ],
+                }),
+          ],
+        };
+      }
+
+      writeCalls.push({ query, params });
+      return { records: [] };
+    },
+  };
+
+  const driver = {
+    session: () => ({
+      executeWrite: async (
+        callback: (tx: typeof transaction) => Promise<unknown>
+      ) => callback(transaction),
+      close: async () => {
+        closed = true;
+      },
+    }),
+  };
+
+  const resolver = setChannelDiscussionFlairConfig({
+    driver: driver as never,
+    createId: () => "generated-id",
+  });
+  const result = await resolver(
+    null,
+    {
+      channelUniqueName: "gardening",
+      flairRequired: true,
+      flairs: [
+        {
+          id: "existing",
+          displayName: "Help",
+          color: "#dc2626",
+          order: 0,
+          archived: false,
+        },
+        {
+          displayName: "Showcase",
+          order: 1,
+          archived: false,
+        },
+      ],
+    },
+    context
+  );
+
+  assert.equal(result.flairRequired, true);
+  assert.equal(result.flairs.length, 3);
+  assert.equal(result.flairs[1].archived, true);
+  assert.equal(configReads, 2);
+  assert.equal(writeCalls.length, 3);
+  assert.deepEqual(writeCalls[0].params, {
+    channelUniqueName: "gardening",
+    flairRequired: true,
+    submittedIds: ["existing", "generated-id"],
+  });
+  assert.deepEqual(writeCalls[1].params, {
+    channelUniqueName: "gardening",
+    flairs: [
+      {
+        id: "existing",
+        displayName: "Help",
+        color: "#DC2626",
+        order: 0,
+        archived: false,
+      },
+    ],
+  });
+  assert.deepEqual(writeCalls[2].params, {
+    channelUniqueName: "gardening",
+    flairs: [
+      {
+        id: "generated-id",
+        displayName: "Showcase",
+        color: null,
+        order: 1,
+        archived: false,
+      },
+    ],
+  });
+  assert.equal(closed, true);
+});
+
+test("rejects a flair ID that does not belong to the channel", async () => {
+  let writeCount = 0;
+  const transaction = {
+    run: async (query: string) => {
+      if (query.includes("AS flairs")) {
+        return {
+          records: [
+            configRecord({ flairRequired: false, flairs: existingFlairs }),
+          ],
+        };
+      }
+      writeCount += 1;
+      return { records: [] };
+    },
+  };
+  const driver = {
+    session: () => ({
+      executeWrite: async (
+        callback: (tx: typeof transaction) => Promise<unknown>
+      ) => callback(transaction),
+      close: async () => {},
+    }),
+  };
+  const resolver = setChannelDiscussionFlairConfig({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        {
+          channelUniqueName: "gardening",
+          flairRequired: false,
+          flairs: [
+            {
+              id: "belongs-to-another-channel",
+              displayName: "Question",
+              order: 0,
+              archived: false,
+            },
+          ],
+        },
+        context
+      ),
+    /does not belong to channel/
+  );
+
+  assert.equal(writeCount, 0);
+});
+
+test("reports a missing channel before writing", async () => {
+  const transaction = {
+    run: async () => ({ records: [] }),
+  };
+  const driver = {
+    session: () => ({
+      executeWrite: async (
+        callback: (tx: typeof transaction) => Promise<unknown>
+      ) => callback(transaction),
+      close: async () => {},
+    }),
+  };
+  const resolver = setChannelDiscussionFlairConfig({ driver: driver as never });
+
+  await assert.rejects(
+    () =>
+      resolver(
+        null,
+        {
+          channelUniqueName: "missing",
+          flairRequired: false,
+          flairs: [],
+        },
+        context
+      ),
+    /Channel not found/
+  );
+});

--- a/customResolvers/mutations/setChannelDiscussionFlairConfig.ts
+++ b/customResolvers/mutations/setChannelDiscussionFlairConfig.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  normalizeDiscussionFlairConfig,
+  type DiscussionFlairConfigInput,
+} from "../../services/discussionFlairConfig.js";
+import { findChannelDiscussionFlairConfig } from "../../services/discussionFlairStore.js";
+import { logger } from "../../logger.js";
+
+type Input = {
+  driver: Driver;
+  createId?: () => string;
+};
+
+type Args = {
+  channelUniqueName: string;
+  flairRequired: boolean;
+  flairs: DiscussionFlairConfigInput[];
+};
+
+export const setChannelDiscussionFlairConfig = ({
+  driver,
+  createId = randomUUID,
+}: Input) => {
+  return async (
+    _parent: unknown,
+    { channelUniqueName, flairRequired, flairs }: Args,
+    context: GraphQLContext
+  ) => {
+    const normalizedChannelName = channelUniqueName?.trim();
+    if (!normalizedChannelName) {
+      throw new GraphQLError("Channel unique name is required.");
+    }
+
+    const normalizedFlairs = normalizeDiscussionFlairConfig(
+      flairs,
+      flairRequired
+    );
+    const session = driver.session();
+
+    try {
+      return await session.executeWrite(async (transaction) => {
+        const existingConfig = await findChannelDiscussionFlairConfig({
+          executor: transaction,
+          channelUniqueName: normalizedChannelName,
+          includeArchived: true,
+        });
+
+        if (!existingConfig) {
+          throw new GraphQLError("Channel not found.", {
+            extensions: { code: "CHANNEL_NOT_FOUND" },
+          });
+        }
+
+        const existingIds = new Set(
+          existingConfig.flairs.map((flair) => flair.id)
+        );
+        for (const flair of normalizedFlairs) {
+          if (flair.id && !existingIds.has(flair.id)) {
+            throw new GraphQLError(
+              `Flair '${flair.id}' does not belong to channel '${normalizedChannelName}'.`,
+              { extensions: { code: "INVALID_DISCUSSION_FLAIR" } }
+            );
+          }
+        }
+
+        const persistedFlairs = normalizedFlairs.map((flair) => ({
+          ...flair,
+          id: flair.id ?? createId(),
+        }));
+        const submittedIds = persistedFlairs.map((flair) => flair.id);
+        const existingFlairUpdates = persistedFlairs.filter((flair) =>
+          existingIds.has(flair.id)
+        );
+        const newFlairs = persistedFlairs.filter(
+          (flair) => !existingIds.has(flair.id)
+        );
+
+        await transaction.run(
+          `
+            MATCH (channel:Channel {uniqueName: $channelUniqueName})
+            SET channel.discussionFlairRequired = $flairRequired
+            WITH channel
+            OPTIONAL MATCH (channel)-[:HAS_DISCUSSION_FLAIR]->(existing:DiscussionFlair)
+            FOREACH (_ IN CASE
+              WHEN existing IS NOT NULL AND NOT existing.id IN $submittedIds
+              THEN [1]
+              ELSE []
+            END | SET existing.archived = true)
+            RETURN channel.uniqueName AS channelUniqueName
+          `,
+          {
+            channelUniqueName: normalizedChannelName,
+            flairRequired,
+            submittedIds,
+          }
+        );
+
+        if (existingFlairUpdates.length > 0) {
+          await transaction.run(
+            `
+              MATCH (channel:Channel {uniqueName: $channelUniqueName})
+              UNWIND $flairs AS flairInput
+              MATCH (channel)-[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair {
+                id: flairInput.id,
+                channelUniqueName: $channelUniqueName
+              })
+              SET flair.displayName = flairInput.displayName,
+                  flair.color = flairInput.color,
+                  flair.order = flairInput.order,
+                  flair.archived = flairInput.archived
+            `,
+            {
+              channelUniqueName: normalizedChannelName,
+              flairs: existingFlairUpdates,
+            }
+          );
+        }
+
+        if (newFlairs.length > 0) {
+          await transaction.run(
+            `
+              MATCH (channel:Channel {uniqueName: $channelUniqueName})
+              UNWIND $flairs AS flairInput
+              CREATE (flair:DiscussionFlair {
+                id: flairInput.id,
+                channelUniqueName: $channelUniqueName,
+                displayName: flairInput.displayName,
+                color: flairInput.color,
+                order: flairInput.order,
+                archived: flairInput.archived
+              })
+              CREATE (channel)-[:HAS_DISCUSSION_FLAIR]->(flair)
+            `,
+            {
+              channelUniqueName: normalizedChannelName,
+              flairs: newFlairs,
+            }
+          );
+        }
+
+        const updatedConfig = await findChannelDiscussionFlairConfig({
+          executor: transaction,
+          channelUniqueName: normalizedChannelName,
+          includeArchived: true,
+        });
+
+        if (!updatedConfig) {
+          throw new GraphQLError("Channel not found.", {
+            extensions: { code: "CHANNEL_NOT_FOUND" },
+          });
+        }
+
+        logger.info("Channel discussion flair configuration updated", {
+          channelUniqueName: normalizedChannelName,
+          updatedBy: context.user?.username ?? null,
+          flairRequired,
+          activeFlairCount: persistedFlairs.filter(
+            (flair) => !flair.archived
+          ).length,
+        });
+
+        return updatedConfig;
+      });
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default setChannelDiscussionFlairConfig;

--- a/customResolvers/queries/getChannelDiscussionFlairConfig.test.ts
+++ b/customResolvers/queries/getChannelDiscussionFlairConfig.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import neo4j from "neo4j-driver";
+import { getChannelDiscussionFlairConfig } from "./getChannelDiscussionFlairConfig.js";
+
+const record = (values: Record<string, unknown>) => ({
+  get: (key: string) => values[key],
+});
+
+test("returns active flair configuration and closes the session", async () => {
+  let closed = false;
+  const calls: Array<Record<string, unknown> | undefined> = [];
+  const driver = {
+    session: () => ({
+      run: async (_query: string, params?: Record<string, unknown>) => {
+        calls.push(params);
+        return {
+          records: [
+            record({
+              channelUniqueName: "gardening",
+              flairRequired: true,
+              flairs: [
+                {
+                  id: "question",
+                  channelUniqueName: "gardening",
+                  displayName: "Question",
+                  color: "#2563EB",
+                  order: neo4j.int(0),
+                  archived: false,
+                },
+              ],
+            }),
+          ],
+        };
+      },
+      close: async () => {
+        closed = true;
+      },
+    }),
+  };
+
+  const resolver = getChannelDiscussionFlairConfig({ driver: driver as never });
+  const result = await resolver(null, {
+    channelUniqueName: " gardening ",
+  });
+
+  assert.deepEqual(result, {
+    channelUniqueName: "gardening",
+    flairRequired: true,
+    flairs: [
+      {
+        id: "question",
+        channelUniqueName: "gardening",
+        displayName: "Question",
+        color: "#2563EB",
+        order: 0,
+        archived: false,
+      },
+    ],
+  });
+  assert.deepEqual(calls[0], {
+    channelUniqueName: "gardening",
+    includeArchived: false,
+  });
+  assert.equal(closed, true);
+});
+
+test("reports a missing channel", async () => {
+  const driver = {
+    session: () => ({
+      run: async () => ({ records: [] }),
+      close: async () => {},
+    }),
+  };
+  const resolver = getChannelDiscussionFlairConfig({ driver: driver as never });
+
+  await assert.rejects(
+    () => resolver(null, { channelUniqueName: "missing" }),
+    /Channel not found/
+  );
+});

--- a/customResolvers/queries/getChannelDiscussionFlairConfig.ts
+++ b/customResolvers/queries/getChannelDiscussionFlairConfig.ts
@@ -1,0 +1,45 @@
+import { GraphQLError } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { findChannelDiscussionFlairConfig } from "../../services/discussionFlairStore.js";
+
+type Input = {
+  driver: Driver;
+};
+
+type Args = {
+  channelUniqueName: string;
+  includeArchived?: boolean | null;
+};
+
+export const getChannelDiscussionFlairConfig = ({ driver }: Input) => {
+  return async (
+    _parent: unknown,
+    { channelUniqueName, includeArchived = false }: Args
+  ) => {
+    const normalizedChannelName = channelUniqueName?.trim();
+    if (!normalizedChannelName) {
+      throw new GraphQLError("Channel unique name is required.");
+    }
+
+    const session = driver.session();
+    try {
+      const config = await findChannelDiscussionFlairConfig({
+        executor: session,
+        channelUniqueName: normalizedChannelName,
+        includeArchived: includeArchived === true,
+      });
+
+      if (!config) {
+        throw new GraphQLError("Channel not found.", {
+          extensions: { code: "CHANNEL_NOT_FOUND" },
+        });
+      }
+
+      return config;
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getChannelDiscussionFlairConfig;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -36,6 +36,7 @@ import {
   previewPluginPipelineCampaign,
 } from './queries/pluginPipelineCampaigns.js'
 import getRankingSettings from "./queries/getRankingSettings.js";
+import getChannelDiscussionFlairConfig from "./queries/getChannelDiscussionFlairConfig.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -65,6 +66,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
       driver,
     }),
     getRankingSettings: getRankingSettings({
+      driver,
+    }),
+    getChannelDiscussionFlairConfig: getChannelDiscussionFlairConfig({
       driver,
     }),
     getSiteWideIssueList: getSiteWideIssueList({

--- a/permissions.ts
+++ b/permissions.ts
@@ -344,6 +344,7 @@ const permissionList = shield({
       unlockWikiPage: and(isAuthenticated, allow),
       setFeaturedWikiPages: and(isAuthenticated, canManageServerSettings),
       setRankingSettings: and(isAuthenticated, canManageServerSettings),
+      setChannelDiscussionFlairConfig: and(isAuthenticated, isChannelOwner),
       suspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       suspendUser: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),
       unsuspendMod: and(isAuthenticated, or(isChannelOwner, canSuspendAndUnsuspendUser)),

--- a/services/discussionFlairConfig.test.ts
+++ b/services/discussionFlairConfig.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeDiscussionFlairConfig } from "./discussionFlairConfig.js";
+
+test("normalizes flair names and colors", () => {
+  assert.deepEqual(
+    normalizeDiscussionFlairConfig(
+      [
+        {
+          displayName: "  Project   Update  ",
+          color: "#2563eb",
+          order: 0,
+        },
+      ],
+      true
+    ),
+    [
+      {
+        id: undefined,
+        displayName: "Project Update",
+        color: "#2563EB",
+        order: 0,
+        archived: false,
+      },
+    ]
+  );
+});
+
+test("allows no active flairs when flair is optional", () => {
+  assert.deepEqual(normalizeDiscussionFlairConfig([], false), []);
+});
+
+test("requires an active flair before enabling the requirement", () => {
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [
+          {
+            id: "archived-flair",
+            displayName: "Archived",
+            order: 0,
+            archived: true,
+          },
+        ],
+        true
+      ),
+    /At least one active flair/
+  );
+});
+
+test("rejects duplicate active names case-insensitively", () => {
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [
+          { displayName: "Question", order: 0 },
+          { displayName: " question ", order: 1 },
+        ],
+        false
+      ),
+    /Active flair names must be unique/
+  );
+});
+
+test("rejects duplicate IDs and active order values", () => {
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [
+          { id: "same", displayName: "One", order: 0 },
+          { id: "same", displayName: "Two", order: 1 },
+        ],
+        false
+      ),
+    /Duplicate flair ID/
+  );
+
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [
+          { displayName: "One", order: 0 },
+          { displayName: "Two", order: 0 },
+        ],
+        false
+      ),
+    /Active flair order values must be unique/
+  );
+});
+
+test("rejects invalid names, colors, and order values", () => {
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [{ displayName: " ", order: 0 }],
+        false
+      ),
+    /must have a display name/
+  );
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [{ displayName: "Question", color: "blue", order: 0 }],
+        false
+      ),
+    /six-digit hexadecimal/
+  );
+  assert.throws(
+    () =>
+      normalizeDiscussionFlairConfig(
+        [{ displayName: "Question", order: -1 }],
+        false
+      ),
+    /non-negative integer/
+  );
+});

--- a/services/discussionFlairConfig.ts
+++ b/services/discussionFlairConfig.ts
@@ -1,0 +1,105 @@
+import { GraphQLError } from "graphql";
+
+export const MAX_DISCUSSION_FLAIR_NAME_LENGTH = 40;
+
+const HEX_COLOR = /^#[0-9A-F]{6}$/;
+
+export type DiscussionFlairConfigInput = {
+  id?: string | null;
+  displayName: string;
+  color?: string | null;
+  order: number;
+  archived?: boolean | null;
+};
+
+export type NormalizedDiscussionFlairConfig = {
+  id?: string;
+  displayName: string;
+  color: string | null;
+  order: number;
+  archived: boolean;
+};
+
+const normalizeDisplayName = (displayName: string) =>
+  displayName.normalize("NFKC").trim().replace(/\s+/g, " ");
+
+const comparisonKey = (displayName: string) =>
+  normalizeDisplayName(displayName).toLocaleLowerCase("en-US");
+
+export const normalizeDiscussionFlairConfig = (
+  flairs: DiscussionFlairConfigInput[],
+  flairRequired: boolean
+): NormalizedDiscussionFlairConfig[] => {
+  if (!Array.isArray(flairs)) {
+    throw new GraphQLError("Flairs must be provided as a list.");
+  }
+
+  const ids = new Set<string>();
+  const activeNames = new Set<string>();
+  const activeOrders = new Set<number>();
+
+  const normalized = flairs.map((flair, index) => {
+    const displayName = normalizeDisplayName(flair.displayName ?? "");
+    if (!displayName) {
+      throw new GraphQLError(`Flair ${index + 1} must have a display name.`);
+    }
+    if (displayName.length > MAX_DISCUSSION_FLAIR_NAME_LENGTH) {
+      throw new GraphQLError(
+        `Flair display names cannot exceed ${MAX_DISCUSSION_FLAIR_NAME_LENGTH} characters.`
+      );
+    }
+
+    const id = flair.id?.trim() || undefined;
+    if (id) {
+      if (ids.has(id)) {
+        throw new GraphQLError(`Duplicate flair ID '${id}'.`);
+      }
+      ids.add(id);
+    }
+
+    if (!Number.isInteger(flair.order) || flair.order < 0) {
+      throw new GraphQLError("Flair order must be a non-negative integer.");
+    }
+
+    const color = flair.color?.trim().toUpperCase() || null;
+    if (color && !HEX_COLOR.test(color)) {
+      throw new GraphQLError(
+        "Flair colors must be six-digit hexadecimal values such as #2563EB."
+      );
+    }
+
+    const archived = flair.archived === true;
+    if (!archived) {
+      const nameKey = comparisonKey(displayName);
+      if (activeNames.has(nameKey)) {
+        throw new GraphQLError(
+          `Active flair names must be unique. '${displayName}' appears more than once.`
+        );
+      }
+      activeNames.add(nameKey);
+
+      if (activeOrders.has(flair.order)) {
+        throw new GraphQLError(
+          `Active flair order values must be unique. Order ${flair.order} appears more than once.`
+        );
+      }
+      activeOrders.add(flair.order);
+    }
+
+    return {
+      id,
+      displayName,
+      color,
+      order: flair.order,
+      archived,
+    };
+  });
+
+  if (flairRequired && !normalized.some((flair) => !flair.archived)) {
+    throw new GraphQLError(
+      "At least one active flair is required before flair selection can be required."
+    );
+  }
+
+  return normalized;
+};

--- a/services/discussionFlairStore.ts
+++ b/services/discussionFlairStore.ts
@@ -1,0 +1,77 @@
+import neo4j, { type Record as Neo4jRecord } from "neo4j-driver";
+
+export type DiscussionFlairOption = {
+  id: string;
+  channelUniqueName: string;
+  displayName: string;
+  color: string | null;
+  order: number;
+  archived: boolean;
+};
+
+export type ChannelDiscussionFlairConfig = {
+  channelUniqueName: string;
+  flairRequired: boolean;
+  flairs: DiscussionFlairOption[];
+};
+
+export type CypherExecutor = {
+  run: (
+    query: string,
+    params?: Record<string, unknown>
+  ) => Promise<{ records: Neo4jRecord[] }>;
+};
+
+const toNumber = (value: unknown) =>
+  neo4j.isInt(value) ? value.toNumber() : Number(value);
+
+export const findChannelDiscussionFlairConfig = async ({
+  executor,
+  channelUniqueName,
+  includeArchived,
+}: {
+  executor: CypherExecutor;
+  channelUniqueName: string;
+  includeArchived: boolean;
+}): Promise<ChannelDiscussionFlairConfig | null> => {
+  const result = await executor.run(
+    `
+      MATCH (channel:Channel {uniqueName: $channelUniqueName})
+      OPTIONAL MATCH (channel)-[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair)
+      WHERE $includeArchived
+         OR coalesce(flair.archived, false) = false
+      WITH channel, flair
+      ORDER BY flair.order ASC, flair.displayName ASC
+      RETURN channel.uniqueName AS channelUniqueName,
+             coalesce(channel.discussionFlairRequired, false) AS flairRequired,
+             collect(CASE WHEN flair IS NULL THEN null ELSE {
+               id: flair.id,
+               channelUniqueName: flair.channelUniqueName,
+               displayName: flair.displayName,
+               color: flair.color,
+               order: flair.order,
+               archived: coalesce(flair.archived, false)
+             } END) AS flairs
+    `,
+    {
+      channelUniqueName,
+      includeArchived,
+    }
+  );
+
+  const record = result.records[0];
+  if (!record) {
+    return null;
+  }
+
+  return {
+    channelUniqueName: record.get("channelUniqueName"),
+    flairRequired: record.get("flairRequired"),
+    flairs: (record.get("flairs") ?? [])
+      .filter(Boolean)
+      .map((flair: DiscussionFlairOption & { order: unknown }) => ({
+        ...flair,
+        order: toNumber(flair.order),
+      })),
+  };
+};

--- a/tests/auth/mutationAuth.test.ts
+++ b/tests/auth/mutationAuth.test.ts
@@ -165,6 +165,25 @@ const authGatedChannelLock: Array<{ name: string; op: string }> = [
   },
 ];
 
+test("setChannelDiscussionFlairConfig is auth-gated rather than default-denied", async () => {
+  const result = await execUnauthenticated(`
+    mutation {
+      setChannelDiscussionFlairConfig(
+        channelUniqueName: "gardening"
+        flairRequired: false
+        flairs: []
+      ) {
+        channelUniqueName
+      }
+    }
+  `);
+
+  assert.equal(
+    result.errors?.[0]?.message,
+    ERROR_MESSAGES.channel.notAuthenticated
+  );
+});
+
 for (const { name, op } of authGatedChannelLock) {
   test(`${name} is auth-gated (unauthenticated -> notAuthenticated, not default-deny)`, async () => {
     const result = await execUnauthenticated(op);

--- a/tests/integration/discussionFlairConfig.test.ts
+++ b/tests/integration/discussionFlairConfig.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test, { after, before, beforeEach } from "node:test";
+import type { Driver } from "neo4j-driver";
+import { getChannelDiscussionFlairConfig } from "../../customResolvers/queries/getChannelDiscussionFlairConfig.js";
+import { setChannelDiscussionFlairConfig } from "../../customResolvers/mutations/setChannelDiscussionFlairConfig.js";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  resetDatabase,
+  startNeo4j,
+  stopNeo4j,
+} from "./neo4jHarness.js";
+
+let driver: Driver;
+
+before(
+  async () => {
+    driver = await startNeo4j();
+  },
+  { timeout: 240000 }
+);
+
+after(async () => {
+  await stopNeo4j();
+});
+
+beforeEach(async () => {
+  await resetDatabase(driver);
+  const session = driver.session();
+  try {
+    await session.run(
+      `CREATE (:Channel {
+        uniqueName: 'gardening',
+        displayName: 'Gardening',
+        discussionFlairRequired: false
+      })`
+    );
+  } finally {
+    await session.close();
+  }
+});
+
+const context = {
+  user: { username: "channel-owner" },
+} as GraphQLContext;
+
+test("persists, reads, and archives channel discussion flairs", async () => {
+  const setConfig = setChannelDiscussionFlairConfig({
+    driver,
+    createId: (() => {
+      const ids = ["question", "showcase"];
+      return () => ids.shift() as string;
+    })(),
+  });
+  const getConfig = getChannelDiscussionFlairConfig({ driver });
+
+  await setConfig(
+    null,
+    {
+      channelUniqueName: "gardening",
+      flairRequired: true,
+      flairs: [
+        {
+          displayName: "Question",
+          color: "#2563EB",
+          order: 0,
+          archived: false,
+        },
+        {
+          displayName: "Showcase",
+          color: "#16A34A",
+          order: 1,
+          archived: false,
+        },
+      ],
+    },
+    context
+  );
+
+  assert.deepEqual(await getConfig(null, { channelUniqueName: "gardening" }), {
+    channelUniqueName: "gardening",
+    flairRequired: true,
+    flairs: [
+      {
+        id: "question",
+        channelUniqueName: "gardening",
+        displayName: "Question",
+        color: "#2563EB",
+        order: 0,
+        archived: false,
+      },
+      {
+        id: "showcase",
+        channelUniqueName: "gardening",
+        displayName: "Showcase",
+        color: "#16A34A",
+        order: 1,
+        archived: false,
+      },
+    ],
+  });
+
+  await setConfig(
+    null,
+    {
+      channelUniqueName: "gardening",
+      flairRequired: true,
+      flairs: [
+        {
+          id: "question",
+          displayName: "Help",
+          color: "#DC2626",
+          order: 0,
+          archived: false,
+        },
+      ],
+    },
+    context
+  );
+
+  const activeConfig = await getConfig(null, {
+    channelUniqueName: "gardening",
+  });
+  assert.deepEqual(
+    activeConfig.flairs.map((flair) => flair.id),
+    ["question"]
+  );
+
+  const managementConfig = await getConfig(null, {
+    channelUniqueName: "gardening",
+    includeArchived: true,
+  });
+  assert.deepEqual(
+    managementConfig.flairs.map((flair) => [flair.id, flair.archived]),
+    [
+      ["question", false],
+      ["showcase", true],
+    ]
+  );
+
+  const session = driver.session();
+  try {
+    await session.run(
+      `
+        MATCH (:Channel {uniqueName: 'gardening'})
+          -[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair)
+        SET flair.archived = true
+      `
+    );
+  } finally {
+    await session.close();
+  }
+
+  const archivedOnlyConfig = await getConfig(null, {
+    channelUniqueName: "gardening",
+  });
+  assert.deepEqual(archivedOnlyConfig.flairs, []);
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -492,6 +492,34 @@ const typeDefinitions = gql`
     group: FilterGroup! @relationship(type: "HAS_FILTER_OPTION", direction: IN)
   }
 
+  """
+  A channel-owned category that can be assigned to a discussion's submission
+  in that channel. Flairs are archived instead of deleted so historical
+  assignments can continue to render.
+  """
+  type DiscussionFlair
+    @query(read: false, aggregate: false)
+    @mutation(operations: [])
+    @subscription(events: []) {
+    id: ID! @id
+    channelUniqueName: String!
+      @settable(onCreate: false, onUpdate: false)
+    displayName: String!
+      @settable(onCreate: false, onUpdate: false)
+    color: String
+      @settable(onCreate: false, onUpdate: false)
+    order: Int!
+      @settable(onCreate: false, onUpdate: false)
+    archived: Boolean! @default(value: false)
+      @settable(onCreate: false, onUpdate: false)
+    Channel: Channel!
+      @relationship(type: "HAS_DISCUSSION_FLAIR", direction: IN)
+      @settable(onCreate: false, onUpdate: false)
+    DiscussionChannels: [DiscussionChannel!]!
+      @relationship(type: "HAS_DISCUSSION_FLAIR", direction: IN)
+      @settable(onCreate: false, onUpdate: false)
+  }
+
   type Channel {
     uniqueName: String! @unique
     createdAt: DateTime! @timestamp(operations: [CREATE])
@@ -534,6 +562,8 @@ const typeDefinitions = gql`
     requireVerifiedPhoneForUploads: Boolean @default(value: false)
     requireVerifiedEmailToPost: Boolean @default(value: false)
     markAsAnsweredEnabled: Boolean @default(value: true)
+    discussionFlairRequired: Boolean @default(value: false)
+      @settable(onCreate: false, onUpdate: false)
 
     allowedFileTypes: [String]
     payoutPercent: Int @default(value: 98)
@@ -572,6 +602,9 @@ const typeDefinitions = gql`
     # wiki + filters
     WikiHomePage:  WikiPage   @relationship(type: "HAS_WIKI_HOME_PAGE", direction: OUT)
     FilterGroups: [FilterGroup!]! @relationship(type: "HAS_FILTER_GROUP", direction: OUT)
+    DiscussionFlairs: [DiscussionFlair!]!
+      @relationship(type: "HAS_DISCUSSION_FLAIR", direction: OUT)
+      @settable(onCreate: false, onUpdate: false)
 
     # plugins
     EnabledPlugins: [PluginVersion!]! @relationship(type: "ENABLED", direction: OUT, properties: "ChannelPluginProperties")
@@ -604,6 +637,9 @@ const typeDefinitions = gql`
       @relationship(type: "SUBSCRIBED_TO_NOTIFICATIONS", direction: IN)
     LabelOptions: [FilterOption!]! @relationship(type: "HAS_LABEL_OPTION", direction: OUT)
     LabelChangeHistory: [LabelChangeHistory!]! @relationship(type: "HAS_LABEL_CHANGE", direction: OUT)
+    Flairs: [DiscussionFlair!]!
+      @relationship(type: "HAS_DISCUSSION_FLAIR", direction: OUT)
+      @settable(onCreate: false, onUpdate: false)
   }
 
   type Discussion {
@@ -1071,6 +1107,39 @@ const typeDefinitions = gql`
     channelConnections: [String!]!
   }
 
+  """
+  A flair in the channel's authoritative configuration list. Existing flairs
+  omitted from a configuration update are archived rather than deleted.
+  """
+  input DiscussionFlairConfigInput {
+    id: ID
+    displayName: String!
+    color: String
+    order: Int!
+    archived: Boolean! = false
+  }
+
+  type DiscussionFlairOption
+    @query(read: false, aggregate: false)
+    @mutation(operations: [])
+    @subscription(events: []) {
+    id: ID!
+    channelUniqueName: String!
+    displayName: String!
+    color: String
+    order: Int!
+    archived: Boolean!
+  }
+
+  type ChannelDiscussionFlairConfig
+    @query(read: false, aggregate: false)
+    @mutation(operations: [])
+    @subscription(events: []) {
+    channelUniqueName: String!
+    flairRequired: Boolean!
+    flairs: [DiscussionFlairOption!]!
+  }
+
   input NewUserInput {
     emailAddress: String!
     username: String!
@@ -1123,6 +1192,15 @@ const typeDefinitions = gql`
       serverName: String!
       input: RankingSettingsPatchInput!
     ): RankingSettings!
+    """
+    Replaces a channel's discussion flair configuration. Existing flairs not
+    included in flairs are archived. Only channel owners may call this mutation.
+    """
+    setChannelDiscussionFlairConfig(
+      channelUniqueName: String!
+      flairRequired: Boolean!
+      flairs: [DiscussionFlairConfigInput!]!
+    ): ChannelDiscussionFlairConfig!
 
     # Share collection as discussion
     shareCollectionAsDiscussion(
@@ -2497,6 +2575,10 @@ const typeDefinitions = gql`
       loggedInUsername: String
     ): SiteWideDiscussionListFormat
     getRankingSettings(serverName: String!): RankingSettings!
+    getChannelDiscussionFlairConfig(
+      channelUniqueName: String!
+      includeArchived: Boolean = false
+    ): ChannelDiscussionFlairConfig!
     getSiteWideIssueList(
       searchInput: String
       selectedChannels: [String]


### PR DESCRIPTION
## Summary

- add a channel-owned `DiscussionFlair` model with stable IDs, ordering, optional colors, and soft archiving
- add a per-channel `discussionFlairRequired` setting
- add a public read API for active flairs and an owner-protected management view including archived flairs
- add an atomic owner-only configuration mutation for creating, updating, reordering, restoring, and archiving flairs
- disable raw generated writes so flair configuration goes through the validated custom mutation

## Behavior

The mutation treats the submitted flair list as authoritative: existing flairs omitted from the list are archived, not deleted. Active flair names and order values must be unique, and a channel cannot require flair selection without at least one active flair.

This PR intentionally stops at the Phase 1 backend foundation. Assigning flairs to submissions and enforcing required selections during discussion creation remain in later phases.

## Validation

- `pnpm run codegen`
- `pnpm run tsc`
- ESLint on all changed TypeScript files
- focused flair unit tests: 11 passed
- authorization schema tests: 23 passed
- full non-integration suite: 1,037 passed
- Neo4j integration test: 1 passed (create, update, soft archive, management read, and archived-only active read)
