### PR TITLE
Enforce discussion flairs on channel submissions

### DIFF
--- a/customResolvers/cypher/createDiscussionChannelQuery.cypher
+++ b/customResolvers/cypher/createDiscussionChannelQuery.cypher
@@ -1,6 +1,9 @@
 MATCH (d:Discussion {id: $discussionId}), (c:Channel {uniqueName: $channelUniqueName}), (u:User {username: $upvotedBy})
 OPTIONAL MATCH (dc:DiscussionChannel {discussionId: $discussionId, channelUniqueName: $channelUniqueName})
-WITH d, c, u, dc
+OPTIONAL MATCH (c)-[:HAS_DISCUSSION_FLAIR]->(selectedFlair:DiscussionFlair)
+WHERE selectedFlair.id IN $flairIds
+  AND coalesce(selectedFlair.archived, false) = false
+WITH d, c, u, dc, collect(selectedFlair) AS selectedFlairs
 WHERE dc IS NULL  // Skip creation if it already exists
 CREATE (newDc:DiscussionChannel {
     discussionId: $discussionId, 
@@ -11,13 +14,16 @@ CREATE (newDc:DiscussionChannel {
 })
 MERGE (newDc)-[:POSTED_IN_CHANNEL]->(d)
 MERGE (newDc)-[:POSTED_IN_CHANNEL]->(c)
+FOREACH (selectedFlair IN selectedFlairs |
+    MERGE (newDc)-[:HAS_DISCUSSION_FLAIR]->(selectedFlair)
+)
 MERGE (u)-[:UPVOTED_DISCUSSION]->(newDc)
 // Only subscribe to notifications if user has opted in
 FOREACH (ignoreMe IN CASE WHEN u.notifyOnReplyToDiscussionByDefault = true THEN [1] ELSE [] END |
     MERGE (u)-[:SUBSCRIBED_TO_NOTIFICATIONS]->(newDc)
 ) 
-WITH newDc, d, c, u
-WITH newDc, d, c, collect(u {username: u.username}) as upvotedByUsers
+WITH newDc, d, c, u, selectedFlairs
+WITH newDc, d, c, selectedFlairs, collect(u {username: u.username}) as upvotedByUsers
 RETURN {
     id: newDc.id,
     discussionId: newDc.discussionId,
@@ -25,5 +31,6 @@ RETURN {
     createdAt: newDc.createdAt,
     Discussion: d {.*},
     Channel: c {.*},
+    Flairs: [selectedFlair IN selectedFlairs | selectedFlair {.*}],
     UpvotedByUsers: upvotedByUsers
 } as discussionChannel

--- a/customResolvers/cypher/updateDiscussionChannelQuery.cypher
+++ b/customResolvers/cypher/updateDiscussionChannelQuery.cypher
@@ -11,5 +11,19 @@ MERGE (dc:DiscussionChannel {discussionId: $discussionId, channelUniqueName: $ch
 ON CREATE SET dc.id = apoc.create.uuid(), dc.createdAt = datetime()
 MERGE (dc)-[:POSTED_IN_CHANNEL]->(c)
 WITH d, dc, c
+OPTIONAL MATCH (dc)-[oldFlairRelationship:HAS_DISCUSSION_FLAIR]->(:DiscussionFlair)
+WITH d, dc, c, collect(oldFlairRelationship) AS oldFlairRelationships
+FOREACH (oldFlairRelationship IN CASE
+  WHEN $flairSelectionProvided THEN oldFlairRelationships
+  ELSE []
+END | DELETE oldFlairRelationship)
+WITH d, dc, c
+OPTIONAL MATCH (c)-[:HAS_DISCUSSION_FLAIR]->(selectedFlair:DiscussionFlair)
+WHERE selectedFlair.id IN $flairIds
+  AND coalesce(selectedFlair.archived, false) = false
+WITH d, dc, c, collect(selectedFlair) AS selectedFlairs
+FOREACH (selectedFlair IN selectedFlairs |
+  MERGE (dc)-[:HAS_DISCUSSION_FLAIR]->(selectedFlair)
+)
 MERGE (dc)-[:POSTED_IN_CHANNEL]->(d)
-RETURN dc, d, c
+RETURN dc, d, c, selectedFlairs

--- a/customResolvers/mutations/createDiscussionWithChannelConnections.test.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.test.ts
@@ -53,8 +53,30 @@ class DiscussionModelStub {
 class SessionStub {
   runCalls: Array<{ query: string; params: Record<string, unknown> }> = [];
   shouldFailConstraint = false;
+  flairRequirements = new Map<
+    string,
+    { flairRequired: boolean; activeFlairIds: string[] }
+  >();
 
   async run(query: string, params: Record<string, unknown>) {
+    if (query.includes("requestedChannelUniqueName")) {
+      const channelUniqueNames = params.channelUniqueNames as string[];
+      return {
+        records: channelUniqueNames.map((channelUniqueName) => {
+          const requirements = this.flairRequirements.get(channelUniqueName) ?? {
+            flairRequired: false,
+            activeFlairIds: [],
+          };
+          const values: Record<string, unknown> = {
+            requestedChannelUniqueName: channelUniqueName,
+            channelExists: true,
+            ...requirements,
+          };
+          return { get: (key: string) => values[key] };
+        }),
+      };
+    }
+
     this.runCalls.push({ query, params });
     if (this.shouldFailConstraint) {
       throw new Error("Constraint validation failed");
@@ -131,6 +153,77 @@ test("createDiscussionWithChannelConnections", async (t) => {
     assert.equal(discussionModel.createCalls.length, 1);
     assert.equal(session.runCalls.length, 1);
     assert.equal(session.runCalls[0].params.channelUniqueName, "test-channel");
+    assert.deepEqual(session.runCalls[0].params.flairIds, []);
+  });
+
+  await t.test("assigns active flairs independently for each channel", async () => {
+    const discussionModel = new DiscussionModelStub();
+    const session = new SessionStub();
+    session.flairRequirements.set("cats", {
+      flairRequired: true,
+      activeFlairIds: ["question", "help"],
+    });
+    session.flairRequirements.set("dogs", {
+      flairRequired: false,
+      activeFlairIds: ["showcase"],
+    });
+
+    await createDiscussionsFromInput(
+      discussionModel as unknown as DiscussionModel,
+      createDriver(session),
+      [
+        {
+          discussionCreateInput: { title: "Multi-forum post" },
+          channelConnections: ["cats", "dogs"],
+          channelFlairSelections: [
+            { channelUniqueName: "cats", flairIds: ["question", "help"] },
+            { channelUniqueName: "dogs", flairIds: ["showcase"] },
+          ],
+        },
+      ]
+    );
+
+    assert.deepEqual(
+      session.runCalls.map(({ params }) => [
+        params.channelUniqueName,
+        params.flairIds,
+      ]),
+      [
+        ["cats", ["question", "help"]],
+        ["dogs", ["showcase"]],
+      ]
+    );
+  });
+
+  await t.test("validates every batch item before creating any discussion", async () => {
+    const discussionModel = new DiscussionModelStub();
+    const session = new SessionStub();
+    session.flairRequirements.set("required", {
+      flairRequired: true,
+      activeFlairIds: ["question"],
+    });
+
+    await assert.rejects(
+      () =>
+        createDiscussionsFromInput(
+          discussionModel as unknown as DiscussionModel,
+          createDriver(session),
+          [
+            {
+              discussionCreateInput: { title: "Valid first item" },
+              channelConnections: ["optional"],
+            },
+            {
+              discussionCreateInput: { title: "Invalid second item" },
+              channelConnections: ["required"],
+            },
+          ]
+        ),
+      /At least one flair is required for channel 'required'/
+    );
+
+    assert.equal(discussionModel.createCalls.length, 0);
+    assert.equal(session.runCalls.length, 0);
   });
 
   await t.test("creates discussion with multiple channel connections", async () => {

--- a/customResolvers/mutations/createDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.ts
@@ -8,6 +8,11 @@ import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunct
 import { sanitizeAlbumCreateNode } from "./utils/ownershipSanitizers.js";
 import type { GraphQLContext } from "../../types/context.js";
 import { logger } from "../../logger.js";
+import {
+  loadChannelDiscussionFlairRequirements,
+  validateDiscussionFlairSelections,
+  type DiscussionChannelFlairSelectionInput,
+} from "../../services/discussionFlairSubmission.js";
 import type {
   DiscussionModel,
   ChannelModel,
@@ -22,6 +27,7 @@ import type {
 type DiscussionCreateInputWithChannels = {
   discussionCreateInput: DiscussionCreateInput;
   channelConnections: string[];
+  channelFlairSelections?: DiscussionChannelFlairSelectionInput[] | null;
 };
 
 type Args = {
@@ -73,6 +79,14 @@ const selectionSet = `
       channelUniqueName
       discussionId
       archived
+      Flairs {
+        id
+        channelUniqueName
+        displayName
+        color
+        order
+        archived
+      }
       Channel {
         uniqueName
       }
@@ -138,39 +152,72 @@ export const createDiscussionsFromInput = async (
       throw new GraphQLError("You must be logged in to create albums.");
     }
 
-    sanitizedInput = input.map(({ discussionCreateInput, channelConnections }) => {
-      const albumCreate = discussionCreateInput?.Album?.create;
-      const albumCreateNode = albumCreate?.node;
+    sanitizedInput = input.map(
+      ({
+        discussionCreateInput,
+        channelConnections,
+        channelFlairSelections,
+      }) => {
+        const albumCreate = discussionCreateInput?.Album?.create;
+        const albumCreateNode = albumCreate?.node;
 
-      if (!albumCreateNode) {
-        return { discussionCreateInput, channelConnections };
-      }
+        if (!albumCreateNode) {
+          return {
+            discussionCreateInput,
+            channelConnections,
+            channelFlairSelections,
+          };
+        }
 
-      return {
-        discussionCreateInput: {
-          ...discussionCreateInput,
-          Album: {
-            ...discussionCreateInput?.Album,
-            create: {
-              ...(albumCreate ?? {}),
-              node: sanitizeAlbumCreateNode(albumCreateNode, username),
+        return {
+          discussionCreateInput: {
+            ...discussionCreateInput,
+            Album: {
+              ...discussionCreateInput?.Album,
+              create: {
+                ...(albumCreate ?? {}),
+                node: sanitizeAlbumCreateNode(albumCreateNode, username),
+              },
             },
           },
-        },
-        channelConnections,
-      };
-    }) as DiscussionCreateInputWithChannels[];
+          channelConnections,
+          channelFlairSelections,
+        };
+      }
+    ) as DiscussionCreateInputWithChannels[];
   }
 
   const session = driver.session();
   const discussions: unknown[] = [];
 
   try {
-    for (const { discussionCreateInput, channelConnections } of sanitizedInput) {
+    for (const { channelConnections } of sanitizedInput) {
       if (!channelConnections || channelConnections.length === 0) {
         throw new Error("At least one channel must be selected");
       }
+    }
 
+    const uniqueChannelNames = [
+      ...new Set(
+        sanitizedInput.flatMap(({ channelConnections }) => channelConnections)
+      ),
+    ];
+    const requirementsByChannel =
+      await loadChannelDiscussionFlairRequirements({
+        executor: session,
+        channelUniqueNames: uniqueChannelNames,
+      });
+    const flairIdsByInput = sanitizedInput.map(
+      ({ channelConnections, channelFlairSelections }) =>
+        validateDiscussionFlairSelections({
+          channelConnections,
+          channelFlairSelections,
+          requirementsByChannel,
+        })
+    );
+
+    for (const [inputIndex, { discussionCreateInput, channelConnections }] of
+      sanitizedInput.entries()) {
       const response = await Discussion.create({
         input: [discussionCreateInput],
         selectionSet: `{ discussions ${selectionSet} }`,
@@ -189,6 +236,7 @@ export const createDiscussionsFromInput = async (
             discussionId: newDiscussionId,
             channelUniqueName,
             upvotedBy: newDiscussion.Author?.username,
+            flairIds: flairIdsByInput[inputIndex].get(channelUniqueName) ?? [],
           });
 
           // Trigger channel plugin pipeline if discussion has a download
@@ -277,6 +325,9 @@ export const createDiscussionsFromInput = async (
     }
   } catch (error: unknown) {
     logger.error("Error creating discussions:", error);
+    if (error instanceof GraphQLError) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to create discussions: ${message}`);
   } finally {
@@ -322,6 +373,9 @@ const getResolver = (input: Input) => {
       return discussions;
     } catch (error: unknown) {
       logger.error(error);
+      if (error instanceof GraphQLError) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`An error occurred while creating discussions: ${message}`);
     }

--- a/customResolvers/mutations/shareCollectionAsDiscussion.test.ts
+++ b/customResolvers/mutations/shareCollectionAsDiscussion.test.ts
@@ -8,6 +8,7 @@ import type {
   DiscussionModel,
 } from "../../ogm_types.js";
 import type { GraphQLContext } from "../../types/context.js";
+import { GraphQLError } from "graphql";
 import shareCollectionAsDiscussion from "./shareCollectionAsDiscussion.js";
 
 let originalMockAuth: string | undefined;
@@ -128,6 +129,7 @@ test("shareCollectionAsDiscussion creates a discussion linked to a public owned 
       serverId: "sims4_builds",
       title: "Shared builds",
       shareMessage: "Some favorites from my library",
+      flairIds: ["showcase"],
     },
     buildContext(),
     {} as never
@@ -142,6 +144,12 @@ test("shareCollectionAsDiscussion creates a discussion linked to a public owned 
 
   const createInput = (calls.createDiscussions[0] as any)[2][0];
   assert.deepEqual(createInput.channelConnections, ["sims4_builds"]);
+  assert.deepEqual(createInput.channelFlairSelections, [
+    {
+      channelUniqueName: "sims4_builds",
+      flairIds: ["showcase"],
+    },
+  ]);
   assert.equal(createInput.discussionCreateInput.title, "Shared builds");
   assert.equal(createInput.discussionCreateInput.body, "Some favorites from my library");
   assert.deepEqual(
@@ -235,5 +243,33 @@ test("shareCollectionAsDiscussion rejects unknown target forums", async () => {
       {} as never
     ),
     /Forum not found/
+  );
+});
+
+test("shareCollectionAsDiscussion preserves flair validation error metadata", async () => {
+  const flairError = new GraphQLError("A flair is required.", {
+    extensions: {
+      code: "DISCUSSION_FLAIR_REQUIRED",
+      channelUniqueName: "sims4_builds",
+    },
+  });
+  const { resolver } = buildResolver({
+    createDiscussions: async () => {
+      throw flairError;
+    },
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      {
+        collectionId: "collection-1",
+        serverId: "sims4_builds",
+        title: "Shared builds",
+      },
+      buildContext(),
+      {} as never
+    ),
+    (error: unknown) => error === flairError
   );
 });

--- a/customResolvers/mutations/shareCollectionAsDiscussion.ts
+++ b/customResolvers/mutations/shareCollectionAsDiscussion.ts
@@ -20,6 +20,7 @@ type Args = {
   title: string;
   content?: string | null;
   shareMessage?: string | null;
+  flairIds?: string[] | null;
 };
 
 type CollectionRecord = {
@@ -89,6 +90,7 @@ const getResolver = (input: Input) => {
     const channelUniqueName = getTrimmed(args.serverId);
     const title = getTrimmed(args.title);
     const body = getTrimmed(args.shareMessage) || getTrimmed(args.content);
+    const flairIds = args.flairIds ?? [];
 
     if (!collectionId) {
       throw new GraphQLError("Collection ID is required.");
@@ -179,6 +181,9 @@ const getResolver = (input: Input) => {
               },
             },
             channelConnections: [channelUniqueName],
+            channelFlairSelections: [
+              { channelUniqueName, flairIds },
+            ],
           },
         ],
         context
@@ -187,6 +192,9 @@ const getResolver = (input: Input) => {
       return discussions[0];
     } catch (error: unknown) {
       logger.error("Error sharing collection as discussion:", error);
+      if (error instanceof GraphQLError) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       throw new GraphQLError(`Failed to share collection: ${message}`);
     }

--- a/customResolvers/mutations/updateDiscussionWithChannelConnections.test.ts
+++ b/customResolvers/mutations/updateDiscussionWithChannelConnections.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import jwt from "jsonwebtoken";
+import getUpdateDiscussionWithChannelConnections from "./updateDiscussionWithChannelConnections.js";
 
 // Since the resolver is the default export wrapped in getResolver,
 // we test the key behaviors that the resolver should exhibit
@@ -62,8 +63,30 @@ class DiscussionModelStub {
 
 class SessionStub {
   runCalls: Array<{ query: string; params: Record<string, unknown> }> = [];
+  flairRequirements = new Map<
+    string,
+    { flairRequired: boolean; activeFlairIds: string[] }
+  >();
 
   async run(query: string, params: Record<string, unknown>) {
+    if (query.includes("requestedChannelUniqueName")) {
+      const channelUniqueNames = params.channelUniqueNames as string[];
+      return {
+        records: channelUniqueNames.map((channelUniqueName) => {
+          const requirements = this.flairRequirements.get(channelUniqueName) ?? {
+            flairRequired: false,
+            activeFlairIds: [],
+          };
+          const values: Record<string, unknown> = {
+            requestedChannelUniqueName: channelUniqueName,
+            channelExists: true,
+            ...requirements,
+          };
+          return { get: (key: string) => values[key] };
+        }),
+      };
+    }
+
     this.runCalls.push({ query, params });
     return { records: [] };
   }
@@ -285,6 +308,86 @@ test("updateDiscussionWithChannelConnections behaviors", async (t) => {
     assert.equal((result[0] as any).body, "Original body");
     // Title should be updated
     assert.equal((result[0] as any).title, "Only Title Changed");
+  });
+});
+
+test("updateDiscussionWithChannelConnections enforces and assigns flairs", async (t) => {
+  const buildResolver = (
+    discussionModel: DiscussionModelStub,
+    session: SessionStub
+  ) =>
+    getUpdateDiscussionWithChannelConnections({
+      Discussion: discussionModel as never,
+      DownloadableFile: {} as never,
+      PluginPipelineRun: {} as never,
+      PluginRun: {} as never,
+      ServerConfig: {} as never,
+      ServerSecret: {} as never,
+      User: {} as never,
+      driver: createDriver(session) as never,
+    });
+
+  await t.test("validates before changing the discussion", async () => {
+    const discussionModel = new DiscussionModelStub();
+    const session = new SessionStub();
+    session.flairRequirements.set("required", {
+      flairRequired: true,
+      activeFlairIds: ["question"],
+    });
+    const resolver = buildResolver(discussionModel, session);
+
+    await assert.rejects(
+      () =>
+        resolver(
+          null,
+          {
+            where: { id: "discussion-1" },
+            discussionUpdateInput: {},
+            channelConnections: ["required"],
+          },
+          createContext() as never,
+          {} as never
+        ),
+      /At least one flair is required for channel 'required'/
+    );
+
+    assert.equal(discussionModel.updateCalls.length, 0);
+    assert.equal(session.runCalls.length, 0);
+  });
+
+  await t.test("passes the selected flairs to the channel connection", async () => {
+    const discussionModel = new DiscussionModelStub();
+    const session = new SessionStub();
+    session.flairRequirements.set("required", {
+      flairRequired: true,
+      activeFlairIds: ["question", "help"],
+    });
+    const resolver = buildResolver(discussionModel, session);
+
+    await resolver(
+      null,
+      {
+        where: { id: "discussion-1" },
+        discussionUpdateInput: {},
+        channelConnections: ["required"],
+        channelFlairSelections: [
+          {
+            channelUniqueName: "required",
+            flairIds: ["question", "help"],
+          },
+        ],
+      },
+      createContext() as never,
+      {} as never
+    );
+
+    assert.equal(discussionModel.updateCalls.length, 1);
+    assert.deepEqual(session.runCalls[0].params, {
+      discussionId: "discussion-1",
+      channelUniqueName: "required",
+      flairIds: ["question", "help"],
+      flairSelectionProvided: true,
+    });
   });
 });
 

--- a/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
@@ -17,6 +17,11 @@ import type {
 } from "../../ogm_types.js";
 import { triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
 import { logger } from "../../logger.js";
+import {
+  loadChannelDiscussionFlairRequirements,
+  validateDiscussionFlairSelections,
+  type DiscussionChannelFlairSelectionInput,
+} from "../../services/discussionFlairSubmission.js";
 
 type Input = {
   Discussion: DiscussionModel;
@@ -34,6 +39,7 @@ type Args = {
   discussionUpdateInput: DiscussionUpdateInput;
   channelConnections?: string[];
   channelDisconnections?: string[];
+  channelFlairSelections?: DiscussionChannelFlairSelectionInput[] | null;
 };
 
 export const getConnectedDownloadableFileIds = (
@@ -67,8 +73,10 @@ const getResolver = (
       where,
       discussionUpdateInput,
       channelConnections = [],
-      channelDisconnections = []
+      channelDisconnections = [],
+      channelFlairSelections = [],
     } = args;
+    const normalizedChannelFlairSelections = channelFlairSelections ?? [];
 
     let sanitizedUpdateInput = discussionUpdateInput;
     const albumInput = discussionUpdateInput?.Album;
@@ -113,6 +121,28 @@ const getResolver = (
           ...discussionUpdateInput,
           Album: nextAlbumInput,
         };
+      }
+    }
+
+    let flairIdsByChannel = new Map<string, string[]>();
+    if (
+      channelConnections.length > 0 ||
+      normalizedChannelFlairSelections.length > 0
+    ) {
+      const flairValidationSession = driver.session();
+      try {
+        const requirementsByChannel =
+          await loadChannelDiscussionFlairRequirements({
+            executor: flairValidationSession,
+            channelUniqueNames: [...new Set(channelConnections)],
+          });
+        flairIdsByChannel = validateDiscussionFlairSelections({
+          channelConnections,
+          channelFlairSelections: normalizedChannelFlairSelections,
+          requirementsByChannel,
+        });
+      } finally {
+        await flairValidationSession.close();
       }
     }
     
@@ -172,6 +202,9 @@ const getResolver = (
       // Update the channel connections
       for (let i = 0; i < channelConnections.length; i++) {
         const channelUniqueName = channelConnections[i];
+        const flairSelectionProvided = normalizedChannelFlairSelections.some(
+          (selection) => selection.channelUniqueName.trim() === channelUniqueName
+        );
 
         // For each channel connection, create a DiscussionChannel node
         // if one does not already exist.
@@ -182,6 +215,8 @@ const getResolver = (
         await session.run(updateDiscussionChannelQuery, {
           discussionId: updatedDiscussionId,
           channelUniqueName: channelUniqueName,
+          flairIds: flairIdsByChannel.get(channelUniqueName) ?? [],
+          flairSelectionProvided,
         });
       }
 
@@ -214,6 +249,14 @@ const getResolver = (
             id
             channelUniqueName
             discussionId
+            Flairs {
+              id
+              channelUniqueName
+              displayName
+              color
+              order
+              archived
+            }
             Channel {
               uniqueName
             }

--- a/services/discussionFlairSubmission.test.ts
+++ b/services/discussionFlairSubmission.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  validateDiscussionFlairSelections,
+  type ChannelDiscussionFlairRequirements,
+} from "./discussionFlairSubmission.js";
+
+const requirements = (
+  entries: Array<[string, boolean, string[]]>
+): Map<string, ChannelDiscussionFlairRequirements> =>
+  new Map(
+    entries.map(([channelUniqueName, flairRequired, activeFlairIds]) => [
+      channelUniqueName,
+      {
+        channelUniqueName,
+        flairRequired,
+        activeFlairIds: new Set(activeFlairIds),
+      },
+    ])
+  );
+
+test("returns channel-specific active flair assignments", () => {
+  const result = validateDiscussionFlairSelections({
+    channelConnections: ["cats", "dogs", "birds"],
+    channelFlairSelections: [
+      { channelUniqueName: "cats", flairIds: ["question", "help"] },
+      { channelUniqueName: "dogs", flairIds: ["showcase"] },
+    ],
+    requirementsByChannel: requirements([
+      ["cats", true, ["question", "help"]],
+      ["dogs", false, ["showcase"]],
+      ["birds", false, []],
+    ]),
+  });
+
+  assert.deepEqual([...result], [
+    ["cats", ["question", "help"]],
+    ["dogs", ["showcase"]],
+    ["birds", []],
+  ]);
+});
+
+test("rejects a required channel without a selection", () => {
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats"],
+        requirementsByChannel: requirements([["cats", true, ["question"]]]),
+      }),
+    /At least one flair is required for channel 'cats'/
+  );
+});
+
+test("rejects missing channels and inactive or cross-channel flairs", () => {
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["missing"],
+        requirementsByChannel: requirements([]),
+      }),
+    /Channel 'missing' was not found/
+  );
+
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats"],
+        channelFlairSelections: [
+          { channelUniqueName: "cats", flairIds: ["archived-or-foreign"] },
+        ],
+        requirementsByChannel: requirements([["cats", false, ["question"]]]),
+      }),
+    /is not active in channel 'cats'/
+  );
+});
+
+test("rejects selections for an unconnected channel", () => {
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats"],
+        channelFlairSelections: [
+          { channelUniqueName: "dogs", flairIds: ["question"] },
+        ],
+        requirementsByChannel: requirements([["cats", false, []]]),
+      }),
+    /must belong to one of the discussion's selected channels/
+  );
+});
+
+test("rejects duplicate channels, selection blocks, and flair IDs", () => {
+  const configs = requirements([["cats", false, ["question"]]]);
+
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats", "cats"],
+        requirementsByChannel: configs,
+      }),
+    /selected more than once/
+  );
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats"],
+        channelFlairSelections: [
+          { channelUniqueName: "cats", flairIds: [] },
+          { channelUniqueName: "cats", flairIds: [] },
+        ],
+        requirementsByChannel: configs,
+      }),
+    /submitted more than once/
+  );
+  assert.throws(
+    () =>
+      validateDiscussionFlairSelections({
+        channelConnections: ["cats"],
+        channelFlairSelections: [
+          { channelUniqueName: "cats", flairIds: ["question", "question"] },
+        ],
+        requirementsByChannel: configs,
+      }),
+    /must be non-empty and unique/
+  );
+});

--- a/services/discussionFlairSubmission.ts
+++ b/services/discussionFlairSubmission.ts
@@ -1,0 +1,157 @@
+import { GraphQLError } from "graphql";
+import type { Record as Neo4jRecord } from "neo4j-driver";
+import type { CypherExecutor } from "./discussionFlairStore.js";
+
+export type DiscussionChannelFlairSelectionInput = {
+  channelUniqueName: string;
+  flairIds: string[];
+};
+
+export type ChannelDiscussionFlairRequirements = {
+  channelUniqueName: string;
+  flairRequired: boolean;
+  activeFlairIds: Set<string>;
+};
+
+const invalidSelection = (
+  message: string,
+  channelUniqueName?: string
+) =>
+  new GraphQLError(message, {
+    extensions: {
+      code: "INVALID_DISCUSSION_FLAIR",
+      ...(channelUniqueName ? { channelUniqueName } : {}),
+    },
+  });
+
+export const loadChannelDiscussionFlairRequirements = async ({
+  executor,
+  channelUniqueNames,
+}: {
+  executor: CypherExecutor;
+  channelUniqueNames: string[];
+}): Promise<Map<string, ChannelDiscussionFlairRequirements>> => {
+  const result = await executor.run(
+    `
+      UNWIND $channelUniqueNames AS requestedChannelUniqueName
+      OPTIONAL MATCH (channel:Channel {uniqueName: requestedChannelUniqueName})
+      OPTIONAL MATCH (channel)-[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair)
+      WHERE coalesce(flair.archived, false) = false
+      WITH requestedChannelUniqueName, channel, flair
+      ORDER BY flair.order ASC, flair.displayName ASC
+      RETURN requestedChannelUniqueName,
+             channel IS NOT NULL AS channelExists,
+             coalesce(channel.discussionFlairRequired, false) AS flairRequired,
+             collect(flair.id) AS activeFlairIds
+    `,
+    { channelUniqueNames }
+  );
+
+  return new Map(
+    result.records
+      .filter((record: Neo4jRecord) => record.get("channelExists") === true)
+      .map((record: Neo4jRecord) => {
+        const channelUniqueName = record.get(
+          "requestedChannelUniqueName"
+        ) as string;
+        return [
+          channelUniqueName,
+          {
+            channelUniqueName,
+            flairRequired: record.get("flairRequired") === true,
+            activeFlairIds: new Set(
+              (record.get("activeFlairIds") ?? []).filter(Boolean)
+            ),
+          },
+        ];
+      })
+  );
+};
+
+export const validateDiscussionFlairSelections = ({
+  channelConnections,
+  channelFlairSelections = [],
+  requirementsByChannel,
+}: {
+  channelConnections: string[];
+  channelFlairSelections?: DiscussionChannelFlairSelectionInput[] | null;
+  requirementsByChannel: Map<string, ChannelDiscussionFlairRequirements>;
+}): Map<string, string[]> => {
+  const connectedChannels = new Set<string>();
+  for (const channelUniqueName of channelConnections) {
+    if (!channelUniqueName?.trim()) {
+      throw invalidSelection("Channel unique names cannot be empty.");
+    }
+    if (connectedChannels.has(channelUniqueName)) {
+      throw invalidSelection(
+        `Channel '${channelUniqueName}' was selected more than once.`,
+        channelUniqueName
+      );
+    }
+    connectedChannels.add(channelUniqueName);
+  }
+
+  const flairIdsByChannel = new Map<string, string[]>();
+  for (const selection of channelFlairSelections ?? []) {
+    const channelUniqueName = selection.channelUniqueName?.trim();
+    if (!channelUniqueName || !connectedChannels.has(channelUniqueName)) {
+      throw invalidSelection(
+        `Flair selections must belong to one of the discussion's selected channels.`,
+        channelUniqueName
+      );
+    }
+    if (flairIdsByChannel.has(channelUniqueName)) {
+      throw invalidSelection(
+        `Flairs for channel '${channelUniqueName}' were submitted more than once.`,
+        channelUniqueName
+      );
+    }
+
+    const flairIds = selection.flairIds ?? [];
+    if (new Set(flairIds).size !== flairIds.length || flairIds.some((id) => !id)) {
+      throw invalidSelection(
+        `Flair IDs for channel '${channelUniqueName}' must be non-empty and unique.`,
+        channelUniqueName
+      );
+    }
+    flairIdsByChannel.set(channelUniqueName, flairIds);
+  }
+
+  for (const channelUniqueName of connectedChannels) {
+    const requirements = requirementsByChannel.get(channelUniqueName);
+    if (!requirements) {
+      throw new GraphQLError(`Channel '${channelUniqueName}' was not found.`, {
+        extensions: { code: "CHANNEL_NOT_FOUND", channelUniqueName },
+      });
+    }
+
+    const flairIds = flairIdsByChannel.get(channelUniqueName) ?? [];
+    if (requirements.flairRequired && flairIds.length === 0) {
+      throw new GraphQLError(
+        `At least one flair is required for channel '${channelUniqueName}'.`,
+        {
+          extensions: {
+            code: "DISCUSSION_FLAIR_REQUIRED",
+            channelUniqueName,
+          },
+        }
+      );
+    }
+
+    const invalidFlairId = flairIds.find(
+      (flairId) => !requirements.activeFlairIds.has(flairId)
+    );
+    if (invalidFlairId) {
+      throw invalidSelection(
+        `Flair '${invalidFlairId}' is not active in channel '${channelUniqueName}'.`,
+        channelUniqueName
+      );
+    }
+
+    if (!flairIdsByChannel.has(channelUniqueName)) {
+      flairIdsByChannel.set(channelUniqueName, []);
+    }
+  }
+
+  return flairIdsByChannel;
+};

--- a/tests/integration/discussionFlairSubmission.test.ts
+++ b/tests/integration/discussionFlairSubmission.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import test, { after, before, beforeEach } from "node:test";
+import {
+  resetDb,
+  run,
+  startImageModEnv,
+  stopImageModEnv,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(
+  async () => {
+    env = await startImageModEnv();
+  },
+  { timeout: 240000 }
+);
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await run(`CREATE (:User {username: 'poster'})`);
+});
+
+const discussionInput = (
+  title: string,
+  channelConnections: string[],
+  channelFlairSelections: Array<{
+    channelUniqueName: string;
+    flairIds: string[];
+  }> = []
+) => ({
+  discussionCreateInput: {
+    title,
+    Author: {
+      connect: { where: { node: { username: "poster" } } },
+    },
+  },
+  channelConnections,
+  channelFlairSelections,
+});
+
+const createDiscussions = (input: ReturnType<typeof discussionInput>[]) =>
+  env.resolvers.Mutation.createDiscussionWithChannelConnections(
+    null,
+    { input },
+    { user: { username: "poster" } }
+  );
+
+test("assigns different active flairs to each channel submission", async () => {
+  await run(
+    `
+      CREATE (cats:Channel {
+        uniqueName: 'cats',
+        discussionFlairRequired: true,
+        createdAt: datetime()
+      })
+      CREATE (dogs:Channel {
+        uniqueName: 'dogs',
+        discussionFlairRequired: false,
+        createdAt: datetime()
+      })
+      CREATE (question:DiscussionFlair {
+        id: 'question',
+        channelUniqueName: 'cats',
+        displayName: 'Question',
+        order: 0,
+        archived: false
+      })
+      CREATE (help:DiscussionFlair {
+        id: 'help',
+        channelUniqueName: 'cats',
+        displayName: 'Help',
+        order: 1,
+        archived: false
+      })
+      CREATE (showcase:DiscussionFlair {
+        id: 'showcase',
+        channelUniqueName: 'dogs',
+        displayName: 'Showcase',
+        order: 0,
+        archived: false
+      })
+      CREATE (cats)-[:HAS_DISCUSSION_FLAIR]->(question)
+      CREATE (cats)-[:HAS_DISCUSSION_FLAIR]->(help)
+      CREATE (dogs)-[:HAS_DISCUSSION_FLAIR]->(showcase)
+    `
+  );
+
+  await createDiscussions([
+    discussionInput("Flair assignments", ["cats", "dogs"], [
+      { channelUniqueName: "cats", flairIds: ["question", "help"] },
+      { channelUniqueName: "dogs", flairIds: ["showcase"] },
+    ]),
+  ]);
+
+  const assignments = await run(
+    `
+      MATCH (dc:DiscussionChannel)-[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair)
+      WITH dc, flair
+      ORDER BY dc.channelUniqueName, flair.order
+      RETURN dc.channelUniqueName AS channelUniqueName,
+             collect(flair.id) AS flairIds
+      ORDER BY channelUniqueName
+    `
+  );
+
+  assert.deepEqual(assignments, [
+    { channelUniqueName: "cats", flairIds: ["question", "help"] },
+    { channelUniqueName: "dogs", flairIds: ["showcase"] },
+  ]);
+});
+
+test("rejects a required channel before creating the discussion", async () => {
+  await run(
+    `
+      CREATE (channel:Channel {
+        uniqueName: 'required',
+        discussionFlairRequired: true,
+        createdAt: datetime()
+      })
+      CREATE (flair:DiscussionFlair {
+        id: 'question',
+        channelUniqueName: 'required',
+        displayName: 'Question',
+        order: 0,
+        archived: false
+      })
+      CREATE (channel)-[:HAS_DISCUSSION_FLAIR]->(flair)
+    `
+  );
+
+  await assert.rejects(
+    () => createDiscussions([discussionInput("Missing flair", ["required"])]),
+    /At least one flair is required for channel 'required'/
+  );
+
+  const [{ discussionCount }] = await run(
+    `MATCH (discussion:Discussion) RETURN count(discussion) AS discussionCount`
+  );
+  assert.equal(Number(discussionCount), 0);
+});
+
+test("rejects archived and cross-channel flairs before creating the discussion", async () => {
+  await run(
+    `
+      CREATE (cats:Channel {
+        uniqueName: 'cats',
+        discussionFlairRequired: false,
+        createdAt: datetime()
+      })
+      CREATE (dogs:Channel {
+        uniqueName: 'dogs',
+        discussionFlairRequired: false,
+        createdAt: datetime()
+      })
+      CREATE (archived:DiscussionFlair {
+        id: 'archived',
+        channelUniqueName: 'cats',
+        displayName: 'Archived',
+        order: 0,
+        archived: true
+      })
+      CREATE (foreign:DiscussionFlair {
+        id: 'foreign',
+        channelUniqueName: 'dogs',
+        displayName: 'Foreign',
+        order: 0,
+        archived: false
+      })
+      CREATE (cats)-[:HAS_DISCUSSION_FLAIR]->(archived)
+      CREATE (dogs)-[:HAS_DISCUSSION_FLAIR]->(foreign)
+    `
+  );
+
+  for (const flairId of ["archived", "foreign"]) {
+    await assert.rejects(
+      () =>
+        createDiscussions([
+          discussionInput("Invalid flair", ["cats"], [
+            { channelUniqueName: "cats", flairIds: [flairId] },
+          ]),
+        ]),
+      new RegExp(`Flair '${flairId}' is not active in channel 'cats'`)
+    );
+  }
+
+  const [{ discussionCount }] = await run(
+    `MATCH (discussion:Discussion) RETURN count(discussion) AS discussionCount`
+  );
+  assert.equal(Number(discussionCount), 0);
+});
+
+test("enforces and assigns flairs when adding a discussion to a channel", async () => {
+  await run(
+    `
+      CREATE (discussion:Discussion {
+        id: 'existing-discussion',
+        title: 'Existing discussion',
+        hasSpoiler: false,
+        createdAt: datetime()
+      })
+      CREATE (channel:Channel {
+        uniqueName: 'required',
+        discussionFlairRequired: true,
+        createdAt: datetime()
+      })
+      CREATE (flair:DiscussionFlair {
+        id: 'question',
+        channelUniqueName: 'required',
+        displayName: 'Question',
+        order: 0,
+        archived: false
+      })
+      CREATE (channel)-[:HAS_DISCUSSION_FLAIR]->(flair)
+    `
+  );
+
+  await env.resolvers.Mutation.updateDiscussionWithChannelConnections(
+    null,
+    {
+      where: { id: "existing-discussion" },
+      discussionUpdateInput: { hasSpoiler: true },
+      channelConnections: ["required"],
+      channelFlairSelections: [
+        { channelUniqueName: "required", flairIds: ["question"] },
+      ],
+    },
+    { user: { username: "poster" } }
+  );
+
+  const assignments = await run(
+    `
+      MATCH (discussion:Discussion {id: 'existing-discussion'})
+        <-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)
+        -[:HAS_DISCUSSION_FLAIR]->(flair:DiscussionFlair)
+      RETURN discussion.hasSpoiler AS hasSpoiler,
+             dc.channelUniqueName AS channelUniqueName,
+             flair.id AS flairId
+    `
+  );
+  assert.deepEqual(assignments, [
+    {
+      hasSpoiler: true,
+      channelUniqueName: "required",
+      flairId: "question",
+    },
+  ]);
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1102,9 +1102,19 @@ const typeDefinitions = gql`
     values: [String!]!
   }
 
+  """
+  The flairs selected for one channel-specific submission of a discussion.
+  Every flair must be active and owned by channelUniqueName.
+  """
+  input DiscussionChannelFlairSelectionInput {
+    channelUniqueName: String!
+    flairIds: [ID!]!
+  }
+
   input DiscussionCreateInputWithChannels {
     discussionCreateInput: DiscussionCreateInput!
     channelConnections: [String!]!
+    channelFlairSelections: [DiscussionChannelFlairSelectionInput!] = []
   }
 
   """
@@ -1208,7 +1218,8 @@ const typeDefinitions = gql`
       serverId: ID!,
       title: String!,
       content: String,
-      shareMessage: String
+      shareMessage: String,
+      flairIds: [ID!] = []
     ): Discussion!
 
     # Library management
@@ -1253,6 +1264,7 @@ const typeDefinitions = gql`
       discussionUpdateInput: DiscussionUpdateInput!
       channelConnections: [String!]
       channelDisconnections: [String]
+      channelFlairSelections: [DiscussionChannelFlairSelectionInput!]
     ): Discussion
     createEventWithChannelConnections(
       input: [EventCreateInputWithChannels!]!


### PR DESCRIPTION
## Summary

- add an additive `channelFlairSelections` input for channel-scoped and sitewide discussion creation
- validate every selected channel and its flair IDs before creating any item in a batch
- enforce required flairs and reject archived, foreign, duplicate, or unconnected selections with structured GraphQL error codes
- persist flair assignments on each channel-specific `DiscussionChannel`
- apply the same validation and assignment contract when adding an existing discussion to a channel
- allow collection shares to provide flair IDs and preserve flair validation metadata

## Behavior

Each channel submission owns its own flair selection. A sitewide post submitted to three forums can therefore send three independent sets of flair IDs. Existing clients remain compatible for channels where flair is optional; a required channel returns `DISCUSSION_FLAIR_REQUIRED` with the affected `channelUniqueName`.

Selections must reference active flairs owned by that channel. Archiving a flair later does not remove its existing `DiscussionChannel` relationship, so historical submissions can continue to render it.

## Scope

This is the Phase 2 backend submission layer. Channel-owner management UI and the channel/sitewide form controls remain in the later frontend phases.

## Validation

- `pnpm run codegen`
- `pnpm run tsc`
- ESLint on all changed TypeScript files
- focused service and resolver tests: 42 passed
- full non-integration suite: 1,047 passed
- Neo4j integration tests: 4 passed
