### PR TITLE
fix: serialize pipeline attempt snapshots

### DIFF
--- a/services/plugin/downloadTrigger.execution.test.ts
+++ b/services/plugin/downloadTrigger.execution.test.ts
@@ -279,7 +279,7 @@ test("creates and completes a first-class pipeline attempt", async () => {
         initiatedByUsername: null,
         retryOfPipelineRunId: null,
         attemptNumber: 1,
-        configurationSnapshot: {
+        configurationSnapshot: JSON.stringify({
           event: EVENT,
           stopOnFirstFailure: true,
           applicability: "ALL_FILES_IMMEDIATE",
@@ -293,7 +293,7 @@ test("creates and completes a first-class pipeline attempt", async () => {
               continueOnError: false,
             },
           ],
-        },
+        }),
         applicability: "ALL_FILES_IMMEDIATE",
         policyEffectiveAt: null,
         policyId: null,

--- a/services/plugin/pipelineAttempt.test.ts
+++ b/services/plugin/pipelineAttempt.test.ts
@@ -109,6 +109,24 @@ test('increments the attempt number for the same target pipeline key', async () 
   })
 
   assert.equal(creates[0]?.input[0]?.attemptNumber, 4)
+  assert.deepEqual(
+    JSON.parse(String(creates[0]?.input[0]?.configurationSnapshot)),
+    {
+      event: 'downloadableFile.created',
+      stopOnFirstFailure: true,
+      applicability: null,
+      effectiveAt: null,
+      steps: [
+        {
+          pluginId: 'scan',
+          version: '2.0.0',
+          order: 0,
+          condition: 'ALWAYS',
+          continueOnError: false,
+        },
+      ],
+    }
+  )
 })
 
 test('derives failed before successful when a job fails', () => {

--- a/services/plugin/pipelineAttempt.ts
+++ b/services/plugin/pipelineAttempt.ts
@@ -133,7 +133,9 @@ export const createPipelineAttempt = async ({
         initiatedByUsername: context.initiatedByUsername || null,
         retryOfPipelineRunId: context.retryOfPipelineRunId || null,
         attemptNumber,
-        configurationSnapshot: buildPipelineConfigurationSnapshot(context),
+        configurationSnapshot: JSON.stringify(
+          buildPipelineConfigurationSnapshot(context)
+        ),
         applicability: context.applicability || null,
         policyEffectiveAt: context.policyEffectiveAt || null,
         policyId: context.policyId || null,


### PR DESCRIPTION
## Summary
- serialize configured pipeline snapshots before persisting them through Neo4j OGM
- preserve the complete event, rollout, and resolved-step snapshot
- add regression coverage matching the production manual-start payload

## Production issue
`startPluginPipeline` passed a nested object to a Neo4j property and failed with `Property values can only be of primitive types or arrays thereof` before creating the attempt.

## Verification
- 28 targeted pipeline tests passed
- `pnpm run tsc`
- ESLint on changed files