### PR TITLE
feat(auth): add local development bearer tokens

### DIFF
--- a/customResolvers/queries/getInstanceSetupStatus.test.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.test.ts
@@ -127,6 +127,43 @@ test("reports invalid email providers as needing EMAIL_PROVIDER", () => {
   assert.deepEqual(status.mail.requiredEnvVarsMissing, ["EMAIL_PROVIDER"]);
 });
 
+test("reports a complete local development auth provider as configured", () => {
+  const status = buildInstanceSetupStatus({
+    env: {
+      NODE_ENV: "development",
+      MULTIFORUM_AUTH_PROVIDER: "local-dev",
+      MULTIFORUM_BOOTSTRAP_EMAIL: "admin@example.test",
+      MULTIFORUM_BOOTSTRAP_USERNAME: "admin",
+      MULTIFORUM_BOOTSTRAP_PASSWORD: "local-password",
+      SUPERADMIN_EMAIL: "admin@example.test",
+    },
+    serverConfig: null,
+  });
+
+  assert.deepEqual(status.auth, {
+    configured: true,
+    enabled: true,
+    requiredEnvVarsMissing: [],
+    setupUrl: "/admin/setup#authentication",
+    docsPath: "/authentication",
+  });
+});
+
+test("reports missing local development auth settings instead of Auth0 settings", () => {
+  const status = buildInstanceSetupStatus({
+    env: { MULTIFORUM_AUTH_PROVIDER: "local-dev" },
+    serverConfig: null,
+  });
+
+  assert.deepEqual(status.auth.requiredEnvVarsMissing, [
+    "NODE_ENV",
+    "MULTIFORUM_BOOTSTRAP_EMAIL",
+    "MULTIFORUM_BOOTSTRAP_USERNAME",
+    "MULTIFORUM_BOOTSTRAP_PASSWORD",
+    "SUPERADMIN_EMAIL",
+  ]);
+});
+
 test("resolves the named ServerConfig before building status", async () => {
   const calls: unknown[] = [];
   const ServerConfig = {

--- a/customResolvers/queries/getInstanceSetupStatus.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.ts
@@ -1,4 +1,9 @@
 import type { ServerConfigModel } from "../../ogm_types.js";
+import {
+  getAuthenticationProvider,
+  getLocalDevAuthMissingVariables,
+  isLocalDevAuthConfigured,
+} from "../../services/localDevAuth.js";
 
 type Environment = NodeJS.ProcessEnv;
 
@@ -69,11 +74,15 @@ export const buildInstanceSetupStatus = ({
   env: Environment;
   serverConfig: ServerFeatureConfig | null;
 }): InstanceSetupStatus => {
-  const authMissing = missingVariables(env, [
-    "AUTH0_DOMAIN",
-    "AUTH0_CLIENT_ID",
-    "AUTH0_AUDIENCE",
-  ]);
+  const authProvider = getAuthenticationProvider(env);
+  const authMissing =
+    authProvider === "local-dev"
+      ? getLocalDevAuthMissingVariables(env)
+      : missingVariables(env, [
+          "AUTH0_DOMAIN",
+          "AUTH0_CLIENT_ID",
+          "AUTH0_AUDIENCE",
+        ]);
   const mailMissing = missingMailVariables(env);
   const mapsMissing = missingVariables(env, ["VITE_GOOGLE_MAPS_API_KEY"]);
   const geocodingMissing = missingVariables(env, ["VITE_OPEN_CAGE_API_KEY"]);
@@ -85,7 +94,10 @@ export const buildInstanceSetupStatus = ({
     "PLUGIN_SECRET_ENCRYPTION_KEY",
   ]);
 
-  const authConfigured = authMissing.length === 0;
+  const authConfigured =
+    authProvider === "local-dev"
+      ? isLocalDevAuthConfigured(env)
+      : authMissing.length === 0;
   const mailConfigured = mailMissing.length === 0;
   const mapsConfigured = mapsMissing.length === 0;
   const geocodingConfigured = geocodingMissing.length === 0;

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,7 +4,14 @@ Configuration is supplied via environment variables (e.g. a `.env` file locally,
 or Heroku config vars in production). The variables the server reads are grouped
 below.
 
-## Authentication (Auth0)
+## Authentication
+
+`MULTIFORUM_AUTH_PROVIDER` selects the authentication provider. Leave it unset
+or set it to `auth0` for the production Auth0 flow. The alternative
+`local-dev` provider is a single-identity convenience for local Docker Compose
+evaluation only: server startup rejects it when `NODE_ENV=production`.
+
+### Auth0
 
 | Variable | Required | Description |
 | --- | --- | --- |
@@ -24,6 +31,36 @@ Why `AUTH0_AUDIENCE` matters: the Nuxt frontend's server-session SDK
 tokens fall through the audience checks and server-side user lookups are
 rejected — users appear logged in but resolve with no username/profile. The
 value must match the frontend's `NUXT_AUTH0_AUDIENCE`.
+
+### Local development authentication
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `MULTIFORUM_AUTH_PROVIDER` | Yes | Set to `local-dev`. Any other non-Auth0 value fails startup. Requires `NODE_ENV=development`; an unset, test, or production environment is rejected. |
+| `MULTIFORUM_BOOTSTRAP_EMAIL` | Yes | Verified email placed in the signed development token. |
+| `MULTIFORUM_BOOTSTRAP_USERNAME` | Yes | Fixed subject/username claim for the development token. The permission layer still resolves the persisted user through the email relationship. |
+| `MULTIFORUM_BOOTSTRAP_PASSWORD` | Yes | Password used both to authenticate the local sign-in request and sign HS256 tokens. Must contain at least 12 characters. |
+| `SUPERADMIN_EMAIL` | Yes | Must exactly match `MULTIFORUM_BOOTSTRAP_EMAIL`, ensuring the one local identity can bootstrap and recover administration. |
+
+When enabled, `POST /auth/local-dev/token` accepts a small JSON body and returns
+a 12-hour bearer token:
+
+```bash
+curl --request POST http://localhost:4000/auth/local-dev/token \
+  --header 'Content-Type: application/json' \
+  --data '{"password":"your-local-password"}'
+```
+
+Responses include `Cache-Control: no-store`. Tokens accept only HS256, require
+the Multiforum local issuer and backend audience, and must exactly match the
+configured email, username, and verified-email claims. Invalid tokens are
+handled like invalid Auth0 tokens. The route returns 404 when local auth is not
+enabled.
+
+This mode is intentionally a single development identity. It has no password
+reset, account database, multi-user credential management, or production
+security support. Use Auth0 (and later a supported OIDC provider) for public
+deployments.
 
 ## Break-glass root (`SUPERADMIN_EMAIL`)
 

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,10 @@ import { PluginPipelineWatchdogService } from "./services/plugin/pipelineWatchdo
 import { PluginPipelineCampaignService } from "./services/plugin/pipelineCampaign.js";
 import { ensureSchemaConstraints } from "./services/schemaConstraints.js";
 import { provisionInstanceOnStartup } from "./services/startupProvisioning.js";
+import {
+  assertAuthenticationConfiguration,
+  createLocalDevTokenHandler,
+} from "./services/localDevAuth.js";
 import { logCriticalError, errorHandlingPlugin } from "./errorHandling.js";
 import type { GraphQLSchema } from "graphql";
 import type { Ogm, GraphQLRequest, GraphQLContext } from "./types/context.js";
@@ -163,6 +167,10 @@ async function initializeServer() {
   try {
     logger.info("🚀 Initializing server...");
 
+    // Fail before connecting to external services if a development-only auth
+    // provider is incomplete or was accidentally enabled in production.
+    assertAuthenticationConfiguration();
+
     await connectToNeo4jWithRetry(driver);
 
     const session = driver.session();
@@ -213,6 +221,19 @@ async function initializeServer() {
 
     const app = express();
     const httpServer = http.createServer(app);
+
+    // This route is invisible unless MULTIFORUM_AUTH_PROVIDER=local-dev. The
+    // provider configuration guard above ensures it can never start in
+    // production, and the handler returns only short-lived signed tokens.
+    app.use(
+      "/auth/local-dev/token",
+      cors({ origin: "*", credentials: false })
+    );
+    app.post(
+      "/auth/local-dev/token",
+      express.json({ limit: "16kb" }),
+      createLocalDevTokenHandler()
+    );
 
     // Reject pathologically deep queries before they reach the schema. Neo4jGraphQL
     // translates a nested GraphQL selection into one Cypher query, so an

--- a/rules/permission/userDataHelperFunctions.test.ts
+++ b/rules/permission/userDataHelperFunctions.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { issueLocalDevToken } from "../../services/localDevAuth.js";
 import { setUserDataOnContext } from "./userDataHelperFunctions.js";
 import type { AuthContextForUserLookup } from "./userDataHelperFunctions.js";
 
@@ -55,4 +56,106 @@ test("does no DB work for an unauthenticated request (no token)", async () => {
   const result = await setUserDataOnContext({ context });
   assert.equal(modelCalls, 0);
   assert.equal(result.username, null);
+});
+
+const localAuthEnvironment = {
+  NODE_ENV: "development",
+  MULTIFORUM_AUTH_PROVIDER: "local-dev",
+  MULTIFORUM_BOOTSTRAP_EMAIL: "admin@example.test",
+  MULTIFORUM_BOOTSTRAP_USERNAME: "bootstrap_admin",
+  MULTIFORUM_BOOTSTRAP_PASSWORD: "local-password",
+  SUPERADMIN_EMAIL: "admin@example.test",
+};
+
+const withLocalAuthEnvironment = async (callback: () => Promise<void>) => {
+  const previous = Object.fromEntries(
+    Object.keys(localAuthEnvironment).map((name) => [name, process.env[name]])
+  );
+  Object.assign(process.env, localAuthEnvironment);
+  try {
+    await callback();
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+};
+
+test("resolves a signed local token through the persisted email relationship", async () => {
+  await withLocalAuthEnvironment(async () => {
+    const token = issueLocalDevToken(
+      localAuthEnvironment.MULTIFORUM_BOOTSTRAP_PASSWORD,
+      localAuthEnvironment
+    );
+    assert.ok(token);
+
+    const context = {
+      ogm: {
+        model(name: string) {
+          if (name === "Email") {
+            return {
+              find: async () => [{ User: { username: "persisted_admin" } }],
+            };
+          }
+          if (name === "User") {
+            return {
+              find: async () => [
+                { ModerationProfile: { displayName: "Local Admin" } },
+              ],
+            };
+          }
+          throw new Error(`Unexpected model ${name}`);
+        },
+      },
+      req: { headers: { authorization: `Bearer ${token}` } },
+    } as unknown as AuthContextForUserLookup;
+
+    const result = await setUserDataOnContext({ context });
+    assert.deepEqual(result, {
+      username: "persisted_admin",
+      email: "admin@example.test",
+      email_verified: true,
+      data: { ModerationProfile: { displayName: "Local Admin" } },
+    });
+  });
+});
+
+test("rejects an invalid local token on mutations", async () => {
+  await withLocalAuthEnvironment(async () => {
+    const context = {
+      ogm: { model: () => ({}) },
+      req: {
+        headers: { authorization: "Bearer invalid-token" },
+        isMutation: true,
+      },
+    } as unknown as AuthContextForUserLookup;
+
+    await assert.rejects(
+      setUserDataOnContext({ context }),
+      /authentication token is invalid/i
+    );
+  });
+});
+
+test("marks an invalid local token on query context without throwing", async () => {
+  await withLocalAuthEnvironment(async () => {
+    const context = {
+      ogm: { model: () => ({}) },
+      req: {
+        headers: { authorization: "Bearer invalid-token" },
+        isMutation: false,
+      },
+    } as unknown as AuthContextForUserLookup;
+
+    const result = await setUserDataOnContext({ context });
+    assert.equal(result.username, null);
+    assert.match(
+      context.jwtError?.message ?? "",
+      /authentication token is invalid/i
+    );
+  });
 });

--- a/rules/permission/userDataHelperFunctions.ts
+++ b/rules/permission/userDataHelperFunctions.ts
@@ -13,6 +13,10 @@ import jwksClient from "jwks-rsa";
 import axios from "axios";
 import NodeCache from "node-cache";
 import { logger } from "../../logger.js";
+import {
+  getAuthenticationProvider,
+  verifyLocalDevToken,
+} from "../../services/localDevAuth.js";
 
 type CachedUserInfo = {
   email: string | null;
@@ -174,15 +178,19 @@ export const setUserDataOnContext = async (
   }
 
   let email: string | null = null;
+  let emailVerified = false;
   let decoded: any;
   let username: string | null | undefined = null;
   let modProfileName: string | null | undefined = null;
+  const mockAuthEnabled = isMockAuthEnabled();
+  const authProvider = mockAuthEnabled ? null : getAuthenticationProvider();
 
   if (token) {
-    if (isMockAuthEnabled()) {
+    if (mockAuthEnabled) {
       const mockPayload = decodeMockTokenPayload(token);
       email = mockPayload.email;
       username = mockPayload.username;
+      emailVerified = true;
 
       if (!username && email) {
         username = await getUserFromEmail(email, ogm.model("Email"));
@@ -193,7 +201,32 @@ export const setUserDataOnContext = async (
       }
     }
 
-    if (!username && !email) {
+    if (!username && !email && authProvider === "local-dev") {
+      try {
+        const localIdentity = verifyLocalDevToken(token);
+        email = localIdentity.email;
+        emailVerified = true;
+        username = await getUserFromEmail(email, ogm.model("Email"));
+        if (username) {
+          modProfileName = await getModProfileNameFromUsername(username, ogm);
+        }
+      } catch (error) {
+        const isExpired =
+          error instanceof Error && error.name === "TokenExpiredError";
+        const errorMessage = isExpired
+          ? ERROR_MESSAGES.channel.tokenExpired ||
+            "Your session has expired. Please sign in again."
+          : ERROR_MESSAGES.channel.invalidToken ||
+            "Your authentication token is invalid. Please sign in again.";
+
+        if (context.req?.isMutation === true) {
+          throw new Error(errorMessage);
+        }
+        context.jwtError = new Error(errorMessage);
+      }
+    }
+
+    if (!username && !email && authProvider === "auth0") {
       if (!process.env.AUTH0_DOMAIN) {
         throw new Error("AUTH0_DOMAIN environment variable is not defined.");
       }
@@ -309,7 +342,7 @@ export const setUserDataOnContext = async (
   return {
     username: username || null,
     email,
-    email_verified: isMockAuthEnabled() ? true : false,
+    email_verified: emailVerified,
     data: {
       ModerationProfile: modProfileName ? { displayName: modProfileName } : null,
     },

--- a/services/localDevAuth.test.ts
+++ b/services/localDevAuth.test.ts
@@ -20,6 +20,31 @@ const localEnv = {
   SUPERADMIN_EMAIL: "admin@example.test",
 };
 
+const withProcessEnvironment = <T>(
+  values: NodeJS.ProcessEnv,
+  callback: () => T
+): T => {
+  const names = ["MULTIFORUM_AUTH_PROVIDER", ...Object.keys(localEnv)];
+  const previous = Object.fromEntries(
+    names.map((name) => [name, process.env[name]])
+  );
+  for (const name of names) {
+    delete process.env[name];
+  }
+  Object.assign(process.env, values);
+  try {
+    return callback();
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+};
+
 test("keeps Auth0 as the backwards-compatible default provider", () => {
   assert.equal(getAuthenticationProvider({}), "auth0");
   assert.equal(getAuthenticationProvider({ MULTIFORUM_AUTH_PROVIDER: "AUTH0" }), "auth0");
@@ -40,6 +65,37 @@ test("reports every missing local development setting", () => {
     "MULTIFORUM_BOOTSTRAP_PASSWORD",
     "SUPERADMIN_EMAIL",
   ]);
+});
+
+test("uses process.env when provider helpers omit an explicit environment", () => {
+  withProcessEnvironment(localEnv, () => {
+    assert.equal(getAuthenticationProvider(), "local-dev");
+    assert.deepEqual(getLocalDevAuthMissingVariables(), []);
+    assert.doesNotThrow(() => assertAuthenticationConfiguration());
+    assert.equal(isLocalDevAuthConfigured(), true);
+
+    const token = issueLocalDevToken("local-password");
+    assert.ok(token);
+    assert.deepEqual(verifyLocalDevToken(token), {
+      email: "admin@example.test",
+      username: "admin",
+    });
+  });
+});
+
+test("accepts the default Auth0 provider without requiring local settings", () => {
+  assert.doesNotThrow(() => assertAuthenticationConfiguration({}));
+  assert.equal(isLocalDevAuthConfigured({}), false);
+});
+
+test("names missing settings when an enabled local provider is incomplete", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({
+      ...localEnv,
+      MULTIFORUM_BOOTSTRAP_PASSWORD: "",
+    }),
+    /MULTIFORUM_BOOTSTRAP_PASSWORD/
+  );
 });
 
 test("refuses local development authentication in production", () => {
@@ -146,6 +202,48 @@ test("rejects a correctly signed token for a different identity", () => {
   assert.throws(() => verifyLocalDevToken(token, localEnv), /does not match/);
 });
 
+test("rejects expired tokens", () => {
+  const token = jwt.sign(
+    {
+      email: localEnv.MULTIFORUM_BOOTSTRAP_EMAIL,
+      username: localEnv.MULTIFORUM_BOOTSTRAP_USERNAME,
+      email_verified: true,
+    },
+    localEnv.MULTIFORUM_BOOTSTRAP_PASSWORD,
+    {
+      algorithm: "HS256",
+      audience: "multiforum-backend",
+      issuer: "multiforum-local-dev",
+      subject: localEnv.MULTIFORUM_BOOTSTRAP_USERNAME,
+      expiresIn: -1,
+    }
+  );
+
+  assert.throws(
+    () => verifyLocalDevToken(token, localEnv),
+    (error: unknown) => error instanceof Error && error.name === "TokenExpiredError"
+  );
+});
+
+test("rejects tokens signed with an algorithm outside the HS256 allow-list", () => {
+  const token = jwt.sign(
+    {
+      email: localEnv.MULTIFORUM_BOOTSTRAP_EMAIL,
+      username: localEnv.MULTIFORUM_BOOTSTRAP_USERNAME,
+      email_verified: true,
+    },
+    localEnv.MULTIFORUM_BOOTSTRAP_PASSWORD,
+    {
+      algorithm: "HS384",
+      audience: "multiforum-backend",
+      issuer: "multiforum-local-dev",
+      subject: localEnv.MULTIFORUM_BOOTSTRAP_USERNAME,
+    }
+  );
+
+  assert.throws(() => verifyLocalDevToken(token, localEnv), /invalid algorithm/);
+});
+
 type ResponseResult = {
   status?: number;
   body?: unknown;
@@ -185,6 +283,14 @@ test("hides the token endpoint unless local auth is enabled", () => {
 
 test("returns an authorization failure without echoing credentials", () => {
   assert.deepEqual(invokeHandler(localEnv, { password: "wrong-password" }), {
+    status: 401,
+    body: { error: "Invalid credentials" },
+    headers: { "Cache-Control": "no-store" },
+  });
+});
+
+test("rejects a token request without a JSON body", () => {
+  assert.deepEqual(invokeHandler(localEnv, undefined), {
     status: 401,
     body: { error: "Invalid credentials" },
     headers: { "Cache-Control": "no-store" },

--- a/services/localDevAuth.test.ts
+++ b/services/localDevAuth.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import {
+  assertAuthenticationConfiguration,
+  createLocalDevTokenHandler,
+  getAuthenticationProvider,
+  getLocalDevAuthMissingVariables,
+  isLocalDevAuthConfigured,
+  issueLocalDevToken,
+  verifyLocalDevToken,
+} from "./localDevAuth.js";
+
+const localEnv = {
+  NODE_ENV: "development",
+  MULTIFORUM_AUTH_PROVIDER: "local-dev",
+  MULTIFORUM_BOOTSTRAP_EMAIL: "admin@example.test",
+  MULTIFORUM_BOOTSTRAP_USERNAME: "admin",
+  MULTIFORUM_BOOTSTRAP_PASSWORD: "local-password",
+  SUPERADMIN_EMAIL: "admin@example.test",
+};
+
+test("keeps Auth0 as the backwards-compatible default provider", () => {
+  assert.equal(getAuthenticationProvider({}), "auth0");
+  assert.equal(getAuthenticationProvider({ MULTIFORUM_AUTH_PROVIDER: "AUTH0" }), "auth0");
+});
+
+test("rejects unknown authentication providers", () => {
+  assert.throws(
+    () => getAuthenticationProvider({ MULTIFORUM_AUTH_PROVIDER: "passwords" }),
+    /Unsupported MULTIFORUM_AUTH_PROVIDER/
+  );
+});
+
+test("reports every missing local development setting", () => {
+  assert.deepEqual(getLocalDevAuthMissingVariables({}), [
+    "NODE_ENV",
+    "MULTIFORUM_BOOTSTRAP_EMAIL",
+    "MULTIFORUM_BOOTSTRAP_USERNAME",
+    "MULTIFORUM_BOOTSTRAP_PASSWORD",
+    "SUPERADMIN_EMAIL",
+  ]);
+});
+
+test("refuses local development authentication in production", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({ ...localEnv, NODE_ENV: "production" }),
+    /cannot run in production/
+  );
+  assert.equal(
+    isLocalDevAuthConfigured({ ...localEnv, NODE_ENV: "production" }),
+    false
+  );
+});
+
+test("requires development mode to be explicit", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({ ...localEnv, NODE_ENV: undefined }),
+    /requires NODE_ENV=development/
+  );
+});
+
+test("requires the bootstrap identity to remain the break-glass root", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({
+      ...localEnv,
+      SUPERADMIN_EMAIL: "someone-else@example.test",
+    }),
+    /must match/
+  );
+});
+
+test("requires a non-trivial local password", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({
+      ...localEnv,
+      MULTIFORUM_BOOTSTRAP_PASSWORD: "too-short",
+    }),
+    /at least 12 characters/
+  );
+});
+
+test("validates the configured email and username", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({
+      ...localEnv,
+      MULTIFORUM_BOOTSTRAP_EMAIL: "not-an-email",
+      SUPERADMIN_EMAIL: "not-an-email",
+    }),
+    /valid email address/
+  );
+  assert.throws(
+    () => assertAuthenticationConfiguration({
+      ...localEnv,
+      MULTIFORUM_BOOTSTRAP_USERNAME: "invalid username",
+    }),
+    /letters, numbers, or underscores/
+  );
+});
+
+test("issues and verifies a short-lived token for the configured identity", () => {
+  const token = issueLocalDevToken("local-password", localEnv);
+  assert.ok(token);
+  assert.deepEqual(verifyLocalDevToken(token, localEnv), {
+    email: "admin@example.test",
+    username: "admin",
+  });
+
+  const decoded = jwt.decode(token) as jwt.JwtPayload;
+  assert.equal(decoded.iss, "multiforum-local-dev");
+  assert.equal(decoded.aud, "multiforum-backend");
+  assert.equal(decoded.sub, "admin");
+  assert.ok((decoded.exp ?? 0) > (decoded.iat ?? 0));
+});
+
+test("does not issue a token for missing or incorrect passwords", () => {
+  assert.equal(issueLocalDevToken(undefined, localEnv), null);
+  assert.equal(issueLocalDevToken("wrong-password", localEnv), null);
+});
+
+test("rejects tokens signed by a different secret", () => {
+  const token = issueLocalDevToken("local-password", localEnv);
+  assert.ok(token);
+  assert.throws(() => verifyLocalDevToken(token, {
+    ...localEnv,
+    MULTIFORUM_BOOTSTRAP_PASSWORD: "different-password",
+  }));
+});
+
+test("rejects a correctly signed token for a different identity", () => {
+  const token = jwt.sign(
+    {
+      email: "attacker@example.test",
+      username: "attacker",
+      email_verified: true,
+    },
+    localEnv.MULTIFORUM_BOOTSTRAP_PASSWORD,
+    {
+      algorithm: "HS256",
+      audience: "multiforum-backend",
+      issuer: "multiforum-local-dev",
+      subject: "attacker",
+    }
+  );
+
+  assert.throws(() => verifyLocalDevToken(token, localEnv), /does not match/);
+});
+
+type ResponseResult = {
+  status?: number;
+  body?: unknown;
+  headers: Record<string, string>;
+};
+
+const invokeHandler = (env: NodeJS.ProcessEnv, body: unknown) => {
+  const result: ResponseResult = { headers: {} };
+  const response = {
+    setHeader: (name: string, value: string) => {
+      result.headers[name] = value;
+    },
+    status: (status: number) => {
+      result.status = status;
+      return response;
+    },
+    json: (responseBody: unknown) => {
+      result.body = responseBody;
+      return response;
+    },
+  };
+  createLocalDevTokenHandler(env)(
+    { body } as never,
+    response as never,
+    (() => {}) as never
+  );
+  return result;
+};
+
+test("hides the token endpoint unless local auth is enabled", () => {
+  assert.deepEqual(invokeHandler({}, { password: "anything" }), {
+    status: 404,
+    body: { error: "Not found" },
+    headers: { "Cache-Control": "no-store" },
+  });
+});
+
+test("returns an authorization failure without echoing credentials", () => {
+  assert.deepEqual(invokeHandler(localEnv, { password: "wrong-password" }), {
+    status: 401,
+    body: { error: "Invalid credentials" },
+    headers: { "Cache-Control": "no-store" },
+  });
+});
+
+test("returns a bearer token without allowing it to be cached", () => {
+  const result = invokeHandler(localEnv, { password: "local-password" });
+  assert.equal(result.status, 200);
+  assert.equal(result.headers["Cache-Control"], "no-store");
+  assert.equal((result.body as { tokenType: string }).tokenType, "Bearer");
+  assert.deepEqual(
+    verifyLocalDevToken(
+      (result.body as { accessToken: string }).accessToken,
+      localEnv
+    ),
+    { email: "admin@example.test", username: "admin" }
+  );
+});

--- a/services/localDevAuth.ts
+++ b/services/localDevAuth.ts
@@ -1,0 +1,199 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { RequestHandler } from "express";
+import jwt, { type JwtPayload } from "jsonwebtoken";
+
+const LOCAL_DEV_PROVIDER = "local-dev";
+const TOKEN_ISSUER = "multiforum-local-dev";
+const TOKEN_AUDIENCE = "multiforum-backend";
+const TOKEN_LIFETIME_SECONDS = 12 * 60 * 60;
+
+type Environment = NodeJS.ProcessEnv;
+
+export type AuthenticationProvider = "auth0" | typeof LOCAL_DEV_PROVIDER;
+
+export type LocalDevIdentity = {
+  email: string;
+  username: string;
+};
+
+export const LOCAL_DEV_AUTH_ENV_VARS = [
+  "NODE_ENV",
+  "MULTIFORUM_BOOTSTRAP_EMAIL",
+  "MULTIFORUM_BOOTSTRAP_USERNAME",
+  "MULTIFORUM_BOOTSTRAP_PASSWORD",
+  "SUPERADMIN_EMAIL",
+] as const;
+
+const hasValue = (env: Environment, name: string): boolean =>
+  Boolean(env[name]?.trim());
+
+export const getAuthenticationProvider = (
+  env: Environment = process.env
+): AuthenticationProvider => {
+  const provider = env.MULTIFORUM_AUTH_PROVIDER?.trim().toLowerCase() || "auth0";
+  if (provider !== "auth0" && provider !== LOCAL_DEV_PROVIDER) {
+    throw new Error(
+      `Unsupported MULTIFORUM_AUTH_PROVIDER '${provider}'. Use 'auth0' or 'local-dev'.`
+    );
+  }
+  return provider;
+};
+
+export const getLocalDevAuthMissingVariables = (
+  env: Environment = process.env
+): string[] =>
+  LOCAL_DEV_AUTH_ENV_VARS.filter((name) => !hasValue(env, name));
+
+const requireLocalDevConfiguration = (env: Environment) => {
+  if (getAuthenticationProvider(env) !== LOCAL_DEV_PROVIDER) {
+    throw new Error("Local development authentication is not enabled.");
+  }
+  if (env.NODE_ENV?.trim().toLowerCase() !== "development") {
+    throw new Error(
+      "MULTIFORUM_AUTH_PROVIDER=local-dev requires NODE_ENV=development and cannot run in production."
+    );
+  }
+
+  const missing = getLocalDevAuthMissingVariables(env);
+  if (missing.length > 0) {
+    throw new Error(
+      `Local development authentication requires: ${missing.join(", ")}.`
+    );
+  }
+
+  const email = env.MULTIFORUM_BOOTSTRAP_EMAIL!.trim();
+  const superAdminEmail = env.SUPERADMIN_EMAIL!.trim();
+  if (email !== superAdminEmail) {
+    throw new Error(
+      "SUPERADMIN_EMAIL must match MULTIFORUM_BOOTSTRAP_EMAIL in local-dev authentication mode."
+    );
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new Error("MULTIFORUM_BOOTSTRAP_EMAIL must be a valid email address.");
+  }
+
+  const username = env.MULTIFORUM_BOOTSTRAP_USERNAME!.trim();
+  if (!/^[a-zA-Z0-9_]{1,50}$/.test(username)) {
+    throw new Error(
+      "MULTIFORUM_BOOTSTRAP_USERNAME must contain 1-50 letters, numbers, or underscores."
+    );
+  }
+
+  const password = env.MULTIFORUM_BOOTSTRAP_PASSWORD!;
+  if (password.length < 12) {
+    throw new Error(
+      "MULTIFORUM_BOOTSTRAP_PASSWORD must contain at least 12 characters."
+    );
+  }
+
+  return {
+    email,
+    username,
+    password,
+  };
+};
+
+export const assertAuthenticationConfiguration = (
+  env: Environment = process.env
+): void => {
+  if (getAuthenticationProvider(env) === LOCAL_DEV_PROVIDER) {
+    requireLocalDevConfiguration(env);
+  }
+};
+
+export const isLocalDevAuthConfigured = (
+  env: Environment = process.env
+): boolean => {
+  try {
+    requireLocalDevConfiguration(env);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const passwordsMatch = (provided: string, expected: string): boolean => {
+  const providedDigest = createHash("sha256").update(provided).digest();
+  const expectedDigest = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+};
+
+export const issueLocalDevToken = (
+  providedPassword: unknown,
+  env: Environment = process.env
+): string | null => {
+  const config = requireLocalDevConfiguration(env);
+  if (
+    typeof providedPassword !== "string" ||
+    !passwordsMatch(providedPassword, config.password)
+  ) {
+    return null;
+  }
+
+  return jwt.sign(
+    {
+      email: config.email,
+      username: config.username,
+      email_verified: true,
+    },
+    config.password,
+    {
+      algorithm: "HS256",
+      audience: TOKEN_AUDIENCE,
+      issuer: TOKEN_ISSUER,
+      expiresIn: TOKEN_LIFETIME_SECONDS,
+      subject: config.username,
+    }
+  );
+};
+
+export const verifyLocalDevToken = (
+  token: string,
+  env: Environment = process.env
+): LocalDevIdentity => {
+  const config = requireLocalDevConfiguration(env);
+  const decoded = jwt.verify(token, config.password, {
+    algorithms: ["HS256"],
+    audience: TOKEN_AUDIENCE,
+    issuer: TOKEN_ISSUER,
+  }) as JwtPayload;
+
+  if (
+    decoded.email !== config.email ||
+    decoded.username !== config.username ||
+    decoded.email_verified !== true ||
+    decoded.sub !== config.username
+  ) {
+    throw new Error(
+      "Local development token identity does not match configuration."
+    );
+  }
+
+  return { email: config.email, username: config.username };
+};
+
+export const createLocalDevTokenHandler = (
+  env: Environment = process.env
+): RequestHandler => {
+  return (request, response) => {
+    response.setHeader("Cache-Control", "no-store");
+
+    if (getAuthenticationProvider(env) !== LOCAL_DEV_PROVIDER) {
+      response.status(404).json({ error: "Not found" });
+      return;
+    }
+
+    const token = issueLocalDevToken(request.body?.password, env);
+    if (!token) {
+      response.status(401).json({ error: "Invalid credentials" });
+      return;
+    }
+
+    response.status(200).json({
+      accessToken: token,
+      tokenType: "Bearer",
+      expiresIn: TOKEN_LIFETIME_SECONDS,
+    });
+  };
+};


### PR DESCRIPTION
## Summary
- add a single-identity local development auth provider and token endpoint
- verify only HS256 tokens with fixed issuer, audience, configured identity, and 12-hour expiry
- refuse startup unless local auth explicitly runs with NODE_ENV=development
- resolve the persisted username through the existing Email relationship rather than trusting the token username
- require the bootstrap email to match SUPERADMIN_EMAIL for first-admin recovery
- report local auth through getInstanceSetupStatus and document the complete contract

## Security boundary
- Auth0 remains the default and unchanged production provider
- local-dev is rejected for unset, test, and production NODE_ENV values
- unknown providers fail startup
- passwords require 12+ characters and are compared as fixed-length SHA-256 digests with timingSafeEqual
- token responses use Cache-Control: no-store; the endpoint returns 404 unless enabled
- token identity claims must exactly match server configuration

## Validation
- npm test: 1,126 passed
- npm run tsc
- focused auth/capability tests: 27 passed
- localDevAuth.ts coverage: 96.92% statements/lines, 93.61% branches, 100% functions
- ESLint: 0 errors (only existing generated coverage-report warnings)
- git diff --check

## Follow-up
The next stacked frontend/Compose PR can add the local sign-in screen and quick-start environment wiring. Automatic creation/linking of the configured bootstrap user can remain a separate backend slice so this security-sensitive PR stays focused.