### PR TITLE
Keep stable round-robin integration shards

### DIFF
--- a/build_scripts/integration-shard-overrides.txt
+++ b/build_scripts/integration-shard-overrides.txt
@@ -2,9 +2,11 @@
 #
 # Format: <shard> <test-file>
 # Files not listed here keep the deterministic round-robin assignment. These
-# two moves balance the process timings measured in CI runs 30782915524 and
-# 30789127659 after reusable-container startup is removed from the remaining
-# direct-container suites. Keep this list small and remeasure before adding
-# more overrides.
+# These moves balance the process timings measured in CI runs 30782915524,
+# 30789127659, and 30790103563 after reusable-container startup is removed from
+# the remaining direct-container suites. Keep this list small and remeasure
+# before adding more overrides.
+1 ./tests/integration/authenticatedRoles.test.ts
+1 ./tests/integration/imagePermissions.test.ts
 3 ./tests/integration/commentQueries.test.ts
 3 ./tests/integration/lockChannel.test.ts

--- a/build_scripts/integration-shard-overrides.txt
+++ b/build_scripts/integration-shard-overrides.txt
@@ -1,11 +1,7 @@
 # Timing-based overrides for the four-shard CI matrix.
 #
 # Format: <shard> <test-file>
-# Files not listed here keep the deterministic round-robin assignment. These
-# These moves balance the process timings measured in CI runs 30782915524,
-# 30789127659, 30790103563, and 30790926765 after reusable-container startup is
-# removed from the remaining direct-container suites. Keep this list small and
-# remeasure before adding more overrides.
-1 ./tests/integration/authenticatedRoles.test.ts
-3 ./tests/integration/commentQueries.test.ts
-3 ./tests/integration/lockChannel.test.ts
+# Files not listed here keep the deterministic round-robin assignment. CI runs
+# 30782915524, 30789127659, 30790103563, 30790926765, and 30791666071 showed
+# enough runner variance that no measured override was consistently faster than
+# round-robin. Keep this list empty unless repeated runs show a stable imbalance.

--- a/build_scripts/integration-shard-overrides.txt
+++ b/build_scripts/integration-shard-overrides.txt
@@ -3,10 +3,9 @@
 # Format: <shard> <test-file>
 # Files not listed here keep the deterministic round-robin assignment. These
 # These moves balance the process timings measured in CI runs 30782915524,
-# 30789127659, and 30790103563 after reusable-container startup is removed from
-# the remaining direct-container suites. Keep this list small and remeasure
-# before adding more overrides.
+# 30789127659, 30790103563, and 30790926765 after reusable-container startup is
+# removed from the remaining direct-container suites. Keep this list small and
+# remeasure before adding more overrides.
 1 ./tests/integration/authenticatedRoles.test.ts
-1 ./tests/integration/imagePermissions.test.ts
 3 ./tests/integration/commentQueries.test.ts
 3 ./tests/integration/lockChannel.test.ts


### PR DESCRIPTION
## Summary
- remove the active timing overrides introduced by merged PR #193
- retain deterministic round-robin assignment for the four integration shards
- keep the override mechanism available, but document that current measurements do not support a stable custom map

## Why
Five CI samples showed substantial runner variance. Moving files from shard 4 to shard 3 produced a 13:14 tail; moving expensive direct-container suites between shards 1 and 3 mostly transferred the 12-minute bottleneck rather than removing it. Plain round-robin assigns all 53 files exactly once at 13 / 14 / 13 / 13 and avoids those deterministic regressions.

## Final CI measurement
Run 30792422647 passed all checks in 11:32 overall.

- unit job: 4:51
- integration shard 1: 8:29
- integration shard 2: 10:36
- integration shard 3: 11:06
- integration shard 4: 10:56

The successful PR #192 reference run was 11:34 overall, so the final workflow is effectively tied within normal CI variance. The unit job improved from 6:46 to 4:51 because merged PR #193 no longer repeats codegen and TypeScript compilation. Integration remains the critical path, and the samples do not justify active per-file overrides.

## Validation
- all 53 integration files assigned exactly once
- shell, TypeScript, and whitespace checks pass
- final GitHub Actions run is fully green