### PR TITLE
Authorize channel moderators to rerun download pipelines

### DIFF
--- a/customResolvers/mutations/rerunPluginPipeline.test.ts
+++ b/customResolvers/mutations/rerunPluginPipeline.test.ts
@@ -132,6 +132,12 @@ const makeInput = ({
         id: "file-1",
         uploadedByUsername: "alice",
         uploadedAt: "2025-01-01T00:00:00.000Z",
+        Discussion: {
+          Author: { username: "alice" },
+          DiscussionChannels: [
+            { channelUniqueName: "cats", archived: false },
+          ],
+        },
       },
     ],
   }),

--- a/customResolvers/mutations/rerunPluginPipeline.ts
+++ b/customResolvers/mutations/rerunPluginPipeline.ts
@@ -8,7 +8,7 @@ import {
   PluginPipelineRunTrigger,
 } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
-import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import { hasChannelModPermission } from "../../rules/permission/hasChannelModPermission.js";
 import {
   triggerChannelPluginPipeline,
   triggerPluginRunsForDownloadableFile,
@@ -63,7 +63,8 @@ const timestamp = (value: unknown): number => Date.parse(String(value));
 
 export const createRerunPluginPipelineResolver = (
   input: RerunPluginPipelineInput,
-  checkServerModPermission: typeof hasServerModPermission = hasServerModPermission,
+  checkChannelModPermission: typeof hasChannelModPermission =
+    hasChannelModPermission,
   triggerDownloadRuns: typeof triggerPluginRunsForDownloadableFile =
     triggerPluginRunsForDownloadableFile,
   triggerChannelRuns: typeof triggerChannelPluginPipeline =
@@ -198,7 +199,7 @@ export const createRerunPluginPipelineResolver = (
     });
     const startResolver = createStartPluginPipelineResolver(
       input,
-      checkServerModPermission,
+      checkChannelModPermission,
       ((args, options) =>
         triggerDownloadRuns(args, withRetryMetadata(options))) as typeof triggerDownloadRuns,
       ((args, options) =>

--- a/customResolvers/mutations/retryDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.test.ts
@@ -85,7 +85,15 @@ test("lets an authorized moderator retry someone else's scan", async () => {
   };
   const resolver = createRetryDownloadableFileScanResolver(
     baseInput({
-      file: { uploadedByUsername: "alice", scanStatus: "SUSPICIOUS" },
+      file: {
+        uploadedByUsername: "alice",
+        scanStatus: "SUSPICIOUS",
+        Discussion: {
+          DiscussionChannels: [
+            { channelUniqueName: "cats", archived: false },
+          ],
+        },
+      },
     }),
     async () => true,
     triggerRuns

--- a/customResolvers/mutations/retryDownloadableFileScan.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.ts
@@ -3,7 +3,10 @@ import type {
 } from "../../ogm_types.js";
 import { PluginPipelineRunStatus } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
-import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import {
+  hasChannelModPermission,
+  ModChannelPermission,
+} from "../../rules/permission/hasChannelModPermission.js";
 import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
 import { createRerunPluginPipelineResolver } from "./rerunPluginPipeline.js";
 
@@ -23,12 +26,19 @@ export type RetryDownloadableFileScanInput = Pick<
 type FileRecord = {
   uploadedByUsername?: string | null;
   scanStatus?: string | null;
-  Discussion?: { Author?: { username?: string | null } | null } | null;
+  Discussion?: {
+    Author?: { username?: string | null } | null;
+    DiscussionChannels?: Array<{
+      channelUniqueName?: string | null;
+      archived?: boolean | null;
+    }>;
+  } | null;
 };
 
 export const createRetryDownloadableFileScanResolver = (
   input: RetryDownloadableFileScanInput,
-  checkServerModPermission: typeof hasServerModPermission = hasServerModPermission,
+  checkChannelModPermission: typeof hasChannelModPermission =
+    hasChannelModPermission,
   triggerRuns: typeof triggerPluginRunsForDownloadableFile =
     triggerPluginRunsForDownloadableFile,
   createRerunResolver: typeof createRerunPluginPipelineResolver =
@@ -44,7 +54,13 @@ export const createRetryDownloadableFileScanResolver = (
       selectionSet: `{
         uploadedByUsername
         scanStatus
-        Discussion { Author { username } }
+        Discussion {
+          Author { username }
+          DiscussionChannels {
+            channelUniqueName
+            archived
+          }
+        }
       }`,
     }) as FileRecord[];
     const file = files[0];
@@ -60,10 +76,22 @@ export const createRetryDownloadableFileScanResolver = (
       file.Discussion?.Author?.username === username
     );
     if (!isCreator) {
-      const canReview = await checkServerModPermission(
-        "canPermanentlyRemoveImage",
-        context
-      );
+      let canReview = false;
+      const channelNames = (file.Discussion?.DiscussionChannels || [])
+        .filter(item => item.archived !== true)
+        .map(item => item.channelUniqueName)
+        .filter((name): name is string => Boolean(name));
+      for (const channelName of channelNames) {
+        const permissionResult = await checkChannelModPermission({
+          permission: ModChannelPermission.canEditDiscussions,
+          channelName,
+          context,
+        });
+        if (permissionResult === true) {
+          canReview = true;
+          break;
+        }
+      }
       if (canReview !== true) throw new Error("Not authorized to retry this scan");
     }
 
@@ -91,7 +119,7 @@ export const createRetryDownloadableFileScanResolver = (
     if (sourceAttempt) {
       const rerun = createRerunResolver(
         input,
-        checkServerModPermission,
+        checkChannelModPermission,
         triggerRuns
       );
       const newAttempt = await rerun(

--- a/customResolvers/mutations/startPluginPipeline.test.ts
+++ b/customResolvers/mutations/startPluginPipeline.test.ts
@@ -16,6 +16,9 @@ type ChannelTrigger = NonNullable<
 >;
 type DownloadTriggerOptions = NonNullable<Parameters<DownloadTrigger>[1]>;
 type ChannelTriggerOptions = NonNullable<Parameters<ChannelTrigger>[1]>;
+type CheckChannelModPermission = NonNullable<
+  Parameters<typeof createStartPluginPipelineResolver>[1]
+>;
 
 const EVENT = PLUGIN_EVENTS.DOWNLOADABLE_FILE_CREATED;
 
@@ -59,6 +62,12 @@ const makeInput = ({
     id: "file-1",
     uploadedByUsername: "alice",
     uploadedAt: "2025-01-01T00:00:00.000Z",
+    Discussion: {
+      Author: { username: "alice" },
+      DiscussionChannels: [
+        { channelUniqueName: "cats", archived: false },
+      ],
+    },
   },
   config = requiredConfig,
   activeAttempts = [] as unknown[],
@@ -144,13 +153,18 @@ test("lets the uploader start a required missing pipeline", async () => {
 test("records a moderator start for someone else's download", async () => {
   const { input } = makeInput();
   let trigger: string | undefined;
+  let permissionInput: Parameters<CheckChannelModPermission>[0] | undefined;
   const triggerDownloadRuns: DownloadTrigger = async (_args, options = {}) => {
     trigger = options.execution?.trigger;
     return [];
   };
+  const checkChannelModPermission: CheckChannelModPermission = async args => {
+    permissionInput = args;
+    return true;
+  };
   const resolver = createStartPluginPipelineResolver(
     input,
-    async () => true,
+    checkChannelModPermission,
     triggerDownloadRuns
   );
 
@@ -164,7 +178,18 @@ test("records a moderator start for someone else's download", async () => {
     contextFor("moderator")
   );
 
-  assert.equal(trigger, "MODERATOR_START");
+  assert.deepEqual(
+    {
+      trigger,
+      permission: permissionInput?.permission,
+      channelName: permissionInput?.channelName,
+    },
+    {
+      trigger: "MODERATOR_START",
+      permission: "canEditDiscussions",
+      channelName: "cats",
+    }
+  );
 });
 
 test("rejects a non-owner without moderation authority", async () => {
@@ -183,6 +208,39 @@ test("rejects a non-owner without moderation authority", async () => {
         eventType: EVENT,
       },
       contextFor("bob")
+    ),
+    /Not authorized/
+  );
+});
+
+test("does not use moderation authority from an unrelated channel", async () => {
+  const { input } = makeInput({
+    file: {
+      id: "file-1",
+      uploadedByUsername: "alice",
+      uploadedAt: "2025-01-01T00:00:00.000Z",
+      Discussion: {
+        Author: { username: "alice" },
+        DiscussionChannels: [
+          { channelUniqueName: "dogs", archived: false },
+        ],
+      },
+    },
+  });
+  const resolver = createStartPluginPipelineResolver(
+    input,
+    async ({ channelName }) => channelName === "cats"
+  );
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        targetId: "file-1",
+        targetType: "DownloadableFile",
+        eventType: EVENT,
+      },
+      contextFor("cats-moderator")
     ),
     /Not authorized/
   );

--- a/customResolvers/mutations/startPluginPipeline.ts
+++ b/customResolvers/mutations/startPluginPipeline.ts
@@ -10,7 +10,10 @@ import {
   PluginPipelineRunTrigger,
 } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
-import { hasServerModPermission } from "../../rules/permission/hasServerModPermission.js";
+import {
+  hasChannelModPermission,
+  ModChannelPermission,
+} from "../../rules/permission/hasChannelModPermission.js";
 import {
   triggerChannelPluginPipeline,
   triggerPluginRunsForDownloadableFile,
@@ -44,7 +47,13 @@ type StartPluginPipelineArgs = {
 
 type FileRecord = DownloadableFileType & {
   uploadedByUsername?: string | null;
-  Discussion?: { Author?: { username?: string | null } | null } | null;
+  Discussion?: {
+    Author?: { username?: string | null } | null;
+    DiscussionChannels?: Array<{
+      channelUniqueName?: string | null;
+      archived?: boolean | null;
+    }>;
+  } | null;
 };
 
 type DiscussionRecord = {
@@ -66,7 +75,8 @@ const userInputError = (message: string) =>
 
 export const createStartPluginPipelineResolver = (
   input: StartPluginPipelineInput,
-  checkServerModPermission: typeof hasServerModPermission = hasServerModPermission,
+  checkChannelModPermission: typeof hasChannelModPermission =
+    hasChannelModPermission,
   triggerDownloadRuns: typeof triggerPluginRunsForDownloadableFile =
     triggerPluginRunsForDownloadableFile,
   triggerChannelRuns: typeof triggerChannelPluginPipeline =
@@ -94,6 +104,7 @@ export const createStartPluginPipelineResolver = (
     let uploadedAt: string | null | undefined;
     let scope: "SERVER" | "CHANNEL";
     let channelId: string | null = null;
+    let moderationChannelNames: string[] = [];
     let pipelines: EventPipeline[] = [];
 
     if (targetType === "DownloadableFile") {
@@ -104,7 +115,13 @@ export const createStartPluginPipelineResolver = (
           uploadedAt
           createdAt
           uploadedByUsername
-          Discussion { Author { username } }
+          Discussion {
+            Author { username }
+            DiscussionChannels {
+              channelUniqueName
+              archived
+            }
+          }
         }`,
       })) as FileRecord[];
       const file = files[0];
@@ -117,6 +134,10 @@ export const createStartPluginPipelineResolver = (
       ownerUsername = file.Discussion?.Author?.username;
       uploaderUsername = file.uploadedByUsername;
       uploadedAt = file.uploadedAt || file.createdAt;
+      moderationChannelNames = (file.Discussion?.DiscussionChannels || [])
+        .filter(item => item.archived !== true)
+        .map(item => item.channelUniqueName)
+        .filter((name): name is string => Boolean(name));
     } else if (targetType === "Discussion") {
       if (!requestedChannelId) {
         throw userInputError(
@@ -162,6 +183,7 @@ export const createStartPluginPipelineResolver = (
       }
       scope = "CHANNEL";
       channelId = requestedChannelId;
+      moderationChannelNames = [requestedChannelId];
       pipelines = (channel.pluginPipelines || []) as EventPipeline[];
       ownerUsername = discussion.Author?.username;
       uploaderUsername = discussion.DownloadableFile?.uploadedByUsername;
@@ -177,10 +199,18 @@ export const createStartPluginPipelineResolver = (
     const isOwner =
       ownerUsername === username || uploaderUsername === username;
     if (!isOwner) {
-      const canModerate = await checkServerModPermission(
-        "canPermanentlyRemoveImage",
-        context
-      );
+      let canModerate = false;
+      for (const channelName of moderationChannelNames) {
+        const permissionResult = await checkChannelModPermission({
+          permission: ModChannelPermission.canEditDiscussions,
+          channelName,
+          context,
+        });
+        if (permissionResult === true) {
+          canModerate = true;
+          break;
+        }
+      }
       if (canModerate !== true) {
         throw new GraphQLError("Not authorized to start this pipeline", {
           extensions: { code: "FORBIDDEN" },


### PR DESCRIPTION
## Summary

- authorize moderators with canEditDiscussions in an active associated channel to start or rerun download pipelines
- prevent moderators from using permissions in unrelated or archived channels
- apply the same authorization rule to the deprecated download scan retry adapter
- preserve uploader and discussion-owner access

## Verification

- full backend unit suite passed
- focused resolver tests: 23 passed
- TypeScript passed
- ESLint passed
- focused changed-file line coverage exceeded 90%

## Coordination

This backend PR is paired with the multiforum-nuxt channel moderator pipeline controls PR.