### PR TITLE
feat: support renamed plugin settings and secrets

### DIFF
--- a/PLUGIN_REQUIREMENTS.md
+++ b/PLUGIN_REQUIREMENTS.md
@@ -92,6 +92,48 @@ To provide a richer admin experience, plugins may define the following additiona
 
 These fields are optional but recommended so administrators can configure plugins without manual frontend work.
 
+### Renaming settings and secrets
+
+An upgrade may preserve a value under a new key only when the new manifest explicitly
+declares the previous key with `renamedFrom`:
+
+```json
+{
+  "secrets": [
+    {
+      "key": "SERVICE_API_KEY",
+      "renamedFrom": "LEGACY_API_KEY",
+      "scope": "server",
+      "required": true
+    }
+  ],
+  "settingsDefaults": {
+    "server": { "serviceUrl": "https://service.example" }
+  },
+  "ui": {
+    "forms": {
+      "server": [{
+        "fields": [{
+          "key": "serviceUrl",
+          "renamedFrom": "endpoint",
+          "type": "text"
+        }]
+      }]
+    }
+  }
+}
+```
+
+Setting values are carried only if they pass the new field's type, option, and
+validation rules. A server secret rename updates only the stored secret's key; the
+encrypted value is neither selected nor decrypted. Secret renames must keep the same
+scope, and the source secret must have been declared by the installed version.
+
+Use `renamedFrom` for a single, unambiguous rename between adjacent releases. Duplicate
+sources or targets, a stored value under both names, and rename chains are rejected.
+When the value's meaning, representation, validation contract, or secret scope changes,
+declare a new key instead and require the administrator to configure it.
+
 ## Plugin Code Requirements
 
 ### Constructor Pattern

--- a/customResolvers/mutationResolvers.ts
+++ b/customResolvers/mutationResolvers.ts
@@ -555,7 +555,8 @@ export default function buildMutationResolvers(deps: ResolverDeps) {
     installPluginVersion: installPluginVersion({
       Plugin,
       PluginVersion,
-      ServerConfig
+      ServerConfig,
+      ServerSecret
     }),
     triggerDownloadableFilePluginRuns: triggerDownloadableFilePluginRuns({
       DownloadableFile,

--- a/customResolvers/mutations/installPluginVersion.ts
+++ b/customResolvers/mutations/installPluginVersion.ts
@@ -3,6 +3,7 @@ import type {
   PluginModel,
   PluginVersionModel,
   ServerConfigModel,
+  ServerSecretModel,
   PluginCreateInput,
   PluginUpdateInput,
   PluginVersionCreateInput,
@@ -15,11 +16,13 @@ import { logger } from "../../logger.js";
 import { downloadBytes, fetchMergedPluginRegistry, type RegistryVersion } from '../../services/plugin/registryService.js'
 import { getPluginVersionCompatibility } from '../../services/plugin/compatibility.js'
 import { reconcileSettings, type SettingsCarryOverReport } from '../../services/plugin/reconcileSettings.js'
+import { migrateServerSecretRenames } from '../../services/plugin/reconcileSecrets.js'
 
 type Input = {
   Plugin: PluginModel
   PluginVersion: PluginVersionModel
   ServerConfig: ServerConfigModel
+  ServerSecret: ServerSecretModel
 }
 
 type Args = {
@@ -33,6 +36,7 @@ type InstalledVersionEdge = {
   node?: {
     id?: string
     version?: string
+    manifest?: unknown
     Plugin?: { id?: string; name?: string }
   }
 }
@@ -47,7 +51,7 @@ const buildReleaseMetadataPayload = (registryVersion: RegistryVersion) => ({
 })
 
 const getResolver = (input: Input) => {
-  const { Plugin, PluginVersion, ServerConfig } = input
+  const { Plugin, PluginVersion, ServerConfig, ServerSecret } = input
 
   return async (_parent: unknown, args: Args, _context: GraphQLContext, _resolveInfo: GraphQLResolveInfo) => {
     const { pluginId, version, carrySettings = false } = args
@@ -318,6 +322,7 @@ const getResolver = (input: Input) => {
               node {
                 id
                 version
+                manifest
                 Plugin {
                   id
                   name
@@ -345,11 +350,18 @@ const getResolver = (input: Input) => {
       if (carrySettings && previousVersionEdge) {
         const reconciled = reconcileSettings({
           oldSettings: previousVersionEdge.properties?.settingsJson,
+          oldManifest: previousVersionEdge.node?.manifest,
           newManifest: artifacts.manifest,
           scope: 'server'
         })
         reconciledSettings = reconciled.settings
         carryOverReport = reconciled.report
+        carryOverReport.renamedSecrets = await migrateServerSecretRenames({
+          ServerSecret,
+          pluginId: pluginSlug,
+          oldManifest: previousVersionEdge.node?.manifest,
+          newManifest: artifacts.manifest
+        })
       }
 
       if (!isAlreadyInstalled) {

--- a/services/plugin/configStatus.ts
+++ b/services/plugin/configStatus.ts
@@ -24,6 +24,7 @@ export type PluginConfigStatus = {
 
 export type PluginManifestField = {
   key?: unknown
+  renamedFrom?: unknown
   label?: unknown
   type?: unknown
   required?: unknown
@@ -40,6 +41,7 @@ export type PluginManifestField = {
 
 type ManifestSecret = {
   key?: unknown
+  renamedFrom?: unknown
   label?: unknown
   scope?: unknown
   required?: unknown

--- a/services/plugin/reconcileSecrets.test.ts
+++ b/services/plugin/reconcileSecrets.test.ts
@@ -75,3 +75,90 @@ test('rejects secret collisions, ambiguous mappings, and rename chains', () => {
     scope: 'server'
   }), /rename chains/)
 })
+
+test('rejects duplicate, malformed, self-referential, and still-declared sources', () => {
+  const plan = (secrets: unknown[]) => () => planSecretRenames({
+    oldManifest,
+    newManifest: { secrets },
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  })
+
+  assert.throws(plan([
+    { key: 'API_KEY', scope: 'server' },
+    { key: 'API_KEY', scope: 'server' }
+  ]), /Ambiguous secret definition/)
+  assert.throws(plan([
+    { key: 'API_KEY', scope: 'server', renamedFrom: '' }
+  ]), /invalid renamedFrom/)
+  assert.throws(plan([
+    { key: 'OLD_API_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' }
+  ]), /cannot be renamed from itself/)
+  assert.throws(plan([
+    { key: 'OLD_API_KEY', scope: 'server' },
+    { key: 'API_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' }
+  ]), /source "OLD_API_KEY" is still declared/)
+})
+
+test('rejects historical chains and stored sources absent from the old manifest', () => {
+  assert.throws(() => planSecretRenames({
+    oldManifest: { secrets: [
+      { key: 'OLD_API_KEY', scope: 'server', renamedFrom: 'LEGACY_API_KEY' }
+    ] },
+    newManifest,
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), /rename chains/)
+
+  assert.throws(() => planSecretRenames({
+    oldManifest: { secrets: [] },
+    newManifest,
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), /was not declared by the installed version/)
+})
+
+test('ignores malformed manifests, invalid secret entries, and other scopes', () => {
+  assert.deepEqual(planSecretRenames({
+    oldManifest: '{not-json',
+    newManifest: '[]',
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), [])
+
+  assert.deepEqual(planSecretRenames({
+    oldManifest,
+    newManifest: { secrets: [
+      null,
+      { key: 123, scope: 'server' },
+      { key: 'CHANNEL_KEY', scope: 'channel', renamedFrom: 'OLD_API_KEY' }
+    ] },
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), [])
+})
+
+test('does not update when fetched records are unusable or no rename applies', async () => {
+  const updates: unknown[] = []
+  const ServerSecret = {
+    find: async () => [
+      { id: null, key: 'OLD_API_KEY' },
+      { id: 'secret-2', key: null },
+      { id: 'secret-3', key: 'UNRELATED_KEY' }
+    ],
+    update: async (input: unknown) => {
+      updates.push(input)
+      return {}
+    }
+  }
+
+  const renamed = await migrateServerSecretRenames({
+    ServerSecret: ServerSecret as unknown as ServerSecretModel,
+    pluginId: 'scanner',
+    oldManifest,
+    newManifest
+  })
+
+  assert.deepEqual(renamed, [])
+  assert.deepEqual(updates, [])
+})

--- a/services/plugin/reconcileSecrets.test.ts
+++ b/services/plugin/reconcileSecrets.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { migrateServerSecretRenames, planSecretRenames } from './reconcileSecrets.js'
+import type { ServerSecretModel } from '../../ogm_types.js'
+
+const oldManifest = {
+  secrets: [{ key: 'OLD_API_KEY', scope: 'server' }]
+}
+
+const newManifest = {
+  secrets: [{ key: 'API_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' }]
+}
+
+test('re-keys a compatible stored secret without selecting or updating ciphertext', async () => {
+  const finds: unknown[] = []
+  const updates: unknown[] = []
+  const ServerSecret = {
+    find: async (input: unknown) => {
+      finds.push(input)
+      return [{ id: 'secret-1', key: 'OLD_API_KEY' }]
+    },
+    update: async (input: unknown) => {
+      updates.push(input)
+      return {}
+    }
+  }
+
+  const renamed = await migrateServerSecretRenames({
+    ServerSecret: ServerSecret as unknown as ServerSecretModel,
+    pluginId: 'scanner',
+    oldManifest,
+    newManifest
+  })
+
+  assert.deepEqual(renamed, [{ from: 'OLD_API_KEY', to: 'API_KEY' }])
+  assert.deepEqual(finds, [{ where: { pluginId: 'scanner' }, selectionSet: '{ id key }' }])
+  assert.deepEqual(updates, [{ where: { id: 'secret-1' }, update: { key: 'API_KEY' } }])
+  assert.equal(JSON.stringify({ finds, updates }).includes('ciphertext'), false)
+})
+
+test('does nothing when the stored rename source is absent', () => {
+  assert.deepEqual(planSecretRenames({
+    oldManifest,
+    newManifest,
+    storedKeys: [],
+    scope: 'server'
+  }), [])
+})
+
+test('rejects secret collisions, ambiguous mappings, and rename chains', () => {
+  assert.throws(() => planSecretRenames({
+    oldManifest,
+    newManifest,
+    storedKeys: ['OLD_API_KEY', 'API_KEY'],
+    scope: 'server'
+  }), /rename collision/)
+
+  assert.throws(() => planSecretRenames({
+    oldManifest,
+    newManifest: { secrets: [
+      { key: 'API_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' },
+      { key: 'BACKUP_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' }
+    ] },
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), /Ambiguous secret rename/)
+
+  assert.throws(() => planSecretRenames({
+    oldManifest,
+    newManifest: { secrets: [
+      { key: 'API_KEY', scope: 'server', renamedFrom: 'OLD_API_KEY' },
+      { key: 'CURRENT_API_KEY', scope: 'server', renamedFrom: 'API_KEY' }
+    ] },
+    storedKeys: ['OLD_API_KEY'],
+    scope: 'server'
+  }), /rename chains/)
+})

--- a/services/plugin/reconcileSecrets.ts
+++ b/services/plugin/reconcileSecrets.ts
@@ -1,0 +1,115 @@
+import type { PluginConfigScope } from './configStatus.js'
+import type { ServerSecretModel } from '../../ogm_types.js'
+
+type SecretDefinition = {
+  key?: unknown
+  scope?: unknown
+  renamedFrom?: unknown
+}
+
+export type SecretRename = { from: string; to: string }
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+const parseRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== 'string') return asRecord(value)
+  try {
+    return asRecord(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+const getSecrets = (manifest: unknown, scope: PluginConfigScope): SecretDefinition[] => {
+  const secrets = parseRecord(manifest).secrets
+  if (!Array.isArray(secrets)) return []
+  return (secrets as SecretDefinition[]).filter(secret =>
+    typeof secret?.key === 'string' && (secret.scope === undefined || secret.scope === scope)
+  )
+}
+
+export const planSecretRenames = (params: {
+  oldManifest: unknown
+  newManifest: unknown
+  storedKeys: string[]
+  scope: PluginConfigScope
+}): SecretRename[] => {
+  const oldSecrets = getSecrets(params.oldManifest, params.scope)
+  const newSecrets = getSecrets(params.newManifest, params.scope)
+  const storedKeys = new Set(params.storedKeys)
+  const oldByKey = new Map(oldSecrets.map(secret => [String(secret.key), secret]))
+  const targetKeys = new Set<string>()
+  const sourceToTarget = new Map<string, string>()
+  const declaredRenames = new Map<string, string>()
+
+  for (const secret of newSecrets) {
+    const target = String(secret.key)
+    if (targetKeys.has(target)) {
+      throw new Error(`Ambiguous secret definition for key "${target}"`)
+    }
+    targetKeys.add(target)
+    if (secret.renamedFrom === undefined) continue
+    if (typeof secret.renamedFrom !== 'string' || !secret.renamedFrom.trim()) {
+      throw new Error(`Secret "${target}" has an invalid renamedFrom value`)
+    }
+    const source = secret.renamedFrom
+    if (source === target) throw new Error(`Secret "${target}" cannot be renamed from itself`)
+    const existingTarget = sourceToTarget.get(source)
+    if (existingTarget) {
+      throw new Error(`Ambiguous secret rename from "${source}" to both "${existingTarget}" and "${target}"`)
+    }
+    sourceToTarget.set(source, target)
+    declaredRenames.set(target, source)
+  }
+
+  const planned: SecretRename[] = []
+  for (const [target, source] of declaredRenames) {
+    if (declaredRenames.has(source) || typeof oldByKey.get(source)?.renamedFrom === 'string') {
+      throw new Error(`Secret rename chains are not supported for "${target}"`)
+    }
+    if (targetKeys.has(source)) {
+      throw new Error(`Secret rename collision: source "${source}" is still declared by the new manifest`)
+    }
+    if (!storedKeys.has(source)) continue
+    if (!oldByKey.has(source)) {
+      throw new Error(`Secret rename source "${source}" was not declared by the installed version`)
+    }
+    if (storedKeys.has(target)) {
+      throw new Error(`Secret rename collision: both "${source}" and "${target}" are stored`)
+    }
+    planned.push({ from: source, to: target })
+  }
+  return planned
+}
+
+export const migrateServerSecretRenames = async (params: {
+  ServerSecret: ServerSecretModel
+  pluginId: string
+  oldManifest: unknown
+  newManifest: unknown
+}): Promise<SecretRename[]> => {
+  const secrets = await params.ServerSecret.find({
+    where: { pluginId: params.pluginId },
+    selectionSet: `{ id key }`
+  })
+  const records = secrets.filter(secret =>
+    typeof secret.id === 'string' && typeof secret.key === 'string'
+  )
+  const renames = planSecretRenames({
+    oldManifest: params.oldManifest,
+    newManifest: params.newManifest,
+    storedKeys: records.map(secret => secret.key),
+    scope: 'server'
+  })
+  const recordsByKey = new Map(records.map(secret => [secret.key, secret]))
+  for (const rename of renames) {
+    await params.ServerSecret.update({
+      where: { id: recordsByKey.get(rename.from)!.id },
+      update: { key: rename.to }
+    })
+  }
+  return renames
+}

--- a/services/plugin/reconcileSettings.test.ts
+++ b/services/plugin/reconcileSettings.test.ts
@@ -130,6 +130,77 @@ test('rejects rename collisions and chains', () => {
   }), /rename chains/)
 })
 
+test('rejects malformed, duplicate, self-referential, and ambiguous rename declarations', () => {
+  const reconcileFields = (fields: unknown[]) => () => reconcileSettings({
+    oldSettings: { endpoint: 'https://custom.example' },
+    newManifest: { ui: { forms: { server: [{ fields }] } } },
+    scope: 'server'
+  })
+
+  assert.throws(reconcileFields([
+    { key: 'serviceUrl', renamedFrom: 42, type: 'text' }
+  ]), /invalid renamedFrom/)
+  assert.throws(reconcileFields([
+    { key: 'endpoint', renamedFrom: 'endpoint', type: 'text' }
+  ]), /cannot be renamed from itself/)
+  assert.throws(reconcileFields([
+    { key: 'serviceUrl', type: 'text' },
+    { key: 'serviceUrl', type: 'text' }
+  ]), /Ambiguous setting definition/)
+  assert.throws(reconcileFields([
+    { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' },
+    { key: 'backupUrl', renamedFrom: 'endpoint', type: 'text' }
+  ]), /Ambiguous setting rename/)
+})
+
+test('rejects historical chains and sources that remain in the new schema', () => {
+  assert.throws(() => reconcileSettings({
+    oldSettings: { endpoint: 'https://custom.example' },
+    oldManifest: { ui: { forms: { server: [{ fields: [
+      { key: 'endpoint', renamedFrom: 'legacyUrl', type: 'text' }
+    ] }] } } },
+    newManifest: { ui: { forms: { server: [{ fields: [
+      { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' }
+    ] }] } } },
+    scope: 'server'
+  }), /rename chains/)
+
+  assert.throws(() => reconcileSettings({
+    oldSettings: { endpoint: 'https://custom.example' },
+    newManifest: {
+      settingsDefaults: { server: { endpoint: 'https://default.example' } },
+      ui: { forms: { server: [{ fields: [
+        { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' }
+      ] }] } }
+    },
+    scope: 'server'
+  }), /source "endpoint" is still declared/)
+})
+
+test('handles malformed manifests and validates defaults-only values by shape', () => {
+  assert.deepEqual(reconcileSettings({
+    oldSettings: '{not-json',
+    newManifest: '[]',
+    scope: 'server'
+  }), {
+    settings: {},
+    report: { carried: [], renamed: [], renamedSecrets: [], dropped: [], reset: [], newDefaults: [] }
+  })
+
+  const result = reconcileSettings({
+    oldSettings: { nullable: 7, list: 'not-an-array', count: 3 },
+    newManifest: {
+      settingsDefaults: { server: { nullable: null, list: [], count: 0 } },
+      ui: { forms: { server: [{ title: 'No fields' }] } }
+    },
+    scope: 'server'
+  })
+
+  assert.deepEqual(result.settings, { nullable: 7, list: [], count: 3 })
+  assert.deepEqual(result.report.carried, ['nullable', 'count'])
+  assert.deepEqual(result.report.reset, ['list'])
+})
+
 test('supports JSON strings from Neo4j properties', () => {
   const result = reconcileSettings({
     oldSettings: '{"mode":"fast"}',

--- a/services/plugin/reconcileSettings.test.ts
+++ b/services/plugin/reconcileSettings.test.ts
@@ -46,11 +46,88 @@ test('carries compatible values, drops removed keys, and resets invalid values',
     },
     report: {
       carried: ['endpoint', 'retries', 'profiles'],
+      renamed: [],
+      renamedSecrets: [],
       dropped: ['removed', 'API_KEY'],
       reset: ['mode'],
       newDefaults: ['added']
     }
   })
+})
+
+test('carries a compatible value through an explicit one-hop rename', () => {
+  const result = reconcileSettings({
+    oldSettings: { endpoint: 'https://custom.example' },
+    oldManifest: newManifest,
+    newManifest: {
+      settingsDefaults: { server: { serviceUrl: 'https://default.example' } },
+      ui: { forms: { server: [{ fields: [
+        { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text', validation: { pattern: '^https://' } }
+      ] }] } }
+    },
+    scope: 'server'
+  })
+
+  assert.deepEqual(result.settings, { serviceUrl: 'https://custom.example' })
+  assert.deepEqual(result.report.renamed, [{ from: 'endpoint', to: 'serviceUrl' }])
+  assert.deepEqual(result.report.dropped, [])
+  assert.deepEqual(result.report.newDefaults, [])
+})
+
+test('resets a renamed setting when its value is invalid for the target field', () => {
+  const result = reconcileSettings({
+    oldSettings: { retries: 4 },
+    newManifest: {
+      settingsDefaults: { server: { retryLabel: 'automatic' } },
+      ui: { forms: { server: [{ fields: [
+        { key: 'retryLabel', renamedFrom: 'retries', type: 'text' }
+      ] }] } }
+    },
+    scope: 'server'
+  })
+
+  assert.deepEqual(result.settings, { retryLabel: 'automatic' })
+  assert.deepEqual(result.report.renamed, [])
+  assert.deepEqual(result.report.reset, ['retryLabel'])
+})
+
+test('leaves a target default new when the rename source is absent', () => {
+  const result = reconcileSettings({
+    oldSettings: {},
+    newManifest: {
+      settingsDefaults: { server: { serviceUrl: 'https://default.example' } },
+      ui: { forms: { server: [{ fields: [
+        { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' }
+      ] }] } }
+    },
+    scope: 'server'
+  })
+
+  assert.deepEqual(result.report.renamed, [])
+  assert.deepEqual(result.report.newDefaults, ['serviceUrl'])
+})
+
+test('rejects rename collisions and chains', () => {
+  assert.throws(() => reconcileSettings({
+    oldSettings: { endpoint: 'old', serviceUrl: 'new' },
+    newManifest: {
+      ui: { forms: { server: [{ fields: [
+        { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' }
+      ] }] } }
+    },
+    scope: 'server'
+  }), /rename collision/)
+
+  assert.throws(() => reconcileSettings({
+    oldSettings: { endpoint: 'old' },
+    newManifest: {
+      ui: { forms: { server: [{ fields: [
+        { key: 'serviceUrl', renamedFrom: 'endpoint', type: 'text' },
+        { key: 'url', renamedFrom: 'serviceUrl', type: 'text' }
+      ] }] } }
+    },
+    scope: 'server'
+  }), /rename chains/)
 })
 
 test('supports JSON strings from Neo4j properties', () => {

--- a/services/plugin/reconcileSettings.ts
+++ b/services/plugin/reconcileSettings.ts
@@ -6,6 +6,8 @@ import {
 
 export type SettingsCarryOverReport = {
   carried: string[]
+  renamed: Array<{ from: string; to: string }>
+  renamedSecrets: Array<{ from: string; to: string }>
   dropped: string[]
   reset: string[]
   newDefaults: string[]
@@ -41,8 +43,79 @@ const getFields = (manifest: Record<string, unknown>, scope: PluginConfigScope):
   }).filter(field => typeof field.key === 'string' && field.type !== 'secret')
 }
 
+const hasOwn = (record: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(record, key)
+
+const getRenameMap = (params: {
+  newFields: PluginManifestField[]
+  oldFields: PluginManifestField[]
+  oldSettings: Record<string, unknown>
+  defaults: Record<string, unknown>
+}): Map<string, string> => {
+  const newKeys = new Set<string>()
+  const sourceToTarget = new Map<string, string>()
+  const renames = new Map<string, string>()
+
+  for (const field of params.newFields) {
+    const target = String(field.key)
+    if (newKeys.has(target)) {
+      throw new Error(`Ambiguous setting definition for key "${target}"`)
+    }
+    newKeys.add(target)
+
+    if (field.renamedFrom === undefined) continue
+    if (typeof field.renamedFrom !== 'string' || !field.renamedFrom.trim()) {
+      throw new Error(`Setting "${target}" has an invalid renamedFrom value`)
+    }
+    const source = field.renamedFrom
+    if (source === target) {
+      throw new Error(`Setting "${target}" cannot be renamed from itself`)
+    }
+    const existingTarget = sourceToTarget.get(source)
+    if (existingTarget) {
+      throw new Error(`Ambiguous setting rename from "${source}" to both "${existingTarget}" and "${target}"`)
+    }
+    sourceToTarget.set(source, target)
+    renames.set(target, source)
+  }
+
+  for (const [target, source] of renames) {
+    if (renames.has(source)) {
+      throw new Error(`Setting rename chains are not supported: "${source}" to "${target}"`)
+    }
+    const oldSource = params.oldFields.find(field => field.key === source)
+    if (typeof oldSource?.renamedFrom === 'string') {
+      throw new Error(`Setting rename chains are not supported for "${target}"`)
+    }
+    if (newKeys.has(source) || hasOwn(params.defaults, source)) {
+      throw new Error(`Setting rename collision: source "${source}" is still declared by the new manifest`)
+    }
+    if (hasOwn(params.oldSettings, source) && hasOwn(params.oldSettings, target)) {
+      throw new Error(`Setting rename collision: both "${source}" and "${target}" have stored values`)
+    }
+  }
+
+  return renames
+}
+
+const validateCarriedValue = (
+  field: PluginManifestField | undefined,
+  defaultValue: unknown,
+  value: unknown
+) => {
+  const hasCompatibleDefaultType =
+    defaultValue === null ||
+    (Array.isArray(defaultValue)
+      ? Array.isArray(value)
+      : typeof defaultValue === typeof value)
+  return field
+    ? validatePluginSetting({ ...field, required: false, validation: { ...field.validation, required: false } }, value)
+    : (hasCompatibleDefaultType ? null : 'Value has an incompatible type')
+}
+
 export const reconcileSettings = (params: {
   oldSettings: unknown
+  oldManifest?: unknown
   newManifest: unknown
   scope: PluginConfigScope
 }): ReconciledSettings => {
@@ -50,29 +123,37 @@ export const reconcileSettings = (params: {
   const defaults = parseRecord(asRecord(manifest.settingsDefaults)[params.scope])
   const oldSettings = parseRecord(params.oldSettings)
   const fields = getFields(manifest, params.scope)
+  const oldFields = getFields(parseRecord(params.oldManifest), params.scope)
   const fieldsByKey = new Map(fields.map(field => [String(field.key), field]))
+  const renames = getRenameMap({ newFields: fields, oldFields, oldSettings, defaults })
   const settings: Record<string, unknown> = { ...defaults }
   const carried: string[] = []
+  const renamed: Array<{ from: string; to: string }> = []
   const dropped: string[] = []
   const reset: string[] = []
 
+  const consumedSources = new Set<string>()
+  for (const [target, source] of renames) {
+    if (!hasOwn(oldSettings, source)) continue
+    consumedSources.add(source)
+    const error = validateCarriedValue(fieldsByKey.get(target), defaults[target], oldSettings[source])
+    if (error) {
+      reset.push(target)
+      continue
+    }
+    settings[target] = oldSettings[source]
+    renamed.push({ from: source, to: target })
+  }
+
   for (const [key, value] of Object.entries(oldSettings)) {
+    if (consumedSources.has(key)) continue
     const field = fieldsByKey.get(key)
-    const hasDefault = Object.prototype.hasOwnProperty.call(defaults, key)
+    const hasDefault = hasOwn(defaults, key)
     if (!field && !hasDefault) {
       dropped.push(key)
       continue
     }
-    const defaultValue = defaults[key]
-    const hasCompatibleDefaultType =
-      defaultValue === null ||
-      (Array.isArray(defaultValue)
-        ? Array.isArray(value)
-        : typeof defaultValue === typeof value)
-    const isInvalid = field
-      ? validatePluginSetting({ ...field, required: false, validation: { ...field.validation, required: false } }, value)
-      : !hasCompatibleDefaultType
-    if (isInvalid) {
+    if (validateCarriedValue(field, defaults[key], value)) {
       reset.push(key)
       continue
     }
@@ -81,10 +162,10 @@ export const reconcileSettings = (params: {
   }
 
   const newDefaults = Object.keys(defaults).filter(
-    key => !Object.prototype.hasOwnProperty.call(oldSettings, key)
+    key => !hasOwn(oldSettings, key) && !hasOwn(oldSettings, renames.get(key) || '')
   )
   return {
     settings,
-    report: { carried, dropped, reset, newDefaults }
+    report: { carried, renamed, renamedSecrets: [], dropped, reset, newDefaults }
   }
 }


### PR DESCRIPTION
## Summary

- add explicit one-hop `renamedFrom` carry-over for plugin settings and server secrets
- validate target settings and reject ambiguous mappings, collisions, self-renames, and rename chains
- re-key stored secrets without selecting or decrypting ciphertext, and expose setting/secret rename metadata in the carry-over report
- document the manifest convention and safe-use boundaries

## Testing

- `TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm --test services/plugin/reconcileSettings.test.ts services/plugin/reconcileSecrets.test.ts` (9 passed)
- `pnpm exec eslint` on changed TypeScript files
- `pnpm exec tsc --noEmit`
- `git diff --check`

The full local unit suite cannot load `graphql-shield` under the available Node 24 runtime; this repository declares Node 22.x. The focused tests, lint, and TypeScript checks pass.

Closes #166