### PR TITLE
feat: expose discussion flairs in list queries

### DIFF
--- a/customResolvers/cypher/discussionFlairProjection.test.ts
+++ b/customResolvers/cypher/discussionFlairProjection.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getDiscussionChannelsQuery,
+  getSiteWideDiscussionsQuery,
+} from "./cypherQueries.js";
+
+const assertProjectsAssignedFlairs = (query: string) => {
+  assert.match(
+    query,
+    /\(dc\)-\[:HAS_DISCUSSION_FLAIR\]->\(assignedFlair:DiscussionFlair\)/
+  );
+  assert.match(query, /Flairs:/);
+  for (const field of [
+    "id",
+    "channelUniqueName",
+    "displayName",
+    "color",
+    "order",
+    "archived",
+  ]) {
+    assert.match(query, new RegExp(`${field}: flair\\.${field}`));
+  }
+};
+
+test("channel discussion lists project assigned flair metadata", () => {
+  assertProjectsAssignedFlairs(getDiscussionChannelsQuery);
+});
+
+test("sitewide discussion lists project each channel's assigned flair metadata", () => {
+  assertProjectsAssignedFlairs(getSiteWideDiscussionsQuery);
+});
+
+test("channel discussion flair projection keeps configured ordering metadata", () => {
+  assert.match(
+    getDiscussionChannelsQuery,
+    /ORDER BY assignedFlair\.order ASC, assignedFlair\.displayName ASC/
+  );
+});

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -202,6 +202,23 @@ WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperU
      weightedVotesCount, comments, hotRank, album, albumImages,
      CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null WHEN favUser IS NOT NULL THEN true ELSE false END AS isFavorited
 
+// Include every assigned flair, including archived flairs. Archiving prevents
+// future assignment but must not erase a historical discussion's category.
+OPTIONAL MATCH (dc)-[:HAS_DISCUSSION_FLAIR]->(assignedFlair:DiscussionFlair)
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
+     weightedVotesCount, comments, hotRank, album, albumImages, isFavorited, assignedFlair
+ORDER BY assignedFlair.order ASC, assignedFlair.displayName ASC
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
+     weightedVotesCount, comments, hotRank, album, albumImages, isFavorited,
+     [flair IN COLLECT(DISTINCT assignedFlair) WHERE flair IS NOT NULL | {
+         id: flair.id,
+         channelUniqueName: flair.channelUniqueName,
+         displayName: flair.displayName,
+         color: flair.color,
+         order: flair.order,
+         archived: flair.archived
+     }] AS assignedFlairs
+
 // Return the results with modified UpvotedByUsers
 RETURN {
     id: dc.id,
@@ -212,6 +229,7 @@ RETURN {
     createdAt: dc.createdAt,
     channelUniqueName: dc.channelUniqueName,
     weightedVotesCount: weightedVotesCount,
+    Flairs: assignedFlairs,
     CommentsAggregate: {
         count: SIZE(comments)
     },

--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -63,8 +63,9 @@ OPTIONAL MATCH (dc)-[:UPVOTED_DISCUSSION]->(upvoter:User)
 OPTIONAL MATCH (dc)<-[:SUPER_UPVOTED_DISCUSSION]-(superUpvoter:User)
 OPTIONAL MATCH (dc)-[:CONTAINS_COMMENT]->(c:Comment)
 WHERE c.isFeedbackComment IS NULL OR c.isFeedbackComment = false
-WITH d, dc, channelNode, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, totalCount
-WITH d, COLLECT({dc: dc, channelIconURL: channelNode.channelIconURL, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount}) AS channelData, totalCount
+OPTIONAL MATCH (dc)-[:HAS_DISCUSSION_FLAIR]->(assignedFlair:DiscussionFlair)
+WITH d, dc, channelNode, COLLECT(DISTINCT upvoter) AS upvotedByUsers, COLLECT(DISTINCT superUpvoter) AS superUpvotedByUsers, COUNT(DISTINCT c) AS commentsCount, COLLECT(DISTINCT assignedFlair) AS assignedFlairs, totalCount
+WITH d, COLLECT({dc: dc, channelIconURL: channelNode.channelIconURL, upvotedByUsers: upvotedByUsers, superUpvotedByUsers: superUpvotedByUsers, commentsCount: commentsCount, assignedFlairs: assignedFlairs}) AS channelData, totalCount
 
 // Now, you can proceed with calculating the score and other aggregations at the discussion level
 WITH d, channelData, totalCount,
@@ -76,6 +77,14 @@ WITH d, score, totalCount,
         createdAt: channel.dc.createdAt,
         channelUniqueName: channel.dc.channelUniqueName,
         discussionId: channel.dc.discussionId,
+        Flairs: [flair IN channel.assignedFlairs WHERE flair IS NOT NULL | {
+          id: flair.id,
+          channelUniqueName: flair.channelUniqueName,
+          displayName: flair.displayName,
+          color: flair.color,
+          order: flair.order,
+          archived: flair.archived
+        }],
         Channel: {
           uniqueName: channel.dc.channelUniqueName,
           channelIconURL: channel.channelIconURL

--- a/tests/integration/getDiscussionsInChannel.test.ts
+++ b/tests/integration/getDiscussionsInChannel.test.ts
@@ -128,3 +128,89 @@ test("download label filters include matching packs and exclude excluded packs f
   assert.deepEqual(titles, ["Vampire Manor"]);
   assert.equal(Number(result.aggregateDiscussionChannelsCount), 1);
 });
+
+test("channel and sitewide discussion lists return assigned flairs, including archived history", async () => {
+  await run(
+    `CREATE (owner:User { username: 'alice', createdAt: datetime() })
+     CREATE (cats:Channel { uniqueName: 'cats', displayName: 'Cats', createdAt: datetime() })
+     CREATE (discussion:Discussion { id: 'discussion-1', title: 'Flair history', body: '', hasDownload: false, createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-1', discussionId: 'discussion-1', channelUniqueName: 'cats', createdAt: datetime(), archived: false })
+     CREATE (question:DiscussionFlair { id: 'question', channelUniqueName: 'cats', displayName: 'Question', color: '#112233', order: 0, archived: false })
+     CREATE (legacy:DiscussionFlair { id: 'legacy', channelUniqueName: 'cats', displayName: 'Legacy', color: null, order: 1, archived: true })
+     CREATE (owner)-[:POSTED_DISCUSSION]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(cats)
+     CREATE (cats)-[:HAS_DISCUSSION_FLAIR]->(question)
+     CREATE (cats)-[:HAS_DISCUSSION_FLAIR]->(legacy)
+     CREATE (dc)-[:HAS_DISCUSSION_FLAIR]->(question)
+     CREATE (dc)-[:HAS_DISCUSSION_FLAIR]->(legacy)`
+  );
+
+  const channelResult = await env.resolvers.Query.getDiscussionsInChannel(
+    null,
+    {
+      channelUniqueName: "cats",
+      options: { offset: "0", limit: "10", sort: "new" },
+      selectedTags: [],
+      searchInput: "",
+      showArchived: false,
+      showUnanswered: false,
+      hasDownload: false,
+      labelFilters: [],
+    },
+    anon(),
+    {} as never
+  );
+
+  const sitewideResult = await env.resolvers.Query.getSiteWideDiscussionList(
+    null,
+    {
+      searchInput: "",
+      selectedChannels: [],
+      selectedTags: [],
+      showArchived: false,
+      hasDownload: false,
+      options: {
+        offset: "0",
+        limit: "10",
+        resultsOrder: "desc",
+        sort: "new",
+        timeFrame: "week",
+      },
+    },
+    anon(),
+    {} as never
+  );
+
+  const expectedFlairs = [
+    {
+      id: "question",
+      channelUniqueName: "cats",
+      displayName: "Question",
+      color: "#112233",
+      order: 0,
+      archived: false,
+    },
+    {
+      id: "legacy",
+      channelUniqueName: "cats",
+      displayName: "Legacy",
+      color: null,
+      order: 1,
+      archived: true,
+    },
+  ];
+  const normalizeFlairs = (flairs: Array<Record<string, unknown>>) =>
+    flairs
+      .map((flair) => ({ ...flair, order: Number(flair.order) }))
+      .sort((left, right) => left.order - right.order);
+
+  assert.deepEqual(
+    normalizeFlairs(channelResult.discussionChannels[0].Flairs),
+    expectedFlairs
+  );
+  assert.deepEqual(
+    normalizeFlairs(sitewideResult.discussions[0].DiscussionChannels[0].Flairs),
+    expectedFlairs
+  );
+});


### PR DESCRIPTION
## Summary
- project channel-specific assigned flairs from the channel discussion list resolver
- project each forum submission's assigned flairs from the sitewide discussion list resolver
- retain archived flair assignments in read results so historical categorization continues to render
- return stable IDs, owning channel, display name, color, order, and archive status

## Validation
- `pnpm run tsc`
- ESLint on changed TypeScript files
- full non-integration suite under Node 22: 1,053 passed
- focused Cypher contract tests: 3 passed
- focused Neo4j integration suite: 5 passed, including channel and sitewide historical flair projection

## Scope
This is the backend read-contract phase required before the frontend can render and edit persisted discussion flair assignments. Filtering remains outside this PR.