### PR TITLE
fix(auth): default GraphQL permissions to deny

### DIFF
--- a/permissions.ts
+++ b/permissions.ts
@@ -1,5 +1,8 @@
-import { and, chain, shield, allow, deny, or } from "graphql-shield";
+import { isIntrospectionType, isObjectType } from "graphql";
+import { middleware } from "graphql-middleware";
+import { and, chain, shield, allow, deny, or, type IRules } from "graphql-shield";
 import rules from "./rules/rules.js";
+import typeDefs from "./typeDefs.js";
 
 const {
   isRoot,
@@ -70,7 +73,134 @@ const {
   canEditWikiHomePage,
 } = rules;
 
-const permissionList = shield({
+// These application-defined output types are intentionally readable. Keeping
+// this list explicit means a newly added schema type is denied by Shield's
+// fallback until its public surface has been reviewed and added here.
+const PUBLIC_READ_TYPES = [
+  "Activity",
+  "Album",
+  "ApplicablePluginPipeline",
+  "Channel",
+  "ChannelDiscussionFlairConfig",
+  "ChannelHealthRow",
+  "ChannelInfo",
+  "ChannelPluginProperties",
+  "ChannelRole",
+  "Collection",
+  "Comment",
+  "CommentAggregateResult",
+  "CommentInfo",
+  "CommentRepliesFormat",
+  "CommentSectionFormat",
+  "Contact",
+  "DayData",
+  "DeleteEventInSeriesResult",
+  "Discussion",
+  "DiscussionChannel",
+  "DiscussionChannelInfo",
+  "DiscussionChannelListFormat",
+  "DiscussionChannelListItem",
+  "DiscussionFlair",
+  "DiscussionFlairOption",
+  "DiscussionInfo",
+  "DownloadScanReviewItem",
+  "DownloadableFile",
+  "DropDataResponse",
+  "Emoji",
+  "EnvironmentInfo",
+  "Event",
+  "EventChannel",
+  "EventChannelInfo",
+  "EventCommentsFormat",
+  "EventInfo",
+  "EventSeries",
+  "Feed",
+  "FileVersion",
+  "FilterGroup",
+  "FilterOption",
+  "GetSortedChannelsResponse",
+  "HotRankingSettings",
+  "Image",
+  "ImageAlbumUsage",
+  "InstallationProperties",
+  "InstalledPlugin",
+  "InternalPluginPipelineRunDetail",
+  "Issue",
+  "IssueAgingBucket",
+  "IssueInfo",
+  "LabelChangeHistory",
+  "License",
+  "LinkFlair",
+  "Message",
+  "ModActivity",
+  "ModChannelRole",
+  "ModDayData",
+  "ModServerRole",
+  "ModerationAction",
+  "Notification",
+  "OwnEmail",
+  "PipelineStep",
+  "Plugin",
+  "PluginConfigFieldStatus",
+  "PluginConfigStatus",
+  "PluginPipelineCampaign",
+  "PluginPipelineCampaignFailure",
+  "PluginPipelineCampaignPreview",
+  "PluginPipelineSummary",
+  "PluginSecretStatus",
+  "PluginVersion",
+  "PrepareDownloadResult",
+  "PublicExpectedPluginJob",
+  "PublicPluginDiagnostic",
+  "PublicPluginJobRun",
+  "PublicPluginPipelineRun",
+  "Purchase",
+  "RankingSettings",
+  "RecurringEvent",
+  "RepeatEnds",
+  "RepeatEvery",
+  "RepeatPattern",
+  "SafetyCheckResponse",
+  "ScratchpadEntry",
+  "SeedDataResponse",
+  "ServerConfig",
+  "ServerHealthAttentionItem",
+  "ServerHealthDashboard",
+  "ServerHealthSummary",
+  "ServerHealthTimeSeriesPoint",
+  "ServerRole",
+  "ServerSecret",
+  "SignedURL",
+  "SiteWideDiscussionListFormat",
+  "SiteWideDiscussionListItem",
+  "SiteWideIssueListFormat",
+  "SiteWideIssueListItem",
+  "SiteWideWikiListFormat",
+  "Suspension",
+  "Tag",
+  "TextVersion",
+  "UndoSuperUpvoteResult",
+  "UploadedDownloadableFileDiscussion",
+  "UploadedDownloadableFileGroup",
+  "UserAggregateResult",
+  "UserContributionData",
+  "WikiEditInfo",
+  "WikiPage",
+  "WikiPageInfo",
+] as const;
+
+const publicReadRules = Object.fromEntries(
+  PUBLIC_READ_TYPES.map((typeName) => [typeName, { "*": allow }])
+);
+
+const declaredObjectTypes = new Set(
+  typeDefs.definitions
+    .filter((definition) => definition.kind === "ObjectTypeDefinition")
+    .map((definition) => definition.name.value)
+);
+
+const permissionRules: IRules = {
+    ...publicReadRules,
     Query: {
       "*": allow,
       // Enumerating all emails is denied for every role — only direct database
@@ -163,8 +293,38 @@ const permissionList = shield({
       notificationBundleEnabled: isAccountOwner,
       notificationBundleContent: isAccountOwner,
 
-      // Default rule for any unspecified fields - allow public access
-      "*": allow,
+      // Fields intentionally public under the previous fallback behavior.
+      Albums: allow,
+      Images: allow,
+      isBot: allow,
+      botProfileId: allow,
+      isDeprecated: allow,
+      deprecatedReason: allow,
+      Comments: allow,
+      Discussions: allow,
+      Events: allow,
+      AdminOfChannels: allow,
+      ModOfChannels: allow,
+      AdminOfServers: allow,
+      RecentlyVisitedChannels: allow,
+      UpvotedComments: allow,
+      UpvotedDiscussionChannels: allow,
+      Suspensions: allow,
+      AuthoredWikiPages: allow,
+      OriginalWikiPages: allow,
+      AuthoredWikiPageVersions: allow,
+      ChannelRoles: allow,
+      ServerRoles: allow,
+      ModChannelRoles: allow,
+      ModServerRoles: allow,
+      PendingModInvites: allow,
+      PendingOwnerInvites: allow,
+      PendingServerAdminInvites: allow,
+      PendingServerModInvites: allow,
+      deleted: allow,
+      notifyOnSuspensionBlocks: allow,
+      ScratchpadEntries: allow,
+      WrittenScratchpadEntries: allow,
     },
     ModerationProfile: {
       // The reverse of User.ModerationProfile: a mod profile must never resolve
@@ -173,9 +333,25 @@ const permissionList = shield({
       // Denied for everyone (including the account owner) — the pseudonymous
       // identity is one-way from the API's perspective.
       User: deny,
-      // Everything else on a moderation profile is public for transparency and
-      // audit: displayName, AuthoredIssues, AuthoredComments, ActivityFeed, etc.
-      "*": allow,
+      // Everything else currently on a moderation profile is public for
+      // transparency and audit. Enumerating these fields ensures a future
+      // identity-bearing edge does not silently inherit an allow wildcard.
+      createdAt: allow,
+      displayName: allow,
+      AuthoredIssues: allow,
+      AuthoredComments: allow,
+      ModChannelRoles: allow,
+      ModServerRoles: allow,
+      ModOfServers: allow,
+      ActivityFeed: allow,
+      Suspensions: allow,
+    },
+    Email: {
+      // Access to an Email node is already restricted at Query.emails and
+      // User.Email. Enumerate its current fields so future identity fields do
+      // not inherit a broad allow wildcard.
+      address: allow,
+      User: allow,
     },
     Mutation: {
       "*": deny,
@@ -409,10 +585,37 @@ const permissionList = shield({
       updateChannelPluginPipelines: and(isAuthenticated, isChannelOwner),
       updateDownloadLabels: and(isAuthenticated, allow), // Permission logic handled in resolver
     },
-  },{
-    debug: true,
-    allowExternalErrors: true
-  });
+  };
+
+// Neo4j GraphQL creates connection, edge, aggregate, and mutation-response
+// object types around the application types. They do not introduce independent
+// data access: access is already controlled at Query/Mutation and at the
+// application-defined relationship field. Allow those generated wrappers so
+// existing connection/aggregate queries continue to work with a deny fallback.
+const permissionList = middleware((schema) => {
+  const generatedTypeRules = Object.fromEntries(
+    Object.values(schema.getTypeMap())
+      .filter(
+        (type) =>
+          isObjectType(type) &&
+          !isIntrospectionType(type) &&
+          !declaredObjectTypes.has(type.name)
+      )
+      .map((type) => [type.name, { "*": allow }])
+  );
+
+  return shield(
+    {
+      ...generatedTypeRules,
+      ...permissionRules,
+    },
+    {
+      debug: true,
+      allowExternalErrors: true,
+      fallbackRule: deny,
+    }
+  ).generate(schema);
+});
   
   
   export default permissionList;

--- a/tests/auth/queryAuth.test.ts
+++ b/tests/auth/queryAuth.test.ts
@@ -1,0 +1,66 @@
+import test, { after, before } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extendSchema,
+  graphql,
+  parse,
+  type GraphQLSchema,
+} from "graphql";
+import type { Driver } from "neo4j-driver";
+import {
+  buildPermissionedSchema,
+  makeRequestContext,
+} from "../helpers/buildPermissionedSchema.js";
+
+let schema: GraphQLSchema;
+let driver: Driver;
+let ogm: ReturnType<typeof makeRequestContext>["ogm"];
+
+before(
+  async () => {
+    ({ schema, driver, ogm } = await buildPermissionedSchema({
+      transformSchema: (baseSchema) =>
+        extendSchema(
+          baseSchema,
+          parse(`
+            extend type Query {
+              permissionFallbackProbe: User
+            }
+
+            extend type User {
+              permissionFallbackProbe: String
+            }
+          `)
+        ),
+    }));
+  },
+  { timeout: 120000 }
+);
+
+after(async () => {
+  await driver.close();
+});
+
+test("an unruled field is denied by the shield fallback", async () => {
+  const result = await graphql({
+    schema,
+    source: `
+      query {
+        permissionFallbackProbe {
+          permissionFallbackProbe
+        }
+      }
+    `,
+    rootValue: {
+      permissionFallbackProbe: {
+        permissionFallbackProbe: "must not escape",
+      },
+    },
+    contextValue: makeRequestContext({ driver, ogm }),
+  });
+
+  assert.match(result.errors?.[0]?.message ?? "", /Not Authoris/i);
+  assert.deepEqual(JSON.parse(JSON.stringify(result.data)), {
+    permissionFallbackProbe: { permissionFallbackProbe: null },
+  });
+});

--- a/tests/helpers/buildPermissionedSchema.ts
+++ b/tests/helpers/buildPermissionedSchema.ts
@@ -27,7 +27,9 @@ export interface PermissionedSchema {
   ogm: ResolverDeps["ogm"];
 }
 
-export async function buildPermissionedSchema(): Promise<PermissionedSchema> {
+export async function buildPermissionedSchema(options?: {
+  transformSchema?: (schema: GraphQLSchema) => GraphQLSchema;
+}): Promise<PermissionedSchema> {
   // Pointed at a local address but never connected to: deny-path tests resolve
   // entirely within graphql-shield.
   const driver = neo4j.driver(
@@ -42,6 +44,7 @@ export async function buildPermissionedSchema(): Promise<PermissionedSchema> {
   const neoSchema = new Neo4jGraphQL({ typeDefs, driver, resolvers });
 
   let schema = await neoSchema.getSchema();
+  schema = options?.transformSchema?.(schema) ?? schema;
   schema = applyMiddleware(schema, permissions);
 
   return { schema, driver, ogm };


### PR DESCRIPTION
Closes #155

## Summary
- set graphql-shield fallbackRule to deny
- explicitly allowlist the existing public application output types while preserving generated Neo4j wrapper behavior
- replace User, ModerationProfile, and Email wildcards with field-level rules for their current surfaces
- add a wired schema regression test proving an unruled field is denied

## Verification
- npm run lint
- npm run tsc
- npm test (Node 22, 1380 tests passed)
- targeted authorization tests (24 passed)