### PR TITLE
Speed up TypeScript test startup

### DIFF
--- a/build_scripts/coverage-merged.sh
+++ b/build_scripts/coverage-merged.sh
@@ -14,12 +14,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "▶ unit suite (fresh coverage)…"
-pnpm exec c8 --temp-directory=coverage/tmp --clean=true --reporter=lcov \
+TS_NODE_TRANSPILE_ONLY=true pnpm exec c8 --temp-directory=coverage/tmp --clean=true --reporter=lcov \
   node --loader ts-node/esm --test \
   $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)
 
 echo "▶ integration suite (accumulating onto unit coverage)…"
-TESTCONTAINERS_REUSE_ENABLE=true pnpm exec c8 --temp-directory=coverage/tmp --clean=false \
+TS_NODE_TRANSPILE_ONLY=true TESTCONTAINERS_REUSE_ENABLE=true pnpm exec c8 --temp-directory=coverage/tmp --clean=false \
   --reporter=lcov --reporter=text-summary \
   node --loader ts-node/esm --test --test-concurrency=1 \
   $(find ./tests/integration -name '*test.ts' -print | sort)

--- a/build_scripts/integration-shard.sh
+++ b/build_scripts/integration-shard.sh
@@ -36,5 +36,6 @@ list_files
 # inline $(list_files) word-splits the newline-separated paths into args, the
 # same way the other coverage scripts use $(find ...).
 export TESTCONTAINERS_REUSE_ENABLE=true
+export TS_NODE_TRANSPILE_ONLY=true
 c8 --reporter=lcov --reporter=text-summary \
   node --loader ts-node/esm --test --test-concurrency=1 $(list_files)

--- a/hooks/userMentionNotificationHook.ts
+++ b/hooks/userMentionNotificationHook.ts
@@ -4,13 +4,13 @@ import { sendEmail } from '../services/mail/index.js';
 import { logger } from "../logger.js";
 import {
   buildDiscussionMentionContext,
-  MentionContextDiscussion,
-  DiscussionSnapshot,
+  type MentionContextDiscussion,
+  type DiscussionSnapshot,
 } from '../utils/buildDiscussionMentionContext.js';
 import {
   buildCommentMentionContext,
-  MentionContextComment,
-  CommentSnapshot,
+  type MentionContextComment,
+  type CommentSnapshot,
 } from '../utils/buildCommentMentionContext.js';
 import {
   createCommentMentionNotificationEmail,
@@ -23,11 +23,15 @@ import type { Record as Neo4jRecord } from 'neo4j-driver';
 export { getNewMentionUsernames } from '../utils/getNewMentionUsernames.js';
 export {
   buildDiscussionMentionContext,
+} from '../utils/buildDiscussionMentionContext.js';
+export type {
   MentionContextDiscussion,
   DiscussionSnapshot,
 } from '../utils/buildDiscussionMentionContext.js';
 export {
   buildCommentMentionContext,
+} from '../utils/buildCommentMentionContext.js';
+export type {
   MentionContextComment,
   CommentSnapshot,
 } from '../utils/buildCommentMentionContext.js';

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "node": "22.x"
   },
   "scripts": {
-    "test": "node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
-    "test:integration": "TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
-    "coverage": "c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
-    "coverage:integration": "TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "test": "TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
+    "test:integration": "TS_NODE_TRANSPILE_ONLY=true TESTCONTAINERS_REUSE_ENABLE=true node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
+    "coverage": "TS_NODE_TRANSPILE_ONLY=true c8 node --loader ts-node/esm --test $(find . -path './node_modules' -prune -o -path './ts_emitted' -prune -o -path './tests/integration' -prune -o -name '*test.ts' -print | sort)",
+    "coverage:integration": "TS_NODE_TRANSPILE_ONLY=true TESTCONTAINERS_REUSE_ENABLE=true c8 node --loader ts-node/esm --test --test-concurrency=1 $(find ./tests/integration -name '*test.ts' -print 2>/dev/null | sort)",
     "test:integration:shard": "bash build_scripts/integration-shard.sh",
     "coverage:merged": "bash build_scripts/coverage-merged.sh",
     "prepare": "husky",


### PR DESCRIPTION
## Summary
- run ts-node test processes in transpile-only mode
- apply the setting consistently to unit, integration, shard, and merged-coverage entry points
- retain the standalone TypeScript type-checking job as the CI type-safety gate

## Motivation
The test runner starts a separate ts-node process for every test file. Repeating TypeScript checking in each process dominates wall time even though CI already runs the full tsc check before tests.

## Validation
- jq empty package.json
- bash -n build_scripts/integration-shard.sh build_scripts/coverage-merged.sh
- git diff --check
- isolated eight-file benchmark: 21.0s current mode, 6.2s transpile-only

CI timing will be compared with recent successful baseline runs after this PR completes.