### PR TITLE
fix: parse stored plugin pipeline configuration

### DIFF
--- a/customResolvers/mutations/startPluginPipeline.ts
+++ b/customResolvers/mutations/startPluginPipeline.ts
@@ -19,7 +19,10 @@ import {
   triggerPluginRunsForDownloadableFile,
 } from "../../services/pluginRunner.js";
 import { resolveDownloadPipelinePlan } from "../../services/plugin/downloadPipelinePlan.js";
-import { generatePipelineId } from "../../services/plugin/pipelineUtils.js";
+import {
+  generatePipelineId,
+  parseStoredPipelines,
+} from "../../services/plugin/pipelineUtils.js";
 import type {
   EventPipeline,
   PluginEdgeData,
@@ -184,7 +187,7 @@ export const createStartPluginPipelineResolver = (
       scope = "CHANNEL";
       channelId = requestedChannelId;
       moderationChannelNames = [requestedChannelId];
-      pipelines = (channel.pluginPipelines || []) as EventPipeline[];
+      pipelines = parseStoredPipelines(channel.pluginPipelines);
       ownerUsername = discussion.Author?.username;
       uploaderUsername = discussion.DownloadableFile?.uploadedByUsername;
       uploadedAt =
@@ -237,7 +240,7 @@ export const createStartPluginPipelineResolver = (
     });
     const config = configs[0] as ServerConfigType | undefined;
     if (scope === "SERVER") {
-      pipelines = (config?.pluginPipelines || []) as EventPipeline[];
+      pipelines = parseStoredPipelines(config?.pluginPipelines);
     }
     const pipelineConfigured =
       scope === "SERVER" ||

--- a/customResolvers/queries/getApplicablePluginPipeline.ts
+++ b/customResolvers/queries/getApplicablePluginPipeline.ts
@@ -8,8 +8,9 @@ import type {
   ServerConfig as ServerConfigType,
   ServerConfigModel,
 } from '../../ogm_types.js'
-import type { EventPipeline, PluginEdgeData } from '../../services/plugin/types.js'
+import type { PluginEdgeData } from '../../services/plugin/types.js'
 import { resolveDownloadPipelinePlan } from '../../services/plugin/downloadPipelinePlan.js'
+import { parseStoredPipelines } from '../../services/plugin/pipelineUtils.js'
 import { assertPublicPipelineTargetVisible } from './pluginPipelineVisibility.js'
 
 type ApplicablePipelineArgs = {
@@ -105,7 +106,7 @@ const getResolver = ({
     }`,
   })
   const config = configs[0] as ServerConfigType | undefined
-  let pipelines = (config?.pluginPipelines || []) as EventPipeline[]
+  let pipelines = parseStoredPipelines(config?.pluginPipelines)
   let pipelineConfigured = false
 
   if (scope === 'CHANNEL') {
@@ -119,7 +120,7 @@ const getResolver = ({
         extensions: { code: 'NOT_FOUND' },
       })
     }
-    pipelines = (channel.pluginPipelines || []) as EventPipeline[]
+    pipelines = parseStoredPipelines(channel.pluginPipelines)
     pipelineConfigured = Boolean(
       pipelines.find(pipeline => pipeline.event === eventType)?.steps.length
     )

--- a/customResolvers/queries/pluginPipelinePublicApi.test.ts
+++ b/customResolvers/queries/pluginPipelinePublicApi.test.ts
@@ -70,14 +70,14 @@ test('returns an applicable pipeline before any attempt exists', async () => {
     ServerConfig: modelStub<'ServerConfig'>({
       find: async () => [
         {
-          pluginPipelines: [
+          pluginPipelines: JSON.stringify([
             {
               event: 'downloadableFile.created',
               applicability: 'NEW_FILES_ONLY',
               effectiveAt: '2026-07-30T00:00:00.000Z',
               steps: [{ pluginId: 'scanner' }],
             },
-          ],
+          ]),
           InstalledVersionsConnection: {
             edges: [
               {
@@ -162,10 +162,10 @@ test('returns channel-scoped applicability for the download discussion', async (
     Channel: modelStub<'Channel'>({
       find: async () => [{
         uniqueName: 'cats',
-        pluginPipelines: [{
+        pluginPipelines: JSON.stringify([{
           event: 'discussionChannel.created',
           steps: [{ pluginId: 'scanner' }],
-        }],
+        }]),
       }],
     }),
     Discussion: discussionModel,

--- a/services/plugin/downloadTrigger.ts
+++ b/services/plugin/downloadTrigger.ts
@@ -3,14 +3,19 @@ import { Storage } from '@google-cloud/storage'
 import type {
   TriggerArgs,
   PluginEdgeData,
-  EventPipeline,
   PendingRun,
   PipelineExecutionMetadata,
 } from './types.js'
 import { DOWNLOAD_EVENTS } from './constants.js'
 import { decryptSecret } from './encryption.js'
 import { loadPluginImplementation } from './pluginLoader.js'
-import { generatePipelineId, shouldRunStep, mergeSettings, getAttachmentUrls } from './pipelineUtils.js'
+import {
+  generatePipelineId,
+  shouldRunStep,
+  mergeSettings,
+  getAttachmentUrls,
+  parseStoredPipelines,
+} from './pipelineUtils.js'
 import { resolveDownloadPipelinePlan } from './downloadPipelinePlan.js'
 import {
   completePipelineAttempt,
@@ -158,7 +163,7 @@ export const triggerPluginRunsForDownloadableFile = async (
 
   const edges = serverConfig.InstalledVersionsConnection?.edges || []
 
-  const pipelines: EventPipeline[] = serverConfig.pluginPipelines || []
+  const pipelines = parseStoredPipelines(serverConfig.pluginPipelines)
   const plan = resolveDownloadPipelinePlan({
     event,
     pipelines,

--- a/services/plugin/pipelineCampaign.ts
+++ b/services/plugin/pipelineCampaign.ts
@@ -14,6 +14,7 @@ import {
 } from "../../ogm_types.js";
 import type { EventPipeline, Models } from "./types.js";
 import { triggerPluginRunsForDownloadableFile } from "./downloadTrigger.js";
+import { parseStoredPipelines } from "./pipelineUtils.js";
 import { logger } from "../../logger.js";
 
 export const DOWNLOAD_CREATED_EVENT = "downloadableFile.created";
@@ -60,7 +61,7 @@ export const getCampaignPolicy = async ({
   const configs = await ServerConfig.find({
     selectionSet: `{ pluginPipelines }`,
   });
-  const pipelines = (configs[0]?.pluginPipelines || []) as EventPipeline[];
+  const pipelines = parseStoredPipelines(configs[0]?.pluginPipelines);
   const policy = pipelines.find(item => item.policyId === policyId);
   if (
     !policy ||

--- a/services/plugin/pipelineUtils.test.ts
+++ b/services/plugin/pipelineUtils.test.ts
@@ -168,6 +168,13 @@ async function testParseStoredPipelinesWithObject() {
   assert.deepEqual(result, [], "Non-array object should return empty array");
 }
 
+async function testParseStoredPipelinesWithJsonObject() {
+  const stored = JSON.stringify({ event: "file.created", steps: [] });
+  const result = parseStoredPipelines(stored);
+
+  assert.deepEqual(result, [], "JSON that is not an array should return empty array");
+}
+
 async function testParseStoredPipelinesWithNull() {
   const result = parseStoredPipelines(null);
 
@@ -506,6 +513,7 @@ async function run() {
   await testParseStoredPipelinesWithInvalidJsonString();
   await testParseStoredPipelinesWithArray();
   await testParseStoredPipelinesWithObject();
+  await testParseStoredPipelinesWithJsonObject();
   await testParseStoredPipelinesWithNull();
   await testParseStoredPipelinesWithUndefined();
   await testParseStoredPipelinesWithEmptyString();

--- a/services/plugin/pipelineUtils.ts
+++ b/services/plugin/pipelineUtils.ts
@@ -60,12 +60,13 @@ export const parseStoredPipelines = (stored: unknown): EventPipeline[] => {
   if (!stored) return []
   if (typeof stored === 'string') {
     try {
-      return JSON.parse(stored)
+      const parsed: unknown = JSON.parse(stored)
+      return Array.isArray(parsed) ? parsed as EventPipeline[] : []
     } catch {
       return []
     }
   }
-  return Array.isArray(stored) ? stored : []
+  return Array.isArray(stored) ? stored as EventPipeline[] : []
 }
 
 export const parseManifest = (manifest: unknown): Record<string, unknown> => {


### PR DESCRIPTION
## Summary
- parse serialized pipeline configuration before resolving applicability
- use the same normalization for manual starts, automatic download runs, and rollout campaigns
- add regression coverage for serialized server and channel pipeline configuration

## Production issue
The public pipeline overview query failed with `pipelines.find is not a function` because Neo4j returns the stored JSON scalar as a string.

## Verification
- targeted backend suite: 30 tests passed
- `pnpm run tsc`
- ESLint on changed files