### PR TITLE
fix: align discussion list schema with clients

### DIFF
--- a/customResolvers/cypher/discussionFlairProjection.test.ts
+++ b/customResolvers/cypher/discussionFlairProjection.test.ts
@@ -37,3 +37,23 @@ test("channel discussion flair projection keeps configured ordering metadata", (
     /ORDER BY assignedFlair\.order ASC, assignedFlair\.displayName ASC/
   );
 });
+
+test("sitewide discussion lists project public download scan metadata", () => {
+  assert.match(
+    getSiteWideDiscussionsQuery,
+    /\(d\)-\[:HAS_DOWNLOADABLE_FILE\]->\(downloadableFile:DownloadableFile\)/
+  );
+  assert.match(
+    getSiteWideDiscussionsQuery,
+    /downloadableFile\.permanentlyRemoved IS NULL OR downloadableFile\.permanentlyRemoved = false/
+  );
+  assert.match(getSiteWideDiscussionsQuery, /id: downloadableFile\.id/);
+  assert.match(
+    getSiteWideDiscussionsQuery,
+    /scanStatus: downloadableFile\.scanStatus/
+  );
+  assert.match(
+    getSiteWideDiscussionsQuery,
+    /DownloadableFiles: downloadableFiles/
+  );
+});

--- a/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
+++ b/customResolvers/cypher/getSiteWideDiscussionsQuery.cypher
@@ -173,9 +173,18 @@ WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRol
          permanentlyRemoved: image.permanentlyRemoved
      } END) WHERE img IS NOT NULL] AS albumImages
 
+OPTIONAL MATCH (d)-[:HAS_DOWNLOADABLE_FILE]->(downloadableFile:DownloadableFile)
+WHERE downloadableFile.permanentlyRemoved IS NULL OR downloadableFile.permanentlyRemoved = false
+
+WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRoles, album, albumImages,
+     [file IN COLLECT(DISTINCT CASE WHEN downloadableFile IS NOT NULL THEN {
+         id: downloadableFile.id,
+         scanStatus: downloadableFile.scanStatus
+     } END) WHERE file IS NOT NULL] AS downloadableFiles
+
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)
-WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRoles, album, albumImages,
+WITH totalCount, d, tagsText, author, discussionChannels, score, rank, serverRoles, album, albumImages, downloadableFiles,
      CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null WHEN favUser IS NOT NULL THEN true ELSE false END AS isFavorited
 
 // Return the results
@@ -209,5 +218,6 @@ RETURN {
         Images: albumImages
       }
     END,
+    DownloadableFiles: downloadableFiles,
     isFavorited: isFavorited
 } AS discussion, totalCount

--- a/customResolvers/typeResolvers.ts
+++ b/customResolvers/typeResolvers.ts
@@ -49,8 +49,12 @@ export default function buildTypeResolvers(deps: ResolverDeps) {
       SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
     },
     DiscussionChannelListItem: {
+      Flairs: emptyArrayFallback('Flairs'),
       SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),
       UpvotedByUsers: emptyArrayFallback('UpvotedByUsers'),
+    },
+    SiteWideDiscussionListItem: {
+      DownloadableFiles: emptyArrayFallback('DownloadableFiles'),
     },
     Comment: {
       SuperUpvotedByUsers: emptyArrayFallback('SuperUpvotedByUsers'),

--- a/tests/integration/getDiscussionsInChannel.test.ts
+++ b/tests/integration/getDiscussionsInChannel.test.ts
@@ -214,3 +214,43 @@ test("channel and sitewide discussion lists return assigned flairs, including ar
     expectedFlairs
   );
 });
+
+test("sitewide discussion lists return scan metadata only for non-removed downloads", async () => {
+  await run(
+    `CREATE (owner:User { username: 'alice', createdAt: datetime() })
+     CREATE (channel:Channel { uniqueName: 'downloads', displayName: 'Downloads', createdAt: datetime() })
+     CREATE (discussion:Discussion { id: 'download-1', title: 'Safe download', body: '', hasDownload: true, createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-download-1', discussionId: 'download-1', channelUniqueName: 'downloads', createdAt: datetime(), archived: false })
+     CREATE (publicFile:DownloadableFile { id: 'file-public', scanStatus: 'CLEAN', permanentlyRemoved: false })
+     CREATE (removedFile:DownloadableFile { id: 'file-removed', scanStatus: 'INFECTED', permanentlyRemoved: true })
+     CREATE (owner)-[:POSTED_DISCUSSION]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(channel)
+     CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(publicFile)
+     CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(removedFile)`
+  );
+
+  const result = await env.resolvers.Query.getSiteWideDiscussionList(
+    null,
+    {
+      searchInput: "",
+      selectedChannels: [],
+      selectedTags: [],
+      showArchived: false,
+      hasDownload: true,
+      options: {
+        offset: "0",
+        limit: "10",
+        resultsOrder: "desc",
+        sort: "new",
+        timeFrame: "week",
+      },
+    },
+    anon(),
+    {} as never
+  );
+
+  assert.deepEqual(result.discussions[0].DownloadableFiles, [
+    { id: "file-public", scanStatus: "CLEAN" },
+  ]);
+});

--- a/tests/listQuerySchema.test.ts
+++ b/tests/listQuerySchema.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Neo4jGraphQL } from "@neo4j/graphql";
+import { parse, validate } from "graphql";
+import typeDefs from "../typeDefs.js";
+
+const schema = await new Neo4jGraphQL({ typeDefs }).getSchema();
+
+const assertValid = (source: string) => {
+  const errors = validate(schema, parse(source));
+  assert.deepEqual(
+    errors.map((error) => error.message),
+    []
+  );
+};
+
+test("channel list clients can request assigned discussion flairs", () => {
+  assertValid(`
+    query ListDiscussions($channelUniqueName: String!) {
+      getDiscussionsInChannel(
+        channelUniqueName: $channelUniqueName
+        searchInput: ""
+        selectedTags: []
+        showArchived: false
+      ) {
+        discussionChannels {
+          Flairs {
+            id
+            channelUniqueName
+            displayName
+            color
+            order
+            archived
+          }
+        }
+      }
+    }
+  `);
+});
+
+test("sitewide list clients can request non-removed download scan states", () => {
+  assertValid(`
+    query ListSitewideDiscussions {
+      getSiteWideDiscussionList(
+        searchInput: ""
+        selectedChannels: []
+        selectedTags: []
+        showArchived: false
+      ) {
+        discussions {
+          DownloadableFiles(where: { permanentlyRemoved_NOT: true }) {
+            id
+            scanStatus
+          }
+        }
+      }
+    }
+  `);
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1640,6 +1640,7 @@ const typeDefinitions = gql`
     DiscussionChannels: [DiscussionChannel!]!
     Tags: [Tag!]!
     Album: Album
+    DownloadableFiles(where: DownloadableFileWhere): [DownloadableFile!]!
     isFavorited: Boolean
   }
 
@@ -1691,6 +1692,7 @@ const typeDefinitions = gql`
     discussionId: ID!
     createdAt: DateTime!
     channelUniqueName: String!
+    Flairs: [DiscussionFlair!]!
     weightedVotesCount: Float
     CommentsAggregate: CommentAggregateResult
     UpvotedByUsers: [User!]!


### PR DESCRIPTION
## Summary

- expose assigned flairs on channel discussion-list results so the mobile client query validates
- expose non-removed downloadable-file scan metadata on sitewide discussion-list results
- add schema-validation, Cypher-projection, and integration coverage for both client query shapes

## Testing

- `pnpm test` — 1,056 passing
- `pnpm run tsc`
- ESLint on changed TypeScript files
- focused schema/projection tests — 6 passing

The new Testcontainers integration case could not run locally because no container runtime was available; CI can exercise it.