### PR TITLE
feat(self-hosting): land instance capability status on main

### DIFF
--- a/customResolvers/queries/getInstanceSetupStatus.test.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildInstanceSetupStatus,
+  default as getInstanceSetupStatus,
+} from "./getInstanceSetupStatus.js";
+
+test("reports missing integrations without exposing environment values", () => {
+  const status = buildInstanceSetupStatus({
+    env: {},
+    serverConfig: null,
+  });
+
+  assert.deepEqual(status, {
+    auth: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: [
+        "AUTH0_DOMAIN",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_AUDIENCE",
+      ],
+      setupUrl: "/admin/setup#authentication",
+      docsPath: "/authentication",
+    },
+    mail: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["EMAIL_FROM", "RESEND_API_KEY"],
+      setupUrl: "/admin/setup#email",
+      docsPath: "/roles/admins/email-notifications",
+    },
+    maps: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["VITE_GOOGLE_MAPS_API_KEY"],
+      setupUrl: "/admin/setup#maps",
+      docsPath: "/roles/admins/map-setup",
+    },
+    geocoding: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["VITE_OPEN_CAGE_API_KEY"],
+      setupUrl: "/admin/setup#geocoding",
+      docsPath: "/roles/admins/map-setup",
+    },
+    uploads: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["GCS_BUCKET_NAME"],
+      setupUrl: "/admin/setup#file-uploads",
+      docsPath: "/roles/admins/image-hosting",
+    },
+    downloads: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["GCS_PRIVATE_DOWNLOAD_BUCKET_NAME"],
+      setupUrl: "/admin/setup#downloads",
+      docsPath: "/roles/forum-owners/downloads-setup",
+    },
+    events: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: [],
+      setupUrl: "/admin/setup#events",
+      docsPath: "/config/server-config",
+    },
+    plugins: {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ["PLUGIN_SECRET_ENCRYPTION_KEY"],
+      setupUrl: "/admin/setup#plugins",
+      docsPath: "/roles/admins/plugin-pipelines",
+    },
+  });
+});
+
+test("combines configured integrations with server feature toggles", () => {
+  const status = buildInstanceSetupStatus({
+    env: {
+      AUTH0_DOMAIN: "tenant.example",
+      AUTH0_CLIENT_ID: "client-secret-value",
+      AUTH0_AUDIENCE: "https://api.example",
+      EMAIL_PROVIDER: "sendgrid",
+      EMAIL_FROM: "forum@example.test",
+      SENDGRID_API_KEY: "mail-secret-value",
+      VITE_GOOGLE_MAPS_API_KEY: "maps-secret-value",
+      VITE_OPEN_CAGE_API_KEY: "geocoding-secret-value",
+      GCS_BUCKET_NAME: "public-media",
+      GCS_PRIVATE_DOWNLOAD_BUCKET_NAME: "private-downloads",
+      PLUGIN_SECRET_ENCRYPTION_KEY: "plugin-secret-value",
+    },
+    serverConfig: { enableDownloads: true, enableEvents: false },
+  });
+
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(status).map(([name, item]) => [
+        name,
+        {
+          configured: item.configured,
+          enabled: item.enabled,
+          missing: item.requiredEnvVarsMissing,
+        },
+      ])
+    ),
+    {
+      auth: { configured: true, enabled: true, missing: [] },
+      mail: { configured: true, enabled: true, missing: [] },
+      maps: { configured: true, enabled: true, missing: [] },
+      geocoding: { configured: true, enabled: true, missing: [] },
+      uploads: { configured: true, enabled: true, missing: [] },
+      downloads: { configured: true, enabled: true, missing: [] },
+      events: { configured: true, enabled: false, missing: [] },
+      plugins: { configured: true, enabled: true, missing: [] },
+    }
+  );
+  assert.equal(JSON.stringify(status).includes("secret-value"), false);
+});
+
+test("reports invalid email providers as needing EMAIL_PROVIDER", () => {
+  const status = buildInstanceSetupStatus({
+    env: { EMAIL_PROVIDER: "smtp" },
+    serverConfig: null,
+  });
+
+  assert.deepEqual(status.mail.requiredEnvVarsMissing, ["EMAIL_PROVIDER"]);
+});
+
+test("resolves the named ServerConfig before building status", async () => {
+  const calls: unknown[] = [];
+  const ServerConfig = {
+    find: async (args: unknown) => {
+      calls.push(args);
+      return [{ enableDownloads: true, enableEvents: true }];
+    },
+  };
+  const resolver = getInstanceSetupStatus({
+    ServerConfig: ServerConfig as never,
+    env: {
+      SERVER_CONFIG_NAME: "Community Forum",
+      GCS_PRIVATE_DOWNLOAD_BUCKET_NAME: "private-downloads",
+    },
+  });
+
+  const result = await resolver();
+
+  assert.deepEqual(calls, [
+    {
+      where: { serverName: "Community Forum" },
+      selectionSet: "{ serverName enableDownloads enableEvents }",
+    },
+  ]);
+  assert.equal(result.downloads.enabled, true);
+  assert.equal(result.events.enabled, true);
+});

--- a/customResolvers/queries/getInstanceSetupStatus.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.ts
@@ -1,0 +1,170 @@
+import type { ServerConfigModel } from "../../ogm_types.js";
+
+type Environment = NodeJS.ProcessEnv;
+
+type ServerFeatureConfig = {
+  enableDownloads?: boolean | null;
+  enableEvents?: boolean | null;
+};
+
+export type InstanceCapabilityStatus = {
+  configured: boolean;
+  enabled: boolean;
+  requiredEnvVarsMissing: string[];
+  setupUrl: string;
+  docsPath: string;
+};
+
+export type InstanceSetupStatus = {
+  auth: InstanceCapabilityStatus;
+  mail: InstanceCapabilityStatus;
+  maps: InstanceCapabilityStatus;
+  geocoding: InstanceCapabilityStatus;
+  uploads: InstanceCapabilityStatus;
+  downloads: InstanceCapabilityStatus;
+  events: InstanceCapabilityStatus;
+  plugins: InstanceCapabilityStatus;
+};
+
+type Input = {
+  ServerConfig: ServerConfigModel;
+  env?: Environment;
+};
+
+const hasValue = (env: Environment, name: string): boolean =>
+  Boolean(env[name]?.trim());
+
+const missingVariables = (env: Environment, names: string[]): string[] =>
+  names.filter((name) => !hasValue(env, name));
+
+const capability = ({
+  configured,
+  enabled = configured,
+  requiredEnvVarsMissing,
+  setupUrl,
+  docsPath,
+}: InstanceCapabilityStatus): InstanceCapabilityStatus => ({
+  configured,
+  enabled,
+  requiredEnvVarsMissing,
+  setupUrl,
+  docsPath,
+});
+
+const missingMailVariables = (env: Environment): string[] => {
+  const provider = env.EMAIL_PROVIDER?.trim().toLowerCase() || "resend";
+  if (provider === "sendgrid") {
+    return missingVariables(env, ["EMAIL_FROM", "SENDGRID_API_KEY"]);
+  }
+  if (provider === "resend") {
+    return missingVariables(env, ["EMAIL_FROM", "RESEND_API_KEY"]);
+  }
+  return ["EMAIL_PROVIDER"];
+};
+
+export const buildInstanceSetupStatus = ({
+  env,
+  serverConfig,
+}: {
+  env: Environment;
+  serverConfig: ServerFeatureConfig | null;
+}): InstanceSetupStatus => {
+  const authMissing = missingVariables(env, [
+    "AUTH0_DOMAIN",
+    "AUTH0_CLIENT_ID",
+    "AUTH0_AUDIENCE",
+  ]);
+  const mailMissing = missingMailVariables(env);
+  const mapsMissing = missingVariables(env, ["VITE_GOOGLE_MAPS_API_KEY"]);
+  const geocodingMissing = missingVariables(env, ["VITE_OPEN_CAGE_API_KEY"]);
+  const uploadsMissing = missingVariables(env, ["GCS_BUCKET_NAME"]);
+  const downloadsMissing = missingVariables(env, [
+    "GCS_PRIVATE_DOWNLOAD_BUCKET_NAME",
+  ]);
+  const pluginsMissing = missingVariables(env, [
+    "PLUGIN_SECRET_ENCRYPTION_KEY",
+  ]);
+
+  const authConfigured = authMissing.length === 0;
+  const mailConfigured = mailMissing.length === 0;
+  const mapsConfigured = mapsMissing.length === 0;
+  const geocodingConfigured = geocodingMissing.length === 0;
+  const uploadsConfigured = uploadsMissing.length === 0;
+  const downloadsConfigured = downloadsMissing.length === 0;
+  const eventsConfigured = serverConfig !== null;
+  const pluginsConfigured = serverConfig !== null && pluginsMissing.length === 0;
+
+  return {
+    auth: capability({
+      configured: authConfigured,
+      enabled: authConfigured,
+      requiredEnvVarsMissing: authMissing,
+      setupUrl: "/admin/setup#authentication",
+      docsPath: "/authentication",
+    }),
+    mail: capability({
+      configured: mailConfigured,
+      enabled: mailConfigured,
+      requiredEnvVarsMissing: mailMissing,
+      setupUrl: "/admin/setup#email",
+      docsPath: "/roles/admins/email-notifications",
+    }),
+    maps: capability({
+      configured: mapsConfigured,
+      enabled: mapsConfigured,
+      requiredEnvVarsMissing: mapsMissing,
+      setupUrl: "/admin/setup#maps",
+      docsPath: "/roles/admins/map-setup",
+    }),
+    geocoding: capability({
+      configured: geocodingConfigured,
+      enabled: geocodingConfigured,
+      requiredEnvVarsMissing: geocodingMissing,
+      setupUrl: "/admin/setup#geocoding",
+      docsPath: "/roles/admins/map-setup",
+    }),
+    uploads: capability({
+      configured: uploadsConfigured,
+      enabled: uploadsConfigured,
+      requiredEnvVarsMissing: uploadsMissing,
+      setupUrl: "/admin/setup#file-uploads",
+      docsPath: "/roles/admins/image-hosting",
+    }),
+    downloads: capability({
+      configured: downloadsConfigured,
+      enabled: downloadsConfigured && serverConfig?.enableDownloads === true,
+      requiredEnvVarsMissing: downloadsMissing,
+      setupUrl: "/admin/setup#downloads",
+      docsPath: "/roles/forum-owners/downloads-setup",
+    }),
+    events: capability({
+      configured: eventsConfigured,
+      enabled: eventsConfigured && serverConfig?.enableEvents === true,
+      requiredEnvVarsMissing: [],
+      setupUrl: "/admin/setup#events",
+      docsPath: "/config/server-config",
+    }),
+    plugins: capability({
+      configured: pluginsConfigured,
+      enabled: pluginsConfigured,
+      requiredEnvVarsMissing: pluginsMissing,
+      setupUrl: "/admin/setup#plugins",
+      docsPath: "/roles/admins/plugin-pipelines",
+    }),
+  };
+};
+
+const getInstanceSetupStatus = ({ ServerConfig, env = process.env }: Input) => {
+  return async () => {
+    const serverName = env.SERVER_CONFIG_NAME?.trim();
+    const serverConfigs = await ServerConfig.find({
+      ...(serverName ? { where: { serverName } } : {}),
+      selectionSet: "{ serverName enableDownloads enableEvents }",
+    });
+    const serverConfig = (serverConfigs[0] as ServerFeatureConfig | undefined) ?? null;
+
+    return buildInstanceSetupStatus({ env, serverConfig });
+  };
+};
+
+export default getInstanceSetupStatus;

--- a/customResolvers/queryResolvers.ts
+++ b/customResolvers/queryResolvers.ts
@@ -38,6 +38,7 @@ import {
 } from './queries/pluginPipelineCampaigns.js'
 import getRankingSettings from "./queries/getRankingSettings.js";
 import getChannelDiscussionFlairConfig from "./queries/getChannelDiscussionFlairConfig.js";
+import getInstanceSetupStatus from "./queries/getInstanceSetupStatus.js";
 
 export default function buildQueryResolvers(deps: ResolverDeps) {
   const {
@@ -71,6 +72,9 @@ export default function buildQueryResolvers(deps: ResolverDeps) {
     }),
     getChannelDiscussionFlairConfig: getChannelDiscussionFlairConfig({
       driver,
+    }),
+    getInstanceSetupStatus: getInstanceSetupStatus({
+      ServerConfig,
     }),
     getSiteWideIssueList: getSiteWideIssueList({
       driver,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -76,6 +76,16 @@ test/E2E environments the seeded admin test user also acts as root.
 | `FRONTEND_URL` | Yes | Base URL of the frontend, used to build links in outbound emails (e.g. mod-invite acceptance links). |
 | `PLUGIN_SECRET_ENCRYPTION_KEY` | If plugins store secrets | 32-character key used to encrypt plugin secrets at rest. Set a strong value in production (the in-code fallback is a placeholder only). |
 
+### Capability reporting
+
+The public `getInstanceSetupStatus` query reports whether optional integrations
+are configured and enabled. It returns missing environment-variable names but
+never their values. Because maps and geocoding currently execute in the Nuxt
+frontend, pass `VITE_GOOGLE_MAPS_API_KEY` and `VITE_OPEN_CAGE_API_KEY` through
+to the backend process as presence-only signals when using this query. The
+Docker Compose quick-start profile will pass these through when it enables the
+capability-based frontend.
+
 ## Build / development / test
 
 | Variable | Required | Description |

--- a/permissions.ts
+++ b/permissions.ts
@@ -81,6 +81,9 @@ const permissionList = shield({
       getServerHealthDashboard: and(isAuthenticated, canManageMods),
       getDownloadScanReviewQueue: and(isAuthenticated, canPermanentlyRemoveImage),
       getPluginConfigStatus: and(isAuthenticated, canManagePlugins),
+      // Public, non-secret capability metadata used to degrade optional UI
+      // integrations cleanly before authentication is available.
+      getInstanceSetupStatus: allow,
       getPluginRunsForDownloadableFile: chain(
         isAuthenticated,
         canManagePlugins

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -2576,6 +2576,25 @@ const typeDefinitions = gql`
     otherAlbums: [Album!]!
   }
 
+  type InstanceCapabilityStatus @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    configured: Boolean!
+    enabled: Boolean!
+    requiredEnvVarsMissing: [String!]!
+    setupUrl: String!
+    docsPath: String!
+  }
+
+  type InstanceSetupStatus @query(read: false, aggregate: false) @mutation(operations: []) @subscription(events: []) {
+    auth: InstanceCapabilityStatus!
+    mail: InstanceCapabilityStatus!
+    maps: InstanceCapabilityStatus!
+    geocoding: InstanceCapabilityStatus!
+    uploads: InstanceCapabilityStatus!
+    downloads: InstanceCapabilityStatus!
+    events: InstanceCapabilityStatus!
+    plugins: InstanceCapabilityStatus!
+  }
+
   type Query {
     # Discovery
     """
@@ -2589,6 +2608,9 @@ const typeDefinitions = gql`
     can support multiple albums per image.
     """
     getImageAlbumUsage(imageId: ID!): ImageAlbumUsage!
+
+    """Return public setup capabilities without exposing environment values."""
+    getInstanceSetupStatus: InstanceSetupStatus!
 
     getDiscussionsInChannel(
       channelUniqueName: String!


### PR DESCRIPTION
## Summary

- reconcile the already-reviewed instance capability query onto `main`
- report configuration, enablement, missing environment variables, and setup links for self-hosted integrations
- restore the backend dependency required by the frontend instance setup checklist and graceful degradation UI

## Why this follow-up exists

PR #203 was merged into `codex/self-hosting-02-auto-provision` after PR #202 had already been merged into `main`, so commit `d21bf8d8` did not propagate to the default branch.

## Testing

- The original stacked PR checks passed before merge
- Fresh CI will run on this reconciliation PR