### PR TITLE
feat: make download quarantine workflows explicit

### DIFF
--- a/build_scripts/migrateLegacyPluginPipelines.ts
+++ b/build_scripts/migrateLegacyPluginPipelines.ts
@@ -1,0 +1,63 @@
+import 'dotenv/config'
+import neo4j from 'neo4j-driver'
+import { createOgmAndModels } from '../customResolvers/resolverDeps.js'
+import { materializeLegacyDownloadPipelines } from '../services/plugin/legacyPipelineMigration.js'
+import type { PluginEdgeData } from '../services/plugin/types.js'
+
+const uri = process.env.NEO4J_URI || 'bolt://localhost:7687'
+const user = process.env.NEO4J_USER || 'neo4j'
+const password = process.env.NEO4J_PASSWORD
+
+if (!password) {
+  throw new Error('NEO4J_PASSWORD is required to migrate plugin pipelines')
+}
+
+const run = async () => {
+  const driver = neo4j.driver(uri, neo4j.auth.basic(user, password))
+  const deps = createOgmAndModels(driver)
+  await deps.ogm.init()
+
+  try {
+    const configs = await deps.ServerConfig.find({
+      selectionSet: `{
+        serverName
+        pluginPipelines
+        InstalledVersionsConnection {
+          edges {
+            properties { enabled settingsJson }
+            node {
+              id version repoUrl tarballGsUri entryPath manifest
+              settingsDefaults uiSchema
+              Plugin { id name displayName description metadata }
+            }
+          }
+        }
+      }`,
+    })
+
+    for (const config of configs) {
+      const result = materializeLegacyDownloadPipelines({
+        storedPipelines: config.pluginPipelines,
+        installedPluginEdges: (
+          config.InstalledVersionsConnection?.edges || []
+        ) as unknown as PluginEdgeData[],
+      })
+      if (result.addedEvents.length === 0) continue
+
+      await deps.ServerConfig.update({
+        where: { serverName: config.serverName },
+        update: { pluginPipelines: JSON.stringify(result.pipelines) },
+      })
+      console.log(
+        `[pipeline-migration] ${config.serverName}: added ${result.addedEvents.join(', ')}`
+      )
+    }
+  } finally {
+    await driver.close()
+  }
+}
+
+run().catch(error => {
+  console.error('Plugin pipeline migration failed', error)
+  process.exitCode = 1
+})

--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -91,6 +91,7 @@ import {
   resumePluginPipelineCampaign,
 } from "./mutations/pluginPipelineCampaigns.js";
 import clearDownloadableFileScan from "./mutations/clearDownloadableFileScan.js";
+import requestDownloadableFileReview from "./mutations/requestDownloadableFileReview.js";
 import trackDownload from "./mutations/trackDownload.js";
 import prepareDownload from "./mutations/prepareDownload.js";
 import updateDownloadableFileSupportSettings from "./mutations/updateDownloadableFileSupportSettings.js";
@@ -620,6 +621,9 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     clearDownloadableFileScan: clearDownloadableFileScan({
       DownloadableFile,
       driver
+    }),
+    requestDownloadableFileReview: requestDownloadableFileReview({
+      DownloadableFile
     }),
     trackDownload: trackDownload({
       driver

--- a/customResolvers/mutations/clearDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.test.ts
@@ -58,6 +58,15 @@ test("clears a held scan and notifies the discussion author", async () => {
     },
     result: { id: "file-1", scanStatus: "CLEAN" },
   });
+  assert.deepEqual({
+    requestedAt: updates[0].update.reviewRequestedAt,
+    requestReason: updates[0].update.reviewRequestReason,
+    requestedBy: updates[0].update.reviewRequestedByUsername,
+  }, {
+    requestedAt: null,
+    requestReason: null,
+    requestedBy: null,
+  });
 });
 
 test("rejects a file that is already clean", async () => {

--- a/customResolvers/mutations/clearDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.test.ts
@@ -86,3 +86,21 @@ test("rejects a file that is already clean", async () => {
     /already clean/
   );
 });
+
+test("requires an audit reason before releasing quarantine", async () => {
+  const resolver = createClearDownloadableFileScanResolver({
+    DownloadableFile: {
+      find: async () => [{ id: "file-1", scanStatus: "SUSPICIOUS" }],
+    } as any,
+    driver: {} as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1", reason: "  " },
+      { user: { username: "moderator" } } as GraphQLContext
+    ),
+    /review reason is required/
+  );
+});

--- a/customResolvers/mutations/clearDownloadableFileScan.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.ts
@@ -44,6 +44,9 @@ export const createClearDownloadableFileScanResolver = ({
         scanStatus: "CLEAN",
         scanReason,
         scanCheckedAt,
+        reviewRequestedAt: null,
+        reviewRequestReason: null,
+        reviewRequestedByUsername: null,
       } as DownloadableFileUpdateInput),
     });
 

--- a/customResolvers/mutations/clearDownloadableFileScan.ts
+++ b/customResolvers/mutations/clearDownloadableFileScan.ts
@@ -28,14 +28,16 @@ export const createClearDownloadableFileScanResolver = ({
       throw new Error("The downloadable file is already clean");
     }
 
+    const explanation = args.reason?.trim();
+    if (!explanation) {
+      throw new Error("A review reason is required to release quarantine");
+    }
+
     const reviewer =
       context.user?.data?.ModerationProfile?.displayName ||
       context.user?.username ||
       "a moderator";
-    const explanation = args.reason?.trim();
-    const scanReason = explanation
-      ? `Cleared by ${reviewer}: ${explanation}`
-      : `Cleared by ${reviewer} after human review`;
+    const scanReason = `Cleared by ${reviewer}: ${explanation}`;
     const scanCheckedAt = new Date().toISOString();
 
     await DownloadableFile.update({

--- a/customResolvers/mutations/createDiscussionPluginPipelineOrder.test.ts
+++ b/customResolvers/mutations/createDiscussionPluginPipelineOrder.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { modelStub } from "../../tests/fixtures/modelStub.js";
+import type {
+  triggerChannelPluginPipeline,
+  triggerPluginRunsForDownloadableFile,
+} from "../../services/pluginRunner.js";
+import { triggerCreatedDownloadPipelines } from "./createDiscussionWithChannelConnections.js";
+
+test("runs server download security before channel automation", async () => {
+  const calls: string[] = [];
+  const triggerDownload: typeof triggerPluginRunsForDownloadableFile =
+    async () => {
+      calls.push("server");
+      return [];
+    };
+  const triggerChannel: typeof triggerChannelPluginPipeline =
+    async ({ channelUniqueName }) => {
+      calls.push(`channel:${channelUniqueName}`);
+      return [];
+    };
+  const pluginModels = {
+    Channel: modelStub<"Channel">(),
+    DownloadableFile: modelStub<"DownloadableFile">(),
+    PluginPipelineRun: modelStub<"PluginPipelineRun">(),
+    PluginRun: modelStub<"PluginRun">(),
+    ServerConfig: modelStub<"ServerConfig">(),
+    ServerSecret: modelStub<"ServerSecret">(),
+  };
+
+  await triggerCreatedDownloadPipelines({
+    discussionId: "discussion-1",
+    downloadableFileId: "file-1",
+    channelConnections: ["cats", "mods"],
+    Discussion: modelStub<"Discussion">(),
+    pluginModels,
+    triggerDownload,
+    triggerChannel,
+  });
+
+  assert.deepEqual(calls, ["server", "channel:cats", "channel:mods"]);
+});
+
+test("continues channel automation when the server pipeline fails", async () => {
+  const calls: string[] = [];
+  const triggerDownload: typeof triggerPluginRunsForDownloadableFile =
+    async () => {
+      calls.push("server-failed");
+      throw new Error("scanner unavailable");
+    };
+  const triggerChannel: typeof triggerChannelPluginPipeline = async () => {
+    calls.push("channel");
+    return [];
+  };
+
+  await triggerCreatedDownloadPipelines({
+    discussionId: "discussion-1",
+    downloadableFileId: "file-1",
+    channelConnections: ["cats"],
+    Discussion: modelStub<"Discussion">(),
+    pluginModels: {
+      Channel: modelStub<"Channel">(),
+      DownloadableFile: modelStub<"DownloadableFile">(),
+      PluginPipelineRun: modelStub<"PluginPipelineRun">(),
+      PluginRun: modelStub<"PluginRun">(),
+      ServerConfig: modelStub<"ServerConfig">(),
+      ServerSecret: modelStub<"ServerSecret">(),
+    },
+    triggerDownload,
+    triggerChannel,
+  });
+
+  assert.deepEqual(calls, ["server-failed", "channel"]);
+});

--- a/customResolvers/mutations/createDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.ts
@@ -47,6 +47,81 @@ type Input = {
   User?: UserModel;
 };
 
+type PluginModels = {
+  Channel: ChannelModel;
+  DownloadableFile: DownloadableFileModel;
+  PluginPipelineRun: PluginPipelineRunModel;
+  PluginRun: PluginRunModel;
+  ServerConfig: ServerConfigModel;
+  ServerSecret: ServerSecretModel;
+  User?: UserModel;
+};
+
+export const triggerCreatedDownloadPipelines = async ({
+  discussionId,
+  downloadableFileId,
+  channelConnections,
+  Discussion,
+  pluginModels,
+  triggerDownload = triggerPluginRunsForDownloadableFile,
+  triggerChannel = triggerChannelPluginPipeline,
+}: {
+  discussionId: string;
+  downloadableFileId: string;
+  channelConnections: string[];
+  Discussion: DiscussionModel;
+  pluginModels: PluginModels;
+  triggerDownload?: typeof triggerPluginRunsForDownloadableFile;
+  triggerChannel?: typeof triggerChannelPluginPipeline;
+}) => {
+  try {
+    await triggerDownload({
+      downloadableFileId,
+      event: "downloadableFile.created",
+      models: {
+        DownloadableFile: pluginModels.DownloadableFile,
+        PluginPipelineRun: pluginModels.PluginPipelineRun,
+        PluginRun: pluginModels.PluginRun,
+        ServerConfig: pluginModels.ServerConfig,
+        ServerSecret: pluginModels.ServerSecret,
+        User: pluginModels.User,
+      },
+    });
+  } catch (triggerError: unknown) {
+    const message = triggerError instanceof Error
+      ? triggerError.message
+      : String(triggerError);
+    logger.error(
+      `downloadableFile.created plugin trigger error for ${discussionId}:`,
+      message
+    );
+  }
+
+  for (const channelUniqueName of channelConnections) {
+    try {
+      await triggerChannel({
+        discussionId,
+        channelUniqueName,
+        event: 'discussionChannel.created',
+        models: {
+          Channel: pluginModels.Channel,
+          Discussion,
+          DownloadableFile: pluginModels.DownloadableFile,
+          PluginPipelineRun: pluginModels.PluginPipelineRun,
+          PluginRun: pluginModels.PluginRun,
+          ServerConfig: pluginModels.ServerConfig,
+          ServerSecret: pluginModels.ServerSecret,
+        }
+      });
+    } catch (pipelineError: unknown) {
+      const message = pipelineError instanceof Error
+        ? pipelineError.message
+        : String(pipelineError);
+      logger.error(`Channel pipeline error for ${channelUniqueName}:`, message);
+    }
+  }
+};
+
 // The reason why we cannot use the auto-generated resolver
 // to create a Discussion with DiscussionChannels already linked
 // is because the creation of the DiscussionChannel nodes
@@ -116,15 +191,7 @@ export const createDiscussionsFromInput = async (
   driver: Driver,
   input: DiscussionCreateInputWithChannels[],
   context?: GraphQLContext,
-  pluginModels?: {
-    Channel: ChannelModel;
-    DownloadableFile: DownloadableFileModel;
-    PluginPipelineRun: PluginPipelineRunModel;
-    PluginRun: PluginRunModel;
-    ServerConfig: ServerConfigModel;
-    ServerSecret: ServerSecretModel;
-    User?: UserModel;
-  }
+  pluginModels?: PluginModels
 ): Promise<unknown[]> => {
   if (!input || input.length === 0) {
     throw new Error("Input cannot be empty");
@@ -239,32 +306,6 @@ export const createDiscussionsFromInput = async (
             flairIds: flairIdsByInput[inputIndex].get(channelUniqueName) ?? [],
           });
 
-          // Trigger channel plugin pipeline if discussion has a download
-          // and plugin models are available
-          if (hasDownload && pluginModels) {
-            try {
-              await triggerChannelPluginPipeline({
-                discussionId: newDiscussionId,
-                channelUniqueName,
-                event: 'discussionChannel.created',
-                models: {
-                  Channel: pluginModels.Channel,
-                  Discussion,
-                  DownloadableFile: pluginModels.DownloadableFile,
-                  Plugin: null as any, // Not used in channel pipeline
-                  PluginVersion: null as any, // Not used directly
-                  PluginPipelineRun: pluginModels.PluginPipelineRun,
-                  PluginRun: pluginModels.PluginRun,
-                  ServerConfig: pluginModels.ServerConfig,
-                  ServerSecret: pluginModels.ServerSecret,
-                }
-              });
-            } catch (pipelineError: unknown) {
-              // Log pipeline errors but don't fail the discussion creation
-              const message = pipelineError instanceof Error ? pipelineError.message : String(pipelineError);
-              logger.error(`Channel pipeline error for ${channelUniqueName}:`, message);
-            }
-          }
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : String(error);
           if (message.includes("Constraint validation failed")) {
@@ -290,17 +331,12 @@ export const createDiscussionsFromInput = async (
             withFile?.[0] as unknown as { DownloadableFiles?: Array<{ id?: string }> }
           )?.DownloadableFiles?.[0]?.id;
           if (downloadableFileId) {
-            await triggerPluginRunsForDownloadableFile({
+            await triggerCreatedDownloadPipelines({
+              discussionId: newDiscussionId,
               downloadableFileId,
-              event: "downloadableFile.created",
-              models: {
-                DownloadableFile: pluginModels.DownloadableFile,
-                PluginPipelineRun: pluginModels.PluginPipelineRun,
-                PluginRun: pluginModels.PluginRun,
-                ServerConfig: pluginModels.ServerConfig,
-                ServerSecret: pluginModels.ServerSecret,
-                User: pluginModels.User,
-              },
+              channelConnections,
+              Discussion,
+              pluginModels,
             });
           }
         } catch (triggerError: unknown) {

--- a/customResolvers/mutations/requestDownloadableFileReview.test.ts
+++ b/customResolvers/mutations/requestDownloadableFileReview.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GraphQLContext } from "../../types/context.js";
+import requestDownloadableFileReview from "./requestDownloadableFileReview.js";
+
+const contextFor = (username: string) => ({
+  user: { username },
+}) as GraphQLContext;
+
+test("records a creator review request for a held file", async () => {
+  const updates: any[] = [];
+  let finds = 0;
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => {
+        finds += 1;
+        return finds === 1
+          ? [{
+              scanStatus: "SUSPICIOUS",
+              uploadedByUsername: "alice",
+              Discussion: { Author: { username: "alice" } },
+            }]
+          : [{ id: "file-1", reviewRequestedByUsername: "alice" }];
+      },
+      update: async (args: unknown) => {
+        updates.push(args);
+        return {};
+      },
+    } as any,
+  });
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1", reason: "This is a false positive" },
+    contextFor("alice") as any
+  );
+
+  assert.deepEqual({
+    update: {
+      ...updates[0].update,
+      reviewRequestedAt: Boolean(updates[0].update.reviewRequestedAt),
+    },
+    result,
+  }, {
+    update: {
+      reviewRequestedAt: true,
+      reviewRequestReason: "This is a false positive",
+      reviewRequestedByUsername: "alice",
+    },
+    result: { id: "file-1", reviewRequestedByUsername: "alice" },
+  });
+});
+
+test("rejects review requests from unrelated users", async () => {
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => [{
+        scanStatus: "INFECTED",
+        uploadedByUsername: "alice",
+        Discussion: { Author: { username: "alice" } },
+      }],
+    } as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      contextFor("bob") as any
+    ),
+    /Only the file creator/
+  );
+});
+
+test("rejects review requests for files that are not held", async () => {
+  const resolver = requestDownloadableFileReview({
+    DownloadableFile: {
+      find: async () => [{
+        scanStatus: "CLEAN",
+        uploadedByUsername: "alice",
+      }],
+    } as any,
+  });
+
+  await assert.rejects(
+    resolver(
+      null,
+      { downloadableFileId: "file-1" },
+      contextFor("alice") as any
+    ),
+    /Only held security scans/
+  );
+});

--- a/customResolvers/mutations/requestDownloadableFileReview.ts
+++ b/customResolvers/mutations/requestDownloadableFileReview.ts
@@ -1,0 +1,71 @@
+import type {
+  DownloadableFileModel,
+  DownloadableFileUpdateInput,
+} from "../../ogm_types.js";
+import type { GraphQLContext } from "../../types/context.js";
+import {
+  setUserDataOnContext,
+  type AuthContextForUserLookup,
+} from "../../rules/permission/userDataHelperFunctions.js";
+
+type Input = { DownloadableFile: DownloadableFileModel };
+
+type FileRecord = {
+  scanStatus?: string | null;
+  uploadedByUsername?: string | null;
+  Discussion?: { Author?: { username?: string | null } | null } | null;
+};
+
+type ReviewContext = GraphQLContext & AuthContextForUserLookup;
+
+const requestDownloadableFileReview = ({ DownloadableFile }: Input) => {
+  return async (
+    _parent: unknown,
+    args: { downloadableFileId: string; reason?: string | null },
+    context: ReviewContext
+  ) => {
+    if (!context.user) {
+      context.user = await setUserDataOnContext({ context });
+    }
+    const username = context.user?.username;
+    if (!username) throw new Error("You must be logged in to request review");
+
+    const files = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{
+        scanStatus
+        uploadedByUsername
+        Discussion { Author { username } }
+      }`,
+    }) as FileRecord[];
+    const file = files[0];
+    if (!file) throw new Error("Downloadable file not found");
+
+    const isCreator = file.uploadedByUsername === username ||
+      file.Discussion?.Author?.username === username;
+    if (!isCreator) throw new Error("Only the file creator can request review");
+    if (file.scanStatus !== "SUSPICIOUS" && file.scanStatus !== "INFECTED") {
+      throw new Error("Only held security scans can be sent for human review");
+    }
+
+    await DownloadableFile.update({
+      where: { id: args.downloadableFileId },
+      update: ({
+        reviewRequestedAt: new Date().toISOString(),
+        reviewRequestReason: args.reason?.trim() || null,
+        reviewRequestedByUsername: username,
+      } as DownloadableFileUpdateInput),
+    });
+
+    const updated = await DownloadableFile.find({
+      where: { id: args.downloadableFileId },
+      selectionSet: `{
+        id fileName scanStatus scanReason scanCheckedAt
+        reviewRequestedAt reviewRequestReason reviewRequestedByUsername
+      }`,
+    });
+    return updated[0];
+  };
+};
+
+export default requestDownloadableFileReview;

--- a/customResolvers/mutations/retryDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { PLUGIN_EVENTS } from "../../services/plugin/constants.js";
-import { modelStub } from "../../tests/fixtures/modelStub.js";
+import {
+  modelStub,
+  type ModelStubMethods,
+} from "../../tests/fixtures/modelStub.js";
 import type { GraphQLContext } from "../../types/context.js";
 import {
   createRetryDownloadableFileScanResolver,
@@ -18,10 +21,12 @@ type RerunResolverFactory = NonNullable<
 const baseInput = ({
   file,
   attempts = [],
+  findAttempts,
   jobs = [],
 }: {
   file: unknown;
   attempts?: unknown[];
+  findAttempts?: ModelStubMethods<"PluginPipelineRun">["find"];
   jobs?: unknown[];
 }): RetryDownloadableFileScanInput => ({
   Channel: modelStub<"Channel">(),
@@ -32,7 +37,7 @@ const baseInput = ({
   Plugin: modelStub<"Plugin">(),
   PluginVersion: modelStub<"PluginVersion">(),
   PluginPipelineRun: modelStub<"PluginPipelineRun">({
-    find: async () => attempts,
+    find: findAttempts ?? (async () => attempts),
   }),
   PluginRun: modelStub<"PluginRun">({
     find: async () => jobs,
@@ -184,17 +189,17 @@ test("retries the latest failed channel scan for an optional channel policy", as
       scanStatus: "FAILED",
       Discussion: { id: "discussion-1" },
     },
+    findAttempts: async ({ where } = {}) => {
+      seenTargets.push(String(where?.targetType));
+      return where?.targetType === "Discussion"
+        ? [{
+            pipelineId: "failed-channel-pipeline",
+            createdAt: "2026-07-31T00:00:00.000Z",
+          }]
+        : [];
+    },
     jobs: [{ id: "new-channel-job" }],
   });
-  input.PluginPipelineRun.find = async ({ where } = {}) => {
-    seenTargets.push(String(where?.targetType));
-    return where?.targetType === "Discussion"
-      ? [{
-          pipelineId: "failed-channel-pipeline",
-          createdAt: "2026-07-31T00:00:00.000Z",
-        }]
-      : [];
-  };
   let sourceId = "";
   const createRerunResolver: RerunResolverFactory =
     () => async (_parent, args) => {

--- a/customResolvers/mutations/retryDownloadableFileScan.test.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.test.ts
@@ -175,3 +175,50 @@ test("routes a modern failed scan through whole-pipeline retry", async () => {
     }
   );
 });
+
+test("retries the latest failed channel scan for an optional channel policy", async () => {
+  const seenTargets: string[] = [];
+  const input = baseInput({
+    file: {
+      uploadedByUsername: "alice",
+      scanStatus: "FAILED",
+      Discussion: { id: "discussion-1" },
+    },
+    jobs: [{ id: "new-channel-job" }],
+  });
+  input.PluginPipelineRun.find = async ({ where } = {}) => {
+    seenTargets.push(String(where?.targetType));
+    return where?.targetType === "Discussion"
+      ? [{
+          pipelineId: "failed-channel-pipeline",
+          createdAt: "2026-07-31T00:00:00.000Z",
+        }]
+      : [];
+  };
+  let sourceId = "";
+  const createRerunResolver: RerunResolverFactory =
+    () => async (_parent, args) => {
+      sourceId = args.pipelineRunId;
+      return {
+        pipelineId: "new-channel-pipeline",
+      } as Awaited<ReturnType<ReturnType<RerunResolverFactory>>>;
+    };
+  const resolver = createRetryDownloadableFileScanResolver(
+    input,
+    async () => false,
+    async () => [],
+    createRerunResolver
+  );
+
+  const result = await resolver(
+    null,
+    { downloadableFileId: "file-1" },
+    contextFor("alice")
+  );
+
+  assert.deepEqual({ seenTargets, sourceId, result }, {
+    seenTargets: ["DownloadableFile", "Discussion"],
+    sourceId: "failed-channel-pipeline",
+    result: [{ id: "new-channel-job" }],
+  });
+});

--- a/customResolvers/mutations/retryDownloadableFileScan.ts
+++ b/customResolvers/mutations/retryDownloadableFileScan.ts
@@ -27,6 +27,7 @@ type FileRecord = {
   uploadedByUsername?: string | null;
   scanStatus?: string | null;
   Discussion?: {
+    id?: string | null;
     Author?: { username?: string | null } | null;
     DiscussionChannels?: Array<{
       channelUniqueName?: string | null;
@@ -55,6 +56,7 @@ export const createRetryDownloadableFileScanResolver = (
         uploadedByUsername
         scanStatus
         Discussion {
+          id
           Author { username }
           DiscussionChannels {
             channelUniqueName
@@ -95,7 +97,7 @@ export const createRetryDownloadableFileScanResolver = (
       if (canReview !== true) throw new Error("Not authorized to retry this scan");
     }
 
-    const attempts = await input.PluginPipelineRun.find({
+    const serverAttempts = await input.PluginPipelineRun.find({
       where: {
         targetId: downloadableFileId,
         targetType: "DownloadableFile",
@@ -111,6 +113,22 @@ export const createRetryDownloadableFileScanResolver = (
       },
       selectionSet: `{ pipelineId createdAt }`,
     });
+    const channelAttempts = file.Discussion?.id
+      ? await input.PluginPipelineRun.find({
+          where: {
+            targetId: file.Discussion.id,
+            targetType: "Discussion",
+            eventType: "discussionChannel.created",
+            status_IN: [
+              PluginPipelineRunStatus.Failed,
+              PluginPipelineRunStatus.TimedOut,
+              PluginPipelineRunStatus.Cancelled,
+            ],
+          },
+          selectionSet: `{ pipelineId createdAt }`,
+        })
+      : [];
+    const attempts = [...serverAttempts, ...channelAttempts];
     const sourceAttempt = [...attempts].sort(
       (left, right) =>
         Date.parse(String(right.createdAt)) -

--- a/customResolvers/queries/getDownloadScanReviewQueue.test.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import getDownloadScanReviewQueue from "./getDownloadScanReviewQueue.js";
+
+test("returns held files with creator requests first", async () => {
+  const calls: any[] = [];
+  let closed = false;
+  const resolver = getDownloadScanReviewQueue({
+    driver: {
+      session: () => ({
+        run: async (query: string, params: unknown) => {
+          calls.push({ query, params });
+          return {
+            records: [{
+              get: () => ({
+                downloadableFileId: "file-1",
+                scanStatus: "SUSPICIOUS",
+                reviewRequestedAt: "2026-07-19T00:00:00Z",
+              }),
+            }],
+          };
+        },
+        close: async () => { closed = true; },
+      }),
+    } as any,
+  });
+
+  const result = await resolver(null, { limit: 500 });
+
+  assert.deepEqual({
+    result,
+    limit: calls[0].params.limit,
+    includesHeldStatuses: calls[0].query.includes("['SUSPICIOUS', 'INFECTED']"),
+    prioritizesRequests: calls[0].query.includes("file.reviewRequestedAt IS NULL"),
+    closed,
+  }, {
+    result: [{
+      downloadableFileId: "file-1",
+      scanStatus: "SUSPICIOUS",
+      reviewRequestedAt: "2026-07-19T00:00:00Z",
+    }],
+    limit: 100,
+    includesHeldStatuses: true,
+    prioritizesRequests: true,
+    closed: true,
+  });
+});

--- a/customResolvers/queries/getDownloadScanReviewQueue.test.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.test.ts
@@ -30,7 +30,7 @@ test("returns held files with creator requests first", async () => {
   assert.deepEqual({
     result,
     limit: calls[0].params.limit,
-    includesHeldStatuses: calls[0].query.includes("['SUSPICIOUS', 'INFECTED']"),
+    includesHeldStatuses: calls[0].query.includes("['SUSPICIOUS', 'INFECTED', 'FAILED']"),
     prioritizesRequests: calls[0].query.includes("file.reviewRequestedAt IS NULL"),
     closed,
   }, {

--- a/customResolvers/queries/getDownloadScanReviewQueue.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.ts
@@ -1,0 +1,46 @@
+import type { Driver } from "neo4j-driver";
+
+type Input = { driver: Driver };
+
+const getDownloadScanReviewQueue = ({ driver }: Input) => {
+  return async (_parent: unknown, args: { limit?: number | null } = {}) => {
+    const limit = Math.min(Math.max(args.limit || 50, 1), 100);
+    const session = driver.session();
+    try {
+      const result = await session.run(
+        `
+        MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile)
+        WHERE file.scanStatus IN ['SUSPICIOUS', 'INFECTED']
+          AND coalesce(file.permanentlyRemoved, false) = false
+        OPTIONAL MATCH (author:User)-[:AUTHORED_DISCUSSION]->(discussion)
+        OPTIONAL MATCH (discussion)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)
+        WITH file, discussion, author, head(collect(dc.channelUniqueName)) AS channelUniqueName
+        ORDER BY
+          CASE WHEN file.reviewRequestedAt IS NULL THEN 1 ELSE 0 END,
+          file.reviewRequestedAt DESC,
+          file.scanCheckedAt DESC
+        LIMIT toInteger($limit)
+        RETURN {
+          downloadableFileId: file.id,
+          fileName: file.fileName,
+          scanStatus: file.scanStatus,
+          scanReason: file.scanReason,
+          scanCheckedAt: toString(file.scanCheckedAt),
+          reviewRequestedAt: toString(file.reviewRequestedAt),
+          reviewRequestReason: file.reviewRequestReason,
+          uploaderUsername: coalesce(file.uploadedByUsername, author.username),
+          discussionId: discussion.id,
+          discussionTitle: discussion.title,
+          channelUniqueName: channelUniqueName
+        } AS review
+        `,
+        { limit }
+      );
+      return result.records.map((record) => record.get("review"));
+    } finally {
+      await session.close();
+    }
+  };
+};
+
+export default getDownloadScanReviewQueue;

--- a/customResolvers/queries/getDownloadScanReviewQueue.ts
+++ b/customResolvers/queries/getDownloadScanReviewQueue.ts
@@ -10,7 +10,7 @@ const getDownloadScanReviewQueue = ({ driver }: Input) => {
       const result = await session.run(
         `
         MATCH (discussion:Discussion)-[:HAS_DOWNLOADABLE_FILE]->(file:DownloadableFile)
-        WHERE file.scanStatus IN ['SUSPICIOUS', 'INFECTED']
+        WHERE file.scanStatus IN ['SUSPICIOUS', 'INFECTED', 'FAILED']
           AND coalesce(file.permanentlyRemoved, false) = false
         OPTIONAL MATCH (author:User)-[:AUTHORED_DISCUSSION]->(discussion)
         OPTIONAL MATCH (discussion)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)
@@ -18,6 +18,11 @@ const getDownloadScanReviewQueue = ({ driver }: Input) => {
         ORDER BY
           CASE WHEN file.reviewRequestedAt IS NULL THEN 1 ELSE 0 END,
           file.reviewRequestedAt DESC,
+          CASE file.scanStatus
+            WHEN 'INFECTED' THEN 0
+            WHEN 'SUSPICIOUS' THEN 1
+            ELSE 2
+          END,
           file.scanCheckedAt DESC
         LIMIT toInteger($limit)
         RETURN {

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -22,6 +22,7 @@ import getPipelineRuns from "./queries/getPipelineRuns.js";
 import publicCollectionsContaining from "./queries/publicCollectionsContaining.js";
 import getOwnEmail from "./queries/getOwnEmail.js";
 import getServerHealthDashboard from "./queries/getServerHealthDashboard.js";
+import getDownloadScanReviewQueue from "./queries/getDownloadScanReviewQueue.js";
 import getSiteWideIssueList from "./queries/getSiteWideIssueList.js";
 import getUploadedDownloadableFiles from "./queries/getUploadedDownloadableFiles.js";
 import getImageAlbumUsage from "./queries/getImageAlbumUsage.js";
@@ -189,6 +190,7 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     getServerHealthDashboard: getServerHealthDashboard({
       driver
-    })
+    }),
+    getDownloadScanReviewQueue: getDownloadScanReviewQueue({ driver })
   };
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tsc": "tsc",
     "logSchema": "node build_scripts/logSchema.js",
     "migrate:private-downloads": "node --loader ts-node/esm build_scripts/migratePrivateDownloads.ts",
+    "migrate:plugin-pipelines": "node --loader ts-node/esm build_scripts/migrateLegacyPluginPipelines.ts",
     "provision": "node --loader ts-node/esm build_scripts/provisionServerDefaults.ts",
     "build": "pnpm run codegen && tsc && node build_scripts/copyCypherFiles.js",
     "heroku-postbuild": "NODE_OPTIONS=--max-old-space-size=2048 pnpm run build",

--- a/permissions.ts
+++ b/permissions.ts
@@ -79,6 +79,7 @@ const permissionList = shield({
       emails: deny,
       getUploadedDownloadableFiles: and(isAuthenticated, allow),
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
+      getDownloadScanReviewQueue: and(isAuthenticated, canPermanentlyRemoveImage),
       getPluginConfigStatus: and(isAuthenticated, canManagePlugins),
       getPluginRunsForDownloadableFile: chain(
         isAuthenticated,
@@ -369,6 +370,7 @@ const permissionList = shield({
       pausePluginPipelineCampaign: and(isAuthenticated, canManagePlugins),
       resumePluginPipelineCampaign: and(isAuthenticated, canManagePlugins),
       clearDownloadableFileScan: and(isAuthenticated, canPermanentlyRemoveImage),
+      requestDownloadableFileReview: and(isAuthenticated, allow),
       permanentlyDeleteImage: and(isAuthenticated, allow),
       permanentlyDeleteDownloadableFile: and(isAuthenticated, allow),
 

--- a/services/plugin/channelTrigger.execution.test.ts
+++ b/services/plugin/channelTrigger.execution.test.ts
@@ -23,6 +23,7 @@ type RunCreateArgs = Parameters<ModelMap["PluginRun"]["create"]>[0];
 type RunUpdateArgs = Parameters<ModelMap["PluginRun"]["update"]>[0];
 type AttemptCreateArgs =
   Parameters<ModelMap["PluginPipelineRun"]["create"]>[0];
+type FileUpdateArgs = Parameters<ModelMap["DownloadableFile"]["update"]>[0];
 
 const EVENT = "discussionChannel.created";
 
@@ -48,10 +49,15 @@ const discussionWithFile = {
   DownloadableFile: { id: "f-1", fileName: "a.zip", url: "http://x/a.zip", kind: "zip", size: 10 },
 };
 
-function makeExecModels(steps: unknown[], edges: unknown[]) {
+function makeExecModels(
+  steps: unknown[],
+  edges: unknown[],
+  serverPipelines: unknown[] = []
+) {
   const updates: RunUpdateArgs[] = [];
   const creates: RunCreateArgs[] = [];
   const attemptCreates: AttemptCreateArgs[] = [];
+  const fileUpdates: FileUpdateArgs[] = [];
   let seq = 0;
   const channel = {
     uniqueName: "cats",
@@ -63,7 +69,11 @@ function makeExecModels(steps: unknown[], edges: unknown[]) {
     FilterGroups: [],
     EnabledPluginsConnection: { edges: [] },
   };
-  const serverConfig = { serverName: "s", InstalledVersionsConnection: { edges } };
+  const serverConfig = {
+    serverName: "s",
+    pluginPipelines: serverPipelines,
+    InstalledVersionsConnection: { edges },
+  };
   const PluginRun = modelStub<"PluginRun">({
     create: async args => {
       creates.push(args);
@@ -95,13 +105,18 @@ function makeExecModels(steps: unknown[], edges: unknown[]) {
       find: async () => [serverConfig],
     }),
     ServerSecret: modelStub<"ServerSecret">(),
-    DownloadableFile: modelStub<"DownloadableFile">(),
+    DownloadableFile: modelStub<"DownloadableFile">({
+      update: async args => {
+        fileUpdates.push(args);
+        return { downloadableFiles: [] };
+      },
+    }),
     PluginPipelineRun,
     PluginRun,
     Plugin: modelStub<"Plugin">(),
     PluginVersion: modelStub<"PluginVersion">(),
   } satisfies Models;
-  return { models, updates, creates, attemptCreates };
+  return { models, updates, creates, attemptCreates, fileUpdates };
 }
 
 const pluginReturning = (result: PluginRunResult): PluginConstructor =>
@@ -143,6 +158,54 @@ test("marks the run FAILED when the plugin reports failure", async () => {
   );
   await execRun(models, loaderFor(pluginReturning({ success: false, error: "nope" })));
   assert.ok(statusesOf(updates).includes("FAILED"));
+});
+
+test("channel security scans receive the attachment and update the hold", async () => {
+  const { models, fileUpdates } = makeExecModels(
+    [{ pluginId: "security-attachment-scan", condition: "ALWAYS" }],
+    [installedEdge("security-attachment-scan")]
+  );
+  let receivedUrls: string[] = [];
+  const Plugin: PluginConstructor = class {
+    constructor(..._args: unknown[]) {}
+    async handleEvent(event: unknown) {
+      const envelope = event as { payload?: { attachmentUrls?: string[] } };
+      receivedUrls = envelope.payload?.attachmentUrls || [];
+      return { success: true, result: { verdict: "clean", message: "Passed" } };
+    }
+  };
+
+  await execRun(models, loaderFor(Plugin));
+
+  assert.deepEqual({
+    receivedUrls,
+    statuses: fileUpdates.map(update => update.update?.scanStatus),
+  }, {
+    receivedUrls: ["http://x/a.zip"],
+    statuses: ["PENDING", "CLEAN"],
+  });
+});
+
+test("server-wide security policy prevents a duplicate channel scan", async () => {
+  const { models, creates, fileUpdates } = makeExecModels(
+    [{ pluginId: "security-attachment-scan", condition: "ALWAYS" }],
+    [installedEdge("security-attachment-scan")],
+    [{
+      event: "downloadableFile.created",
+      steps: [{ pluginId: "security-attachment-scan" }],
+    }]
+  );
+
+  const runs = await execRun(
+    models,
+    loaderFor(pluginReturning({ success: true }))
+  );
+
+  assert.deepEqual({ runs, creates: creates.length, fileUpdates }, {
+    runs: [],
+    creates: 0,
+    fileUpdates: [],
+  });
 });
 
 test("records channel manual-start metadata supplied by the caller", async () => {

--- a/services/plugin/channelTrigger.ts
+++ b/services/plugin/channelTrigger.ts
@@ -10,7 +10,14 @@ import type {
 import { CHANNEL_EVENTS } from './constants.js'
 import { decryptSecret } from './encryption.js'
 import { loadPluginImplementation } from './pluginLoader.js'
-import { generatePipelineId, shouldRunStep, mergeSettings, buildPluginVersionMaps, getPluginForStep } from './pipelineUtils.js'
+import {
+  generatePipelineId,
+  shouldRunStep,
+  mergeSettings,
+  buildPluginVersionMaps,
+  getPluginForStep,
+  parseStoredPipelines,
+} from './pipelineUtils.js'
 import {
   completePipelineAttempt,
   createPipelineAttempt,
@@ -28,7 +35,14 @@ import {
 } from './publicDiagnostics.js'
 import { buildBotInvocationContext } from './buildBotInvocationContext.js'
 import { createPromptDebugLogger } from './promptDebug.js'
-import type { PluginRunCreateInput, PluginRunUpdateInput, Channel, Discussion, DownloadableFile, ServerConfig } from '../../ogm_types.js'
+import {
+  SECURITY_SCAN_PLUGIN_ID,
+  failedDownloadScanOutcome,
+  resolveDownloadScanOutcome,
+  type DownloadScanOutcome,
+} from './downloadScanOutcome.js'
+import { createDownloadReadUrl } from '../downloadStorage.js'
+import type { PluginRunCreateInput, PluginRunUpdateInput, DownloadableFileUpdateInput, Channel, Discussion, DownloadableFile, ServerConfig } from '../../ogm_types.js'
 import { logger } from "../../logger.js";
 
 export const isChannelEvent = (event: string) => CHANNEL_EVENTS.has(event)
@@ -117,7 +131,7 @@ export const triggerChannelPluginPipeline = async (
   }
 
   const channel: Channel = channels[0]
-  const channelPipelines: EventPipeline[] = channel.pluginPipelines || []
+  const channelPipelines = parseStoredPipelines(channel.pluginPipelines)
   const eventPipeline = channelPipelines.find(p => p.event === event)
 
   // Build a map of channel-level plugin settings by plugin name
@@ -151,6 +165,8 @@ export const triggerChannelPluginPipeline = async (
         size
         uploadedAt
         createdAt
+        storageBucket
+        storageObjectName
       }
     }`
   })
@@ -176,6 +192,7 @@ export const triggerChannelPluginPipeline = async (
   const serverConfigs = await ServerConfig.find({
     selectionSet: `{
       serverName
+      pluginPipelines
       InstalledVersionsConnection {
         edges {
           properties {
@@ -210,6 +227,15 @@ export const triggerChannelPluginPipeline = async (
   }
 
   const edges = serverConfig.InstalledVersionsConnection?.edges || []
+  const serverUploadPipeline = parseStoredPipelines(
+    serverConfig.pluginPipelines
+  )
+    .find(pipeline => pipeline.event === 'downloadableFile.created')
+  const serverSecurityRequired = Boolean(
+    serverUploadPipeline?.steps.some(
+      step => step.pluginId === SECURITY_SCAN_PLUGIN_ID
+    )
+  )
 
   // Build version-aware plugin map (pluginName -> sorted array of versions).
   // The generated relationship edge type is cast to the plugin layer's
@@ -222,6 +248,11 @@ export const triggerChannelPluginPipeline = async (
   const pluginsToRun: PluginToRun[] = []
 
   eventPipeline.steps.forEach((step, index) => {
+    // A server-wide security requirement takes precedence. Do not scan the
+    // same bytes again merely because the channel also selected the scanner.
+    if (step.pluginId === SECURITY_SCAN_PLUGIN_ID && serverSecurityRequired) {
+      return
+    }
     // Get plugin for step, respecting version specification
     const pluginMatch = getPluginForStep(pluginVersionsMap, step.pluginId, step.version)
     if (pluginMatch) {
@@ -242,6 +273,21 @@ export const triggerChannelPluginPipeline = async (
   const runs: unknown[] = []
   const jobStatuses: PipelineJobStatus[] = pluginsToRun.map(() => 'PENDING')
   const stopOnFirstFailure = eventPipeline?.stopOnFirstFailure ?? true
+  const securityScanExpected = pluginsToRun.some(
+    plugin => plugin.pluginId === SECURITY_SCAN_PLUGIN_ID
+  )
+  let securityScanOutcome: DownloadScanOutcome | null = null
+
+  if (securityScanExpected) {
+    await DownloadableFile.update({
+      where: { id: downloadableFile.id },
+      update: ({
+        scanStatus: 'PENDING',
+        scanReason: null,
+        scanCheckedAt: null,
+      } as DownloadableFileUpdateInput),
+    })
+  }
   let previousStatus: 'SUCCEEDED' | 'FAILED' | null = null
   let pipelineStopped = false
 
@@ -505,6 +551,7 @@ export const triggerChannelPluginPipeline = async (
       }
 
       const pluginInstance = new PluginClass(context)
+      const attachmentUrl = await createDownloadReadUrl({ file: downloadableFile })
       const eventEnvelope = {
         type: event,
         payload: {
@@ -515,6 +562,7 @@ export const triggerChannelPluginPipeline = async (
           fileName: downloadableFile.fileName,
           fileSize: downloadableFile.size,
           fileUrl: downloadableFile.url,
+          attachmentUrls: attachmentUrl ? [attachmentUrl] : [],
           channel: channelContext,
           context: buildBotInvocationContext({
             invocationType: 'discussion-created',
@@ -534,6 +582,9 @@ export const triggerChannelPluginPipeline = async (
       }
 
       const result = await pluginInstance.handleEvent(eventEnvelope)
+      if (pluginId === SECURITY_SCAN_PLUGIN_ID) {
+        securityScanOutcome = resolveDownloadScanOutcome(result)
+      }
       const runEnd = performance.now()
       const durationMs = Math.round(runEnd - runStart)
 
@@ -583,6 +634,10 @@ export const triggerChannelPluginPipeline = async (
       const durationMs = Math.round(runEnd - runStart)
       const message = (error instanceof Error ? error.message : '') || 'Plugin execution failed'
 
+      if (pluginId === SECURITY_SCAN_PLUGIN_ID) {
+        securityScanOutcome = failedDownloadScanOutcome(message)
+      }
+
       previousStatus = 'FAILED'
 
       await completePluginRunLease({
@@ -623,6 +678,20 @@ export const triggerChannelPluginPipeline = async (
     } finally {
       heartbeat.stop()
     }
+  }
+
+  if (securityScanExpected) {
+    const outcome = securityScanOutcome || failedDownloadScanOutcome(
+      'The security scan was skipped before it could complete.'
+    )
+    await DownloadableFile.update({
+      where: { id: downloadableFile.id },
+      update: ({
+        scanStatus: outcome.status,
+        scanReason: outcome.reason,
+        scanCheckedAt: new Date().toISOString(),
+      } as DownloadableFileUpdateInput),
+    })
   }
 
   await completePipelineAttempt({

--- a/services/plugin/downloadPipelinePlan.test.ts
+++ b/services/plugin/downloadPipelinePlan.test.ts
@@ -117,7 +117,7 @@ test('reports no applicable plugins when configured jobs are unavailable', () =>
   )
 })
 
-test('builds an ordered fallback pipeline from installed event plugins', () => {
+test('does not run enabled plugins without an explicit event pipeline', () => {
   const secondPlugin = installedPlugin('content-metadata')
   const unrelatedPlugin = {
     ...installedPlugin('unrelated'),
@@ -138,26 +138,16 @@ test('builds an ordered fallback pipeline from installed event plugins', () => {
   })
 
   assert.deepEqual(
-    plan.pluginsToRun.map(({ pluginId, order, step }) => ({
-      pluginId,
-      order,
-      condition: step.condition,
-      continueOnError: step.continueOnError,
-    })),
-    [
-      {
-        pluginId: 'security-attachment-scan',
-        order: 0,
-        condition: 'ALWAYS',
-        continueOnError: false,
-      },
-      {
-        pluginId: 'content-metadata',
-        order: 1,
-        condition: 'ALWAYS',
-        continueOnError: false,
-      },
-    ]
+    {
+      required: plan.required,
+      reason: plan.reason,
+      pluginIds: plan.pluginsToRun.map(({ pluginId }) => pluginId),
+    },
+    {
+      required: false,
+      reason: 'NO_APPLICABLE_PLUGINS',
+      pluginIds: [],
+    }
   )
 })
 

--- a/services/plugin/downloadPipelinePlan.ts
+++ b/services/plugin/downloadPipelinePlan.ts
@@ -1,7 +1,6 @@
 import type {
   EventPipeline,
   PipelineApplicability,
-  PipelineStep,
   PluginEdgeData,
   PluginToRun,
 } from './types.js'
@@ -60,37 +59,6 @@ const resolveConfiguredSteps = ({
   return pluginsToRun
 }
 
-const resolveFallbackSteps = ({
-  event,
-  pluginVersionsMap,
-}: {
-  event: string
-  pluginVersionsMap: ReturnType<typeof buildPluginVersionMaps>
-}): PluginToRun[] => {
-  const pluginsToRun: PluginToRun[] = []
-  let order = 0
-
-  for (const [pluginId, versions] of pluginVersionsMap) {
-    const latestVersion = versions[0]
-    if (!latestVersion || !handlesEvent(latestVersion.edgeData, event)) continue
-
-    const step: PipelineStep = {
-      pluginId,
-      condition: 'ALWAYS',
-      continueOnError: false,
-    }
-    pluginsToRun.push({
-      pluginId,
-      edgeData: latestVersion.edgeData,
-      step,
-      order,
-    })
-    order += 1
-  }
-
-  return pluginsToRun
-}
-
 const uploadedBeforePolicy = ({
   applicability,
   effectiveAt,
@@ -129,10 +97,12 @@ export const resolveDownloadPipelinePlan = ({
     eventPipeline?.applicability || DEFAULT_APPLICABILITY
   const effectiveAt = eventPipeline?.effectiveAt || null
   const pluginVersionsMap = buildPluginVersionMaps(installedPluginEdges)
-  const pluginsToRun =
-    eventPipeline && eventPipeline.steps.length > 0
-      ? resolveConfiguredSteps({ event, eventPipeline, pluginVersionsMap })
-      : resolveFallbackSteps({ event, pluginVersionsMap })
+  // Enabling a plugin makes it available to pipeline editors. It must not
+  // silently opt every channel into every event declared by its manifest.
+  // Only an explicitly configured event pipeline is executable/required.
+  const pluginsToRun = eventPipeline
+    ? resolveConfiguredSteps({ event, eventPipeline, pluginVersionsMap })
+    : []
 
   if (
     uploadedBeforePolicy({

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -72,7 +72,20 @@ function makeExecModels(edges: unknown[], file = fileNode) {
   let seq = 0;
   const serverConfig = {
     serverName: "s",
-    pluginPipelines: null,
+    pluginPipelines: [
+      {
+        event: EVENT,
+        steps: edges.map((edge) => ({
+          pluginId: (edge as ReturnType<typeof installedEdge>).node.Plugin.name,
+        })),
+      },
+      {
+        event: "downloadableFile.updated",
+        steps: edges.map((edge) => ({
+          pluginId: (edge as ReturnType<typeof installedEdge>).node.Plugin.name,
+        })),
+      },
+    ],
     InstalledVersionsConnection: { edges },
   };
   const PluginRun = modelStub<"PluginRun">({

--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -444,6 +444,9 @@ test("persists the scanner verdict on the downloadable file", async () => {
       scanStatus: "PENDING",
       scanReason: null,
       scanCheckedAt: null,
+      reviewRequestedAt: null,
+      reviewRequestReason: null,
+      reviewRequestedByUsername: null,
     },
   });
   assert.deepEqual(fileUpdates[1], {

--- a/services/plugin/downloadTrigger.test.ts
+++ b/services/plugin/downloadTrigger.test.ts
@@ -69,7 +69,7 @@ test("returns [] when there is no server config", async () => {
   assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig: null })), []);
 });
 
-test("returns [] when no plugins are installed (fallback path)", async () => {
+test("returns [] when no explicit pipeline is configured", async () => {
   const serverConfig = {
     serverName: "s",
     pluginPipelines: null,
@@ -78,7 +78,7 @@ test("returns [] when no plugins are installed (fallback path)", async () => {
   assert.deepEqual(await run(makeModels({ file: fileNode, serverConfig })), []);
 });
 
-test("returns [] when an installed plugin does not handle the event", async () => {
+test("returns [] when an enabled plugin is not explicitly configured", async () => {
   const serverConfig = {
     serverName: "s",
     pluginPipelines: null,

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -210,7 +210,10 @@ export const triggerPluginRunsForDownloadableFile = async (
       update: ({
         scanStatus: 'PENDING',
         scanReason: null,
-        scanCheckedAt: null
+        scanCheckedAt: null,
+        reviewRequestedAt: null,
+        reviewRequestReason: null,
+        reviewRequestedByUsername: null
       } as DownloadableFileUpdateInput)
     })
   }

--- a/services/plugin/legacyPipelineMigration.test.ts
+++ b/services/plugin/legacyPipelineMigration.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { materializeLegacyDownloadPipelines } from './legacyPipelineMigration.js'
+
+const edge = (name: string, events: string[]) => ({
+  properties: { enabled: true, settingsJson: null },
+  node: {
+    id: `version-${name}`,
+    version: '1.0.0',
+    repoUrl: '',
+    tarballGsUri: '',
+    entryPath: 'dist/index.js',
+    manifest: JSON.stringify({ events }),
+    settingsDefaults: null,
+    uiSchema: null,
+    Plugin: {
+      id: `plugin-${name}`,
+      name,
+      displayName: name,
+      description: '',
+      metadata: null,
+    },
+  },
+})
+
+test('materializes enabled legacy download hooks as explicit pipelines', () => {
+  let policyNumber = 0
+  const result = materializeLegacyDownloadPipelines({
+    storedPipelines: [],
+    installedPluginEdges: [edge('scanner', [
+      'downloadableFile.created',
+      'downloadableFile.downloaded',
+    ])],
+    effectiveAt: '2026-08-03T00:00:00.000Z',
+    createPolicyId: () => `policy-${++policyNumber}`,
+  })
+
+  assert.deepEqual(result, {
+    pipelines: [
+      {
+        event: 'downloadableFile.created',
+        steps: [{
+          pluginId: 'scanner',
+          condition: 'ALWAYS',
+          continueOnError: false,
+        }],
+        stopOnFirstFailure: true,
+        applicability: 'ALL_FILES_IMMEDIATE',
+        effectiveAt: '2026-08-03T00:00:00.000Z',
+        policyId: 'policy-1',
+      },
+      {
+        event: 'downloadableFile.downloaded',
+        steps: [{
+          pluginId: 'scanner',
+          condition: 'ALWAYS',
+          continueOnError: false,
+        }],
+        stopOnFirstFailure: true,
+        applicability: 'ALL_FILES_IMMEDIATE',
+        effectiveAt: '2026-08-03T00:00:00.000Z',
+        policyId: 'policy-2',
+      },
+    ],
+    addedEvents: [
+      'downloadableFile.created',
+      'downloadableFile.downloaded',
+    ],
+  })
+})
+
+test('preserves an existing explicit event instead of replacing it', () => {
+  const existing = {
+    event: 'downloadableFile.created',
+    steps: [{ pluginId: 'chosen-plugin' }],
+  }
+  const result = materializeLegacyDownloadPipelines({
+    storedPipelines: [existing],
+    installedPluginEdges: [edge('scanner', ['downloadableFile.created'])],
+  })
+
+  assert.deepEqual(result, { pipelines: [existing], addedEvents: [] })
+})

--- a/services/plugin/legacyPipelineMigration.ts
+++ b/services/plugin/legacyPipelineMigration.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto'
+import { DOWNLOAD_EVENTS } from './constants.js'
+import {
+  buildPluginVersionMaps,
+  parseManifest,
+  parseStoredPipelines,
+} from './pipelineUtils.js'
+import type { EventPipeline, PluginEdgeData } from './types.js'
+
+export const materializeLegacyDownloadPipelines = ({
+  storedPipelines,
+  installedPluginEdges,
+  effectiveAt = new Date().toISOString(),
+  createPolicyId = randomUUID,
+}: {
+  storedPipelines: unknown
+  installedPluginEdges: PluginEdgeData[]
+  effectiveAt?: string
+  createPolicyId?: () => string
+}) => {
+  const pipelines = parseStoredPipelines(storedPipelines)
+  const configuredEvents = new Set(pipelines.map(pipeline => pipeline.event))
+  const versions = buildPluginVersionMaps(installedPluginEdges)
+  const additions: EventPipeline[] = []
+
+  for (const event of DOWNLOAD_EVENTS) {
+    if (configuredEvents.has(event)) continue
+
+    const steps = [...versions.entries()]
+      .filter(([, pluginVersions]) => {
+        const latest = pluginVersions[0]
+        if (!latest) return false
+        const manifest = parseManifest(latest.edgeData.node.manifest)
+        return Array.isArray(manifest.events) && manifest.events.includes(event)
+      })
+      .map(([pluginId]) => ({
+        pluginId,
+        condition: 'ALWAYS' as const,
+        continueOnError: false,
+      }))
+
+    if (steps.length === 0) continue
+    additions.push({
+      event,
+      steps,
+      stopOnFirstFailure: true,
+      applicability: 'ALL_FILES_IMMEDIATE',
+      effectiveAt,
+      policyId: createPolicyId(),
+    })
+  }
+
+  return {
+    pipelines: [...pipelines, ...additions],
+    addedEvents: additions.map(pipeline => pipeline.event),
+  }
+}

--- a/tests/integration/downloadScanReviewQueue.test.ts
+++ b/tests/integration/downloadScanReviewQueue.test.ts
@@ -1,0 +1,91 @@
+import test, { after, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  startImageModEnv,
+  stopImageModEnv,
+  resetDb,
+  run,
+  type ImageModEnv,
+} from "./imageModerationHarness.js";
+
+let env: ImageModEnv;
+
+before(async () => {
+  env = await startImageModEnv();
+}, { timeout: 240000 });
+
+after(async () => {
+  await stopImageModEnv();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+test("download scan review queue includes held files and prioritizes requests", async () => {
+  await run(`
+    CREATE (channel:Channel {uniqueName: 'general', displayName: 'General'})
+    CREATE (author:User {username: 'alice'})
+    CREATE (discussion:Discussion {
+      id: 'discussion-1',
+      title: 'Download',
+      createdAt: datetime(),
+      hasDownload: true
+    })
+    CREATE (dc:DiscussionChannel {
+      id: 'dc-1',
+      discussionId: 'discussion-1',
+      channelUniqueName: 'general',
+      createdAt: datetime()
+    })
+    CREATE (requested:DownloadableFile {
+      id: 'requested-file',
+      fileName: 'requested.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/requested.zip',
+      createdAt: datetime(),
+      scanStatus: 'SUSPICIOUS',
+      reviewRequestedAt: datetime(),
+      reviewRequestReason: 'False positive'
+    })
+    CREATE (unrequested:DownloadableFile {
+      id: 'unrequested-file',
+      fileName: 'unrequested.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/unrequested.zip',
+      createdAt: datetime(),
+      scanStatus: 'INFECTED'
+    })
+    CREATE (clean:DownloadableFile {
+      id: 'clean-file',
+      fileName: 'clean.zip',
+      kind: 'OTHER',
+      url: 'https://example.com/clean.zip',
+      createdAt: datetime(),
+      scanStatus: 'CLEAN'
+    })
+    CREATE (author)-[:POSTED_DISCUSSION]->(discussion)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+    CREATE (dc)-[:POSTED_IN_CHANNEL]->(channel)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(requested)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(unrequested)
+    CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(clean)
+  `);
+
+  const result = await env.resolvers.Query.getDownloadScanReviewQueue(
+    null,
+    { limit: 10 }
+  );
+
+  assert.deepEqual(
+    result.map((item: any) => ({
+      id: item.downloadableFileId,
+      requested: Boolean(item.reviewRequestedAt),
+      channel: item.channelUniqueName,
+    })),
+    [
+      { id: "requested-file", requested: true, channel: "general" },
+      { id: "unrequested-file", requested: false, channel: "general" },
+    ]
+  );
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -458,6 +458,9 @@ const typeDefinitions = gql`
     scanStatus: ScanStatus! @default(value: PENDING)
     scanCheckedAt: DateTime
     scanReason: String
+    reviewRequestedAt: DateTime
+    reviewRequestReason: String
+    reviewRequestedByUsername: String
 
     # purchases back‑ref
     purchasers: [Purchase!]! @relationship(type: "PURCHASED_FILE", direction: IN)
@@ -1561,6 +1564,10 @@ const typeDefinitions = gql`
       downloadableFileId: ID!
       reason: String
     ): DownloadableFile!
+    requestDownloadableFileReview(
+      downloadableFileId: ID!
+      reason: String
+    ): DownloadableFile!
     enableServerPlugin(
       pluginId: String!
       version: String!
@@ -2512,6 +2519,20 @@ const typeDefinitions = gql`
     attentionItems: [ServerHealthAttentionItem!]!
   }
 
+  type DownloadScanReviewItem @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    downloadableFileId: ID!
+    fileName: String!
+    scanStatus: ScanStatus!
+    scanReason: String
+    scanCheckedAt: DateTime
+    reviewRequestedAt: DateTime
+    reviewRequestReason: String
+    uploaderUsername: String
+    discussionId: ID!
+    discussionTitle: String
+    channelUniqueName: String
+  }
+
   type UserContributionData {
     username: String!
     displayName: String
@@ -2677,6 +2698,7 @@ const typeDefinitions = gql`
       sortBy: String
       sortDirection: String
     ): ServerHealthDashboard!
+    getDownloadScanReviewQueue(limit: Int = 50): [DownloadScanReviewItem!]!
     isOriginalPosterSuspended(issueId: String!): Boolean
     safetyCheck: SafetyCheckResponse
     getServerPluginSecrets(


### PR DESCRIPTION
## Summary
- require explicit server or channel pipeline configuration instead of implicit enabled-plugin execution
- run server security checks before channel automation and support real channel attachment scans without duplicates
- add logical quarantine review, retry, audited release, and legacy pipeline migration support

## Deployment note
Run pnpm migrate:plugin-pipelines against existing production data before deploying the fallback-removal behavior.

## Verification
- pnpm test with Node 22
- pnpm run tsc
- ESLint on changed files
- targeted coverage-enabled tests