### PR TITLE
Speed up and balance integration tests

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -114,9 +114,12 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
-      - name: Verify build (tsc + cypher copy)
+      # codegen and tsc already ran above, which covers the first two commands
+      # in the build script. Complete the remaining asset-copy step without
+      # regenerating and recompiling the entire project a second time.
+      - name: Complete build (copy Cypher assets)
         if: needs.changes.outputs.code == 'true'
-        run: pnpm run build
+        run: node build_scripts/copyCypherFiles.js
 
       - name: Docs-only change — tests skipped
         if: needs.changes.outputs.code != 'true'

--- a/build_scripts/integration-shard-overrides.txt
+++ b/build_scripts/integration-shard-overrides.txt
@@ -1,0 +1,11 @@
+# Timing-based overrides for the four-shard CI matrix.
+#
+# Format: <shard> <test-file>
+# Files not listed here keep the deterministic round-robin assignment. These
+# four moves balance the process timings measured in CI run 30782915524 after
+# reusable-container startup is removed from the remaining direct-container
+# suites. Keep this list small and remeasure before adding more overrides.
+3 ./tests/integration/contentUnarchive.test.ts
+3 ./tests/integration/contributionsQueries.test.ts
+3 ./tests/integration/commentQueries.test.ts
+3 ./tests/integration/lockChannel.test.ts

--- a/build_scripts/integration-shard-overrides.txt
+++ b/build_scripts/integration-shard-overrides.txt
@@ -2,10 +2,9 @@
 #
 # Format: <shard> <test-file>
 # Files not listed here keep the deterministic round-robin assignment. These
-# four moves balance the process timings measured in CI run 30782915524 after
-# reusable-container startup is removed from the remaining direct-container
-# suites. Keep this list small and remeasure before adding more overrides.
-3 ./tests/integration/contentUnarchive.test.ts
-3 ./tests/integration/contributionsQueries.test.ts
+# two moves balance the process timings measured in CI runs 30782915524 and
+# 30789127659 after reusable-container startup is removed from the remaining
+# direct-container suites. Keep this list small and remeasure before adding
+# more overrides.
 3 ./tests/integration/commentQueries.test.ts
 3 ./tests/integration/lockChannel.test.ts

--- a/build_scripts/integration-shard.sh
+++ b/build_scripts/integration-shard.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Run one shard of the integration suite. The sorted integration test files are
-# partitioned round-robin across SHARD_TOTAL shards, so each shard runs roughly
-# 1/SHARD_TOTAL of them. CI runs the shards in parallel (a matrix job), each
-# against its own Testcontainers Neo4j. Coverage (lcov) is written for this
-# shard's subset; CI uploads each shard under the `integration` Codecov flag and
-# Codecov unions them, so a line covered by any shard counts as covered.
+# Run one shard of the integration suite. Files are partitioned round-robin,
+# with a small set of measured four-shard overrides to balance actual runtime.
+# CI runs the shards in parallel (a matrix job), each against its own
+# Testcontainers Neo4j. Coverage (lcov) is written for this shard's subset; CI
+# uploads each shard under the `integration` Codecov flag and Codecov unions
+# them, so a line covered by any shard counts as covered.
 #
 # Env:
 #   SHARD       1-based shard index   (default 1)
@@ -17,11 +17,23 @@ cd "$(dirname "$0")/.."
 
 SHARD="${SHARD:-1}"
 SHARD_TOTAL="${SHARD_TOTAL:-1}"
+OVERRIDES_FILE="build_scripts/integration-shard-overrides.txt"
 
-# Round-robin: the file on line NR goes to shard ((NR-1) % SHARD_TOTAL) + 1.
+# Round-robin is the general rule, so newly added tests are always included.
+# For the four-shard CI layout, apply the small timing-based override map.
 list_files() {
   find ./tests/integration -name '*test.ts' -print | sort \
-    | awk "NR % ${SHARD_TOTAL} == (${SHARD} - 1)"
+    | awk -v shard="${SHARD}" -v total="${SHARD_TOTAL}" '
+        FNR == NR {
+          if ($1 !~ /^#/ && NF == 2) overrides[$2] = $1
+          next
+        }
+        {
+          target = (FNR % total) + 1
+          if (total == 4 && ($0 in overrides)) target = overrides[$0]
+          if (target == shard) print
+        }
+      ' "${OVERRIDES_FILE}" -
 }
 
 if [ -z "$(list_files)" ]; then

--- a/tests/integration/authenticatedRoles.test.ts
+++ b/tests/integration/authenticatedRoles.test.ts
@@ -24,6 +24,7 @@ import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
 
 const ADMIN_EMAIL = "admin@e2e.test";
 const SERVER_CONFIG_NAME = "E2ETestServer";
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
 
 let container: StartedNeo4jContainer;
 let schema: GraphQLSchema;
@@ -33,7 +34,9 @@ let ogm: any;
 before(async () => {
   // APOC is required: the OGM queries the permission rules run (suspension
   // lookups) call apoc.date.convertFormat.
-  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  let builder = new Neo4jContainer("neo4j:5-community").withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
 
   // The schema helper builds its driver from these, so set them before import.
   process.env.NEO4J_URI = container.getBoltUri();
@@ -51,6 +54,7 @@ before(async () => {
 
   const session = driver.session();
   try {
+    await session.run("MATCH (n) DETACH DELETE n");
     await session.run("CREATE (:User { username: 'adminuser' })");
     await session.run("CREATE (:User { username: 'normaluser' })");
     await session.run("CREATE (:ServerConfig { serverName: $name })", {
@@ -71,7 +75,7 @@ before(async () => {
 
 after(async () => {
   await driver?.close();
-  await container?.stop();
+  if (!REUSE) await container?.stop();
 });
 
 const mockToken = (claims: Record<string, unknown>) =>

--- a/tests/integration/authorIsChannelModerator.test.ts
+++ b/tests/integration/authorIsChannelModerator.test.ts
@@ -12,6 +12,7 @@ import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
 
 const SERVER_CONFIG_NAME = "ModTagTestServer";
 const CHANNEL = "cats";
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
 
 let container: StartedNeo4jContainer;
 let schema: GraphQLSchema;
@@ -19,7 +20,9 @@ let driver: Driver;
 let ogm: any;
 
 before(async () => {
-  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  let builder = new Neo4jContainer("neo4j:5-community").withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   process.env.NEO4J_URI = container.getBoltUri();
   process.env.NEO4J_USER = container.getUsername();
   process.env.NEO4J_PASSWORD = container.getPassword();
@@ -33,6 +36,7 @@ before(async () => {
 
   const session = driver.session();
   try {
+    await session.run("MATCH (n) DETACH DELETE n");
     await session.run("CREATE (:Channel { uniqueName: $ch })", { ch: CHANNEL });
 
     // Owner: ADMIN_OF_CHANNEL
@@ -79,7 +83,7 @@ before(async () => {
 
 after(async () => {
   await driver?.close();
-  await container?.stop();
+  if (!REUSE) await container?.stop();
 });
 
 const QUERY = /* GraphQL */ `

--- a/tests/integration/channelPreferenceEnforcement.test.ts
+++ b/tests/integration/channelPreferenceEnforcement.test.ts
@@ -57,6 +57,8 @@ before(async () => {
   ({ schema, driver, ogm } = await buildPermissionedSchema());
   await ogm.init();
 
+  await run("MATCH (n) DETACH DELETE n");
+
   // Seed the admin caller and a ServerConfig with downloads enabled at the
   // SERVER level — so the server-level download gate (serverDownloadsEnabled)
   // always passes and the CHANNEL-level downloadsEnabled flag is the only thing

--- a/tests/integration/imagePermissions.test.ts
+++ b/tests/integration/imagePermissions.test.ts
@@ -14,6 +14,7 @@ import { mockToken } from "./imageModerationHarness.js";
 import { ERROR_MESSAGES } from "../../rules/errorMessages.js";
 
 const SERVER_CONFIG_NAME = "ImagePermTestServer";
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
 
 let container: StartedNeo4jContainer;
 let schema: GraphQLSchema;
@@ -21,7 +22,9 @@ let driver: Driver;
 let ogm: any;
 
 before(async () => {
-  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  let builder = new Neo4jContainer("neo4j:5-community").withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   process.env.NEO4J_URI = container.getBoltUri();
   process.env.NEO4J_USER = container.getUsername();
   process.env.NEO4J_PASSWORD = container.getPassword();
@@ -37,7 +40,7 @@ before(async () => {
 
 after(async () => {
   await driver?.close();
-  await container?.stop();
+  if (!REUSE) await container?.stop();
 });
 
 beforeEach(async () => {

--- a/tests/integration/moderationProfileIdentityLink.test.ts
+++ b/tests/integration/moderationProfileIdentityLink.test.ts
@@ -26,6 +26,7 @@ const USERNAME = "linkeduser";
 const MOD_PROFILE = "PseudoMod";
 const EMAIL = "secret@e2e.test";
 const OTHER_USERNAME = "otheruser";
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
 
 let container: StartedNeo4jContainer;
 let schema: GraphQLSchema;
@@ -33,10 +34,11 @@ let driver: Driver;
 let ogm: any;
 
 before(async () => {
-  container = await new Neo4jContainer("neo4j:5-community")
+  let builder = new Neo4jContainer("neo4j:5-community")
     .withApoc()
-    .withStartupTimeout(240000)
-    .start();
+    .withStartupTimeout(240000);
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   process.env.NEO4J_URI = container.getBoltUri();
   process.env.NEO4J_USER = container.getUsername();
   process.env.NEO4J_PASSWORD = container.getPassword();
@@ -68,6 +70,7 @@ before(async () => {
 
   const session = driver.session();
   try {
+    await session.run("MATCH (n) DETACH DELETE n");
     // A user whose real identity (username + email) is linked to a pseudonymous
     // moderation profile, plus an unrelated second user used for the
     // authenticated-non-owner case.
@@ -87,7 +90,7 @@ before(async () => {
 
 after(async () => {
   await driver?.close();
-  await container?.stop();
+  if (!REUSE) await container?.stop();
 });
 
 const mockToken = (claims: Record<string, unknown>) =>

--- a/tests/integration/provisionServerDefaults.test.ts
+++ b/tests/integration/provisionServerDefaults.test.ts
@@ -11,6 +11,7 @@ import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
 import { ROLE_NAMES } from "../../seedData/defaultRoles.js";
 
 const SERVER_CONFIG_NAME = "ProvisionTestServer";
+const REUSE = process.env.TESTCONTAINERS_REUSE_ENABLE === "true";
 
 let container: StartedNeo4jContainer;
 let driver: Driver;
@@ -21,7 +22,9 @@ const provision = () =>
   provisionServerDefaultsFromOgm(ogm, { serverName: SERVER_CONFIG_NAME });
 
 before(async () => {
-  container = await new Neo4jContainer("neo4j:5-community").withApoc().start();
+  let builder = new Neo4jContainer("neo4j:5-community").withApoc();
+  if (REUSE) builder = builder.withReuse();
+  container = await builder.start();
   process.env.NEO4J_URI = container.getBoltUri();
   process.env.NEO4J_USER = container.getUsername();
   process.env.NEO4J_PASSWORD = container.getPassword();
@@ -42,6 +45,7 @@ before(async () => {
   // "DefaultServerRole must be less than or equal to one").
   const session = driver.session();
   try {
+    await session.run("MATCH (n) DETACH DELETE n");
     await session.run(
       `CREATE (sc:ServerConfig { serverName: $name })
        CREATE (a:User { username: 'alice' })-[:ADMIN_OF_SERVER]->(sc)
@@ -57,7 +61,7 @@ before(async () => {
 
 after(async () => {
   await driver?.close();
-  await container?.stop();
+  if (!REUSE) await container?.stop();
 });
 
 const findRole = async (name: string) => {

--- a/tests/integration/suspensionEnforcement.test.ts
+++ b/tests/integration/suspensionEnforcement.test.ts
@@ -51,6 +51,7 @@ before(async () => {
   ({ schema, driver, ogm } = await buildPermissionedSchema());
   await ogm.init();
 
+  await run("MATCH (n) DETACH DELETE n");
   await run(
     `CREATE (:ServerConfig { serverName: $name, enableDownloads: true, allowedFileTypes: [] })
      CREATE (:User { username: 'normaluser' })`,


### PR DESCRIPTION
## Summary
- reuse one Neo4j Testcontainers instance per integration shard and reset graph state before direct-container suites seed data
- rebalance the four CI shards using timings from the successful post-PR #192 run
- skip a duplicate codegen and TypeScript compilation pass after those checks have already succeeded

## Validation
- full TypeScript compile
- shell syntax, workflow/package JSON, and whitespace checks
- verified all 53 integration files are assigned exactly once across four shards
- local container-backed tests could not run because this workspace has no available Docker runtime; this PR's CI run is the authoritative integration validation and timing measurement

## Timing basis
The shard override map uses per-file timings from successful workflow run 30782915524. I will update this PR with the measured CI result.