### PR TITLE
fix: project files in channel download lists

### DIFF
--- a/customResolvers/cypher/discussionFlairProjection.test.ts
+++ b/customResolvers/cypher/discussionFlairProjection.test.ts
@@ -38,22 +38,24 @@ test("channel discussion flair projection keeps configured ordering metadata", (
   );
 });
 
-test("sitewide discussion lists project public download scan metadata", () => {
+const assertProjectsPublicDownloadScanMetadata = (query: string) => {
   assert.match(
-    getSiteWideDiscussionsQuery,
+    query,
     /\(d\)-\[:HAS_DOWNLOADABLE_FILE\]->\(downloadableFile:DownloadableFile\)/
   );
   assert.match(
-    getSiteWideDiscussionsQuery,
+    query,
     /downloadableFile\.permanentlyRemoved IS NULL OR downloadableFile\.permanentlyRemoved = false/
   );
-  assert.match(getSiteWideDiscussionsQuery, /id: downloadableFile\.id/);
-  assert.match(
-    getSiteWideDiscussionsQuery,
-    /scanStatus: downloadableFile\.scanStatus/
-  );
-  assert.match(
-    getSiteWideDiscussionsQuery,
-    /DownloadableFiles: downloadableFiles/
-  );
+  assert.match(query, /id: downloadableFile\.id/);
+  assert.match(query, /scanStatus: downloadableFile\.scanStatus/);
+  assert.match(query, /DownloadableFiles: downloadableFiles/);
+};
+
+test("sitewide discussion lists project public download scan metadata", () => {
+  assertProjectsPublicDownloadScanMetadata(getSiteWideDiscussionsQuery);
+});
+
+test("channel discussion lists project public download scan metadata", () => {
+  assertProjectsPublicDownloadScanMetadata(getDiscussionChannelsQuery);
 });

--- a/customResolvers/cypher/getDiscussionChannelsQuery.cypher
+++ b/customResolvers/cypher/getDiscussionChannelsQuery.cypher
@@ -196,20 +196,30 @@ WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperU
          permanentlyRemoved: image.permanentlyRemoved
      } END) WHERE img IS NOT NULL] AS albumImages
 
+OPTIONAL MATCH (d)-[:HAS_DOWNLOADABLE_FILE]->(downloadableFile:DownloadableFile)
+WHERE downloadableFile.permanentlyRemoved IS NULL OR downloadableFile.permanentlyRemoved = false
+
+WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
+     weightedVotesCount, comments, hotRank, album, albumImages,
+     [file IN COLLECT(DISTINCT CASE WHEN downloadableFile IS NOT NULL THEN {
+         id: downloadableFile.id,
+         scanStatus: downloadableFile.scanStatus
+     } END) WHERE file IS NOT NULL] AS downloadableFiles
+
 // Check if the logged-in user has favorited this discussion
 OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_DISCUSSIONS]->(d)
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
-     weightedVotesCount, comments, hotRank, album, albumImages,
+     weightedVotesCount, comments, hotRank, album, albumImages, downloadableFiles,
      CASE WHEN $loggedInUsername IS NULL OR $loggedInUsername = "" THEN null WHEN favUser IS NOT NULL THEN true ELSE false END AS isFavorited
 
 // Include every assigned flair, including archived flairs. Archiving prevents
 // future assignment but must not erase a historical discussion's category.
 OPTIONAL MATCH (dc)-[:HAS_DISCUSSION_FLAIR]->(assignedFlair:DiscussionFlair)
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
-     weightedVotesCount, comments, hotRank, album, albumImages, isFavorited, assignedFlair
+     weightedVotesCount, comments, hotRank, album, albumImages, downloadableFiles, isFavorited, assignedFlair
 ORDER BY assignedFlair.order ASC, assignedFlair.displayName ASC
 WITH totalCount, dc, d, author, tagsText, loggedInUserUpvote, loggedInUserSuperUpvote, totalUpvoters,
-     weightedVotesCount, comments, hotRank, album, albumImages, isFavorited,
+     weightedVotesCount, comments, hotRank, album, albumImages, downloadableFiles, isFavorited,
      [flair IN COLLECT(DISTINCT assignedFlair) WHERE flair IS NOT NULL | {
          id: flair.id,
          channelUniqueName: flair.channelUniqueName,
@@ -266,6 +276,7 @@ RETURN {
                 }
               END,
         Tags: [t IN tagsText | {text: t}],
+        DownloadableFiles: downloadableFiles,
         // Membership-derived MOD badge: is the author channel staff (owner or
         // moderator) of this channel? Computed inline because the @cypher field
         // of the same name only auto-resolves on the generated `discussions`

--- a/tests/integration/getDiscussionsInChannel.test.ts
+++ b/tests/integration/getDiscussionsInChannel.test.ts
@@ -254,3 +254,39 @@ test("sitewide discussion lists return scan metadata only for non-removed downlo
     { id: "file-public", scanStatus: "CLEAN" },
   ]);
 });
+
+test("channel discussion lists return scan metadata only for non-removed downloads", async () => {
+  await run(
+    `CREATE (owner:User { username: 'alice', createdAt: datetime() })
+     CREATE (channel:Channel { uniqueName: 'downloads', displayName: 'Downloads', createdAt: datetime() })
+     CREATE (discussion:Discussion { id: 'download-1', title: 'Safe download', body: '', hasDownload: true, createdAt: datetime() })
+     CREATE (dc:DiscussionChannel { id: 'dc-download-1', discussionId: 'download-1', channelUniqueName: 'downloads', createdAt: datetime(), archived: false })
+     CREATE (publicFile:DownloadableFile { id: 'file-public', scanStatus: 'CLEAN', permanentlyRemoved: false })
+     CREATE (removedFile:DownloadableFile { id: 'file-removed', scanStatus: 'INFECTED', permanentlyRemoved: true })
+     CREATE (owner)-[:POSTED_DISCUSSION]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(discussion)
+     CREATE (dc)-[:POSTED_IN_CHANNEL]->(channel)
+     CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(publicFile)
+     CREATE (discussion)-[:HAS_DOWNLOADABLE_FILE]->(removedFile)`
+  );
+
+  const result = await env.resolvers.Query.getDiscussionsInChannel(
+    null,
+    {
+      channelUniqueName: "downloads",
+      options: { offset: "0", limit: "10", sort: "new", timeFrame: "week" },
+      selectedTags: [],
+      searchInput: "",
+      showArchived: false,
+      showUnanswered: false,
+      hasDownload: true,
+      labelFilters: [],
+    },
+    anon(),
+    {} as never
+  );
+
+  assert.deepEqual(result.discussionChannels[0].Discussion.DownloadableFiles, [
+    { id: "file-public", scanStatus: "CLEAN" },
+  ]);
+});


### PR DESCRIPTION
## Summary

- project non-removed downloadable-file scan metadata from the channel discussion-list Cypher query
- include the projected files in each nested `Discussion` result so the non-null GraphQL field resolves correctly
- add static projection coverage and a live Neo4j regression test for the exact channel download-list path

## Testing

- `pnpm test` — 1,069 passing
- `pnpm run tsc`
- ESLint on changed TypeScript files
- focused projection tests — 5 passing
- `tests/integration/getDiscussionsInChannel.test.ts` — 7 passing against Neo4j/Testcontainers