### PR TITLE
fix: separate Heroku build and runtime heaps

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -69,7 +69,7 @@ test/E2E environments the seeded admin test user also acts as root.
 | --- | --- | --- |
 | `PORT` | No | Port the Apollo server listens on (defaults are provided in code; Heroku sets this automatically). |
 | `NODE_ENV` | No | Standard Node environment (`development` / `production` / `test`). |
-| `NODE_OPTIONS` | Recommended on memory-limited hosts | Standard Node runtime flags. On a 1 GB Heroku dyno, use `--max-old-space-size=768` so schema generation triggers garbage collection before exceeding the dyno memory quota. Re-test this value after materially expanding the GraphQL schema or changing dyno size. |
+| `NODE_OPTIONS` | Recommended on memory-limited hosts | Standard Node runtime flags. On a 1 GB Heroku dyno, use `--max-old-space-size=768` so runtime schema generation triggers garbage collection before exceeding the dyno memory quota. The Heroku build script overrides this with a 2 GB heap because GraphQL/OGM type generation needs more memory during compilation. Re-test both values after materially expanding the GraphQL schema or changing dyno size. |
 | `GRAPHQL_MAX_DEPTH` | No | Maximum allowed GraphQL query nesting depth (default `15`). Deeper queries are rejected before execution to prevent one crafted query from generating a pathological Cypher query. |
 | `SERVER_CONFIG_NAME` | Yes | Name of the `ServerConfig` record this instance runs as (e.g. `Listical`). The special value `Cypress Test Server` enables test-only behavior. |
 | `FRONTEND_URL` | Yes | Base URL of the frontend, used to build links in outbound emails (e.g. mod-invite acceptance links). |

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "migrate:private-downloads": "node --loader ts-node/esm build_scripts/migratePrivateDownloads.ts",
     "provision": "node --loader ts-node/esm build_scripts/provisionServerDefaults.ts",
     "build": "pnpm run codegen && tsc && node build_scripts/copyCypherFiles.js",
-    "heroku-postbuild": "pnpm run build",
+    "heroku-postbuild": "NODE_OPTIONS=--max-old-space-size=2048 pnpm run build",
     "start": "node ./ts_emitted/index.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- keep the production web dyno on a 768 MB Node heap to stay within its 1 GB quota
- override the Heroku build heap to 2 GB for GraphQL/OGM type generation
- document why the build and runtime limits differ

## Verification
- ran NODE_OPTIONS=--max-old-space-size=768 pnpm run heroku-postbuild on Node 22
- the script correctly used a 2 GB heap and completed codegen, TypeScript compilation, and Cypher copying
- pnpm exec eslint . --quiet

## Incident context
The runtime cap recovered Standard-2X startup, but Heroku also injected it into codegen, where 768 MB caused a safe pre-release OOM. This separates those two memory profiles.