### PR TITLE
feat(self-hosting): provision local bootstrap admin

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -37,8 +37,8 @@ value must match the frontend's `NUXT_AUTH0_AUDIENCE`.
 | Variable | Required | Description |
 | --- | --- | --- |
 | `MULTIFORUM_AUTH_PROVIDER` | Yes | Set to `local-dev`. Any other non-Auth0 value fails startup. Requires `NODE_ENV=development`; an unset, test, or production environment is rejected. |
-| `MULTIFORUM_BOOTSTRAP_EMAIL` | Yes | Verified email placed in the signed development token. |
-| `MULTIFORUM_BOOTSTRAP_USERNAME` | Yes | Fixed subject/username claim for the development token. The permission layer still resolves the persisted user through the email relationship. |
+| `MULTIFORUM_BOOTSTRAP_EMAIL` | Yes | Verified email placed in the signed development token. With automatic provisioning enabled on an empty database, startup also creates this email relationship. |
+| `MULTIFORUM_BOOTSTRAP_USERNAME` | Yes | Fixed subject/username claim for the development token. With automatic provisioning enabled on an empty database, startup creates this user and connects it as the first SuperAdmin. The permission layer still resolves the persisted user through the email relationship. |
 | `MULTIFORUM_BOOTSTRAP_PASSWORD` | Yes | Password used both to authenticate the local sign-in request and sign HS256 tokens. Must contain at least 12 characters. |
 | `SUPERADMIN_EMAIL` | Yes | Must exactly match `MULTIFORUM_BOOTSTRAP_EMAIL`, ensuring the one local identity can bootstrap and recover administration. |
 
@@ -109,7 +109,7 @@ test/E2E environments the seeded admin test user also acts as root.
 | `NODE_OPTIONS` | Recommended on memory-limited hosts | Standard Node runtime flags. On a 1 GB Heroku dyno, use `--max-old-space-size=768` so runtime schema generation triggers garbage collection before exceeding the dyno memory quota. The Heroku build script overrides this with a 2 GB heap because GraphQL/OGM type generation needs more memory during compilation. Re-test both values after materially expanding the GraphQL schema or changing dyno size. |
 | `GRAPHQL_MAX_DEPTH` | No | Maximum allowed GraphQL query nesting depth (default `15`). Deeper queries are rejected before execution to prevent one crafted query from generating a pathological Cypher query. |
 | `SERVER_CONFIG_NAME` | Yes | Name of the `ServerConfig` record this instance runs as (e.g. `Listical`). When automatic provisioning is enabled, Multiforum uses this name to create the config and install or update its default roles. The special value `Cypress Test Server` enables test-only behavior. |
-| `MULTIFORUM_AUTO_PROVISION` | No | Set to `true`, `1`, `yes`, or `on` to create or reconcile the named `ServerConfig` and its default roles during startup. It is disabled by default, so existing deployments are unchanged. The operation is idempotent; an opted-in provisioning error fails startup rather than accepting traffic with partial defaults. |
+| `MULTIFORUM_AUTO_PROVISION` | No | Set to `true`, `1`, `yes`, or `on` to create or reconcile the named `ServerConfig` and its default roles during startup. In `local-dev` auth mode, an empty user database also receives the configured bootstrap user, email, moderation profile, and SuperAdmin connection. A non-empty database is never seeded with a new identity; an exact existing bootstrap identity is only reconciled into SuperAdmins. It is disabled by default, so existing deployments are unchanged. The operation is idempotent; an opted-in provisioning error fails startup rather than accepting traffic with partial defaults. |
 | `FRONTEND_URL` | Yes | Base URL of the frontend, used to build links in outbound emails (e.g. mod-invite acceptance links). |
 | `PLUGIN_SECRET_ENCRYPTION_KEY` | If plugins store secrets | 32-character key used to encrypt plugin secrets at rest. Set a strong value in production (the in-code fallback is a placeholder only). |
 

--- a/services/bootstrapAdmin.test.ts
+++ b/services/bootstrapAdmin.test.ts
@@ -187,6 +187,32 @@ test("rejects username and email collisions", async () => {
   );
 });
 
+test("rejects matching records whose identity relationships are missing", async () => {
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: {
+        find: async () => [{ username: "admin", Email: null }],
+      },
+      Email: { find: async () => [] },
+      ServerConfig: { find: async () => [] },
+    }),
+    /username is linked to a different email/
+  );
+
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: { find: async () => [] },
+      Email: {
+        find: async () => [{ address: "admin@example.test", User: null }],
+      },
+      ServerConfig: { find: async () => [] },
+    }),
+    /admin@example\.test.*linked to a different username/
+  );
+});
+
 test("rejects an incomplete existing user/email relationship", async () => {
   await assert.rejects(
     provisionBootstrapAdmin({
@@ -251,6 +277,36 @@ test("fails clearly when required model mutations are unavailable", async () => 
     }),
     /ServerConfig model does not support bootstrap updates/
   );
+});
+
+test("ignores malformed SuperAdmin entries while reconciling the identity", async () => {
+  let updateCalls = 0;
+  const result = await provisionBootstrapAdmin({
+    ...baseInput(),
+    User: {
+      find: async () => [
+        { username: "admin", Email: { address: "admin@example.test" } },
+      ],
+    },
+    Email: {
+      find: async () => [
+        { address: "admin@example.test", User: { username: "admin" } },
+      ],
+    },
+    ServerConfig: {
+      find: async () => [
+        { SuperAdmins: [null, {}, { username: "someone-else" }] },
+      ],
+      update: async () => {
+        updateCalls += 1;
+      },
+    },
+  });
+
+  assert.deepEqual({ result, updateCalls }, {
+    result: { status: "connected", username: "admin" },
+    updateCalls: 1,
+  });
 });
 
 test("resolves the required models from OGM", async () => {

--- a/services/bootstrapAdmin.test.ts
+++ b/services/bootstrapAdmin.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  provisionBootstrapAdmin,
+  provisionBootstrapAdminFromOgm,
+} from "./bootstrapAdmin.js";
+
+const baseInput = () => ({
+  serverName: "Community Forum",
+  email: "admin@example.test",
+  username: "admin",
+});
+
+test("creates the first user and connects it as SuperAdmin", async () => {
+  const userCreates: unknown[] = [];
+  const configUpdates: unknown[] = [];
+  const messages: string[] = [];
+  let userFindCall = 0;
+
+  const result = await provisionBootstrapAdmin({
+    ...baseInput(),
+    User: {
+      find: async () => {
+        userFindCall += 1;
+        return [];
+      },
+      create: async (args) => userCreates.push(args),
+    },
+    Email: { find: async () => [] },
+    ServerConfig: {
+      find: async () => [{ serverName: "Community Forum", SuperAdmins: [] }],
+      update: async (args) => configUpdates.push(args),
+    },
+    log: (message) => messages.push(message),
+  });
+
+  assert.equal(userFindCall, 2);
+  assert.deepEqual(userCreates, [
+    {
+      input: [
+        {
+          username: "admin",
+          Email: { create: { node: { address: "admin@example.test" } } },
+          ModerationProfile: {
+            create: { node: { displayName: "bootstrap-admin" } },
+          },
+        },
+      ],
+    },
+  ]);
+  assert.deepEqual(configUpdates, [
+    {
+      where: { serverName: "Community Forum" },
+      update: {
+        SuperAdmins: [
+          { connect: [{ where: { node: { username: "admin" } } }] },
+        ],
+      },
+    },
+  ]);
+  assert.deepEqual(result, { status: "created", username: "admin" });
+  assert.deepEqual(messages, [
+    "Created bootstrap user 'admin'.",
+    "Connected bootstrap user 'admin' as a SuperAdmin.",
+  ]);
+});
+
+test("connects an existing matching identity without recreating it", async () => {
+  let createCalls = 0;
+  let updateCalls = 0;
+  const result = await provisionBootstrapAdmin({
+    ...baseInput(),
+    User: {
+      find: async () => [
+        { username: "admin", Email: { address: "admin@example.test" } },
+      ],
+      create: async () => {
+        createCalls += 1;
+      },
+    },
+    Email: {
+      find: async () => [
+        { address: "admin@example.test", User: { username: "admin" } },
+      ],
+    },
+    ServerConfig: {
+      find: async () => [{ SuperAdmins: [] }],
+      update: async () => {
+        updateCalls += 1;
+      },
+    },
+  });
+
+  assert.deepEqual({ result, createCalls, updateCalls }, {
+    result: { status: "connected", username: "admin" },
+    createCalls: 0,
+    updateCalls: 1,
+  });
+});
+
+test("is unchanged when the matching identity is already a SuperAdmin", async () => {
+  let updateCalls = 0;
+  const messages: string[] = [];
+  const result = await provisionBootstrapAdmin({
+    ...baseInput(),
+    User: {
+      find: async () => [
+        { username: "admin", Email: { address: "admin@example.test" } },
+      ],
+    },
+    Email: {
+      find: async () => [
+        { address: "admin@example.test", User: { username: "admin" } },
+      ],
+    },
+    ServerConfig: {
+      find: async () => [{ SuperAdmins: [{ username: "admin" }] }],
+      update: async () => {
+        updateCalls += 1;
+      },
+    },
+    log: (message) => messages.push(message),
+  });
+
+  assert.deepEqual({ result, updateCalls, messages }, {
+    result: { status: "unchanged", username: "admin" },
+    updateCalls: 0,
+    messages: ["Bootstrap user 'admin' is already a SuperAdmin."],
+  });
+});
+
+test("does not create a bootstrap identity in a non-empty database", async () => {
+  let findCall = 0;
+  let createCalls = 0;
+  const result = await provisionBootstrapAdmin({
+    ...baseInput(),
+    User: {
+      find: async () => {
+        findCall += 1;
+        return findCall === 2 ? [{ username: "someone" }] : [];
+      },
+      create: async () => {
+        createCalls += 1;
+      },
+    },
+    Email: { find: async () => [] },
+    ServerConfig: {
+      find: async () => {
+        throw new Error("ServerConfig must not be queried after a skip");
+      },
+    },
+  });
+
+  assert.deepEqual({ result, createCalls }, {
+    result: { status: "skipped", reason: "database-not-empty" },
+    createCalls: 0,
+  });
+});
+
+test("rejects username and email collisions", async () => {
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: {
+        find: async () => [
+          { username: "admin", Email: { address: "other@example.test" } },
+        ],
+      },
+      Email: { find: async () => [] },
+      ServerConfig: { find: async () => [] },
+    }),
+    /username is linked to a different email/
+  );
+
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: { find: async () => [] },
+      Email: {
+        find: async () => [
+          { address: "admin@example.test", User: { username: "someone" } },
+        ],
+      },
+      ServerConfig: { find: async () => [] },
+    }),
+    /admin@example\.test.*linked to a different username/
+  );
+});
+
+test("rejects an incomplete existing user/email relationship", async () => {
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: {
+        find: async () => [
+          { username: "admin", Email: { address: "admin@example.test" } },
+        ],
+      },
+      Email: { find: async () => [] },
+      ServerConfig: { find: async () => [] },
+    }),
+    /relationship is incomplete/
+  );
+});
+
+test("fails fast when the provisioned ServerConfig cannot be found", async () => {
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: {
+        find: async () => [
+          { username: "admin", Email: { address: "admin@example.test" } },
+        ],
+      },
+      Email: {
+        find: async () => [
+          { address: "admin@example.test", User: { username: "admin" } },
+        ],
+      },
+      ServerConfig: { find: async () => [] },
+    }),
+    /ServerConfig 'Community Forum' does not exist/
+  );
+});
+
+test("fails clearly when required model mutations are unavailable", async () => {
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: { find: async () => [] },
+      Email: { find: async () => [] },
+      ServerConfig: { find: async () => [] },
+    }),
+    /User model does not support bootstrap creation/
+  );
+
+  await assert.rejects(
+    provisionBootstrapAdmin({
+      ...baseInput(),
+      User: {
+        find: async () => [
+          { username: "admin", Email: { address: "admin@example.test" } },
+        ],
+      },
+      Email: {
+        find: async () => [
+          { address: "admin@example.test", User: { username: "admin" } },
+        ],
+      },
+      ServerConfig: { find: async () => [{ SuperAdmins: [] }] },
+    }),
+    /ServerConfig model does not support bootstrap updates/
+  );
+});
+
+test("resolves the required models from OGM", async () => {
+  const modelNames: string[] = [];
+  const models = {
+    User: {
+      find: async () => [
+        { username: "admin", Email: { address: "admin@example.test" } },
+      ],
+    },
+    Email: {
+      find: async () => [
+        { address: "admin@example.test", User: { username: "admin" } },
+      ],
+    },
+    ServerConfig: {
+      find: async () => [{ SuperAdmins: [{ username: "admin" }] }],
+    },
+  };
+
+  const result = await provisionBootstrapAdminFromOgm(
+    {
+      model: (name) => {
+        modelNames.push(name);
+        return models[name as keyof typeof models];
+      },
+    },
+    baseInput()
+  );
+
+  assert.deepEqual(modelNames, ["User", "Email", "ServerConfig"]);
+  assert.deepEqual(result, { status: "unchanged", username: "admin" });
+});

--- a/services/bootstrapAdmin.ts
+++ b/services/bootstrapAdmin.ts
@@ -1,0 +1,144 @@
+import type { OgmLike } from "../seedData/provisionServerDefaults.js";
+
+type Model = {
+  find: (args: Record<string, unknown>) => Promise<any[]>;
+  create?: (args: Record<string, unknown>) => Promise<unknown>;
+  update?: (args: Record<string, unknown>) => Promise<unknown>;
+};
+
+export type BootstrapAdminResult =
+  | { status: "created"; username: string }
+  | { status: "connected"; username: string }
+  | { status: "unchanged"; username: string }
+  | { status: "skipped"; reason: "database-not-empty" };
+
+export type BootstrapAdminInput = {
+  User: Model;
+  Email: Model;
+  ServerConfig: Model;
+  serverName: string;
+  email: string;
+  username: string;
+  log?: (message: string) => void;
+};
+
+const linkedEmail = (user: any): string | null =>
+  typeof user?.Email?.address === "string" ? user.Email.address : null;
+
+const linkedUsername = (email: any): string | null =>
+  typeof email?.User?.username === "string" ? email.User.username : null;
+
+export const provisionBootstrapAdmin = async (
+  input: BootstrapAdminInput
+): Promise<BootstrapAdminResult> => {
+  const { User, Email, ServerConfig, serverName, email, username } = input;
+  const log = input.log ?? (() => {});
+
+  const [usersByUsername, emailsByAddress] = await Promise.all([
+    User.find({
+      where: { username },
+      selectionSet: "{ username Email { address } }",
+    }),
+    Email.find({
+      where: { address: email },
+      selectionSet: "{ address User { username } }",
+    }),
+  ]);
+
+  const existingUser = usersByUsername[0];
+  const existingEmail = emailsByAddress[0];
+  if (existingUser && linkedEmail(existingUser) !== email) {
+    throw new Error(
+      `Cannot bootstrap '${username}': that username is linked to a different email.`
+    );
+  }
+  if (existingEmail && linkedUsername(existingEmail) !== username) {
+    throw new Error(
+      `Cannot bootstrap '${username}': '${email}' is linked to a different username.`
+    );
+  }
+  if (Boolean(existingUser) !== Boolean(existingEmail)) {
+    throw new Error(
+      `Cannot bootstrap '${username}': the existing user/email relationship is incomplete.`
+    );
+  }
+
+  let created = false;
+  if (!existingUser) {
+    const existingUsers = await User.find({
+      options: { limit: 1 },
+      selectionSet: "{ username }",
+    });
+    if (existingUsers.length > 0) {
+      log("Skipped bootstrap admin: the database already contains users.");
+      return { status: "skipped", reason: "database-not-empty" };
+    }
+    if (!User.create) {
+      throw new Error("User model does not support bootstrap creation.");
+    }
+
+    await User.create({
+      input: [
+        {
+          username,
+          Email: { create: { node: { address: email } } },
+          ModerationProfile: {
+            create: { node: { displayName: `bootstrap-${username}` } },
+          },
+        },
+      ],
+    });
+    created = true;
+    log(`Created bootstrap user '${username}'.`);
+  }
+
+  const serverConfigs = await ServerConfig.find({
+    where: { serverName },
+    selectionSet: "{ serverName SuperAdmins { username } }",
+  });
+  const serverConfig = serverConfigs[0];
+  if (!serverConfig) {
+    throw new Error(
+      `Cannot bootstrap '${username}': ServerConfig '${serverName}' does not exist.`
+    );
+  }
+
+  const isAlreadySuperAdmin = (serverConfig.SuperAdmins ?? []).some(
+    (admin: { username?: string | null }) => admin?.username === username
+  );
+  if (isAlreadySuperAdmin) {
+    log(`Bootstrap user '${username}' is already a SuperAdmin.`);
+    return { status: "unchanged", username };
+  }
+  if (!ServerConfig.update) {
+    throw new Error("ServerConfig model does not support bootstrap updates.");
+  }
+
+  await ServerConfig.update({
+    where: { serverName },
+    update: {
+      SuperAdmins: [
+        { connect: [{ where: { node: { username } } }] },
+      ],
+    },
+  });
+  log(`Connected bootstrap user '${username}' as a SuperAdmin.`);
+
+  return { status: created ? "created" : "connected", username };
+};
+
+export const provisionBootstrapAdminFromOgm = (
+  ogm: OgmLike,
+  options: {
+    serverName: string;
+    email: string;
+    username: string;
+    log?: (message: string) => void;
+  }
+): Promise<BootstrapAdminResult> =>
+  provisionBootstrapAdmin({
+    User: ogm.model("User") as Model,
+    Email: ogm.model("Email") as Model,
+    ServerConfig: ogm.model("ServerConfig") as Model,
+    ...options,
+  });

--- a/services/localDevAuth.ts
+++ b/services/localDevAuth.ts
@@ -102,6 +102,13 @@ export const assertAuthenticationConfiguration = (
   }
 };
 
+export const getLocalDevBootstrapIdentity = (
+  env: Environment = process.env
+): LocalDevIdentity => {
+  const { email, username } = requireLocalDevConfiguration(env);
+  return { email, username };
+};
+
 export const isLocalDevAuthConfigured = (
   env: Environment = process.env
 ): boolean => {

--- a/services/startupProvisioning.test.ts
+++ b/services/startupProvisioning.test.ts
@@ -34,6 +34,7 @@ test("provisions an explicitly enabled instance", async () => {
   assert.deepEqual(result, {
     status: "provisioned",
     result: provisionedResult,
+    bootstrapAdmin: { status: "skipped", reason: "auth-provider" },
   });
   assert.deepEqual(messages, [
     "[startup-provision] Created defaults.",
@@ -109,5 +110,56 @@ test("propagates opt-in provisioning failures so startup fails fast", async () =
       },
     }),
     /database rejected defaults/
+  );
+});
+
+test("provisions the configured local development identity after server defaults", async () => {
+  const calls: string[] = [];
+  const result = await provisionInstanceOnStartup({
+    ogm: { model: () => ({}) },
+    env: {
+      MULTIFORUM_AUTO_PROVISION: "true",
+      SERVER_CONFIG_NAME: "Community Forum",
+      NODE_ENV: "development",
+      MULTIFORUM_AUTH_PROVIDER: "local-dev",
+      MULTIFORUM_BOOTSTRAP_EMAIL: "admin@example.test",
+      MULTIFORUM_BOOTSTRAP_USERNAME: "admin",
+      MULTIFORUM_BOOTSTRAP_PASSWORD: "local-password",
+      SUPERADMIN_EMAIL: "admin@example.test",
+    },
+    provision: async () => {
+      calls.push("defaults");
+      return provisionedResult;
+    },
+    provisionBootstrapAdmin: async (_ogm, options) => {
+      calls.push(`admin:${options.username}:${options.email}:${options.serverName}`);
+      return { status: "created", username: options.username };
+    },
+  });
+
+  assert.deepEqual(calls, [
+    "defaults",
+    "admin:admin:admin@example.test:Community Forum",
+  ]);
+  assert.deepEqual(result, {
+    status: "provisioned",
+    result: provisionedResult,
+    bootstrapAdmin: { status: "created", username: "admin" },
+  });
+});
+
+test("fails startup when enabled local auth is incomplete", async () => {
+  await assert.rejects(
+    provisionInstanceOnStartup({
+      ogm: { model: () => ({}) },
+      env: {
+        MULTIFORUM_AUTO_PROVISION: "true",
+        SERVER_CONFIG_NAME: "Community Forum",
+        NODE_ENV: "development",
+        MULTIFORUM_AUTH_PROVIDER: "local-dev",
+      },
+      provision: async () => provisionedResult,
+    }),
+    /Local development authentication requires/
   );
 });

--- a/services/startupProvisioning.test.ts
+++ b/services/startupProvisioning.test.ts
@@ -163,3 +163,108 @@ test("fails startup when enabled local auth is incomplete", async () => {
     /Local development authentication requires/
   );
 });
+
+test("uses the production default role provisioner when no seam is injected", async () => {
+  const requestedModels: string[] = [];
+  const roleModel = {
+    find: async () => [],
+    create: async () => ({}),
+    update: async () => ({}),
+  };
+  const serverConfigModel = {
+    find: async () => [],
+    create: async () => ({}),
+    update: async () => ({}),
+  };
+
+  const result = await provisionInstanceOnStartup({
+    ogm: {
+      model: (name) => {
+        requestedModels.push(name);
+        return name === "ServerConfig" ? serverConfigModel : roleModel;
+      },
+    },
+    env: {
+      MULTIFORUM_AUTO_PROVISION: "true",
+      SERVER_CONFIG_NAME: "Community Forum",
+    },
+  });
+
+  assert.deepEqual(requestedModels, [
+    "ServerRole",
+    "ModServerRole",
+    "ServerConfig",
+  ]);
+  assert.equal(result.status, "provisioned");
+  if (result.status === "provisioned") {
+    assert.equal(result.result.serverConfigCreated, true);
+    assert.deepEqual(result.bootstrapAdmin, {
+      status: "skipped",
+      reason: "auth-provider",
+    });
+  }
+});
+
+test("uses the default bootstrap provisioner and forwards its logs", async () => {
+  let userFindCalls = 0;
+  let userCreateCalls = 0;
+  let configUpdateCalls = 0;
+  const messages: string[] = [];
+  const models = {
+    User: {
+      find: async () => {
+        userFindCalls += 1;
+        return [];
+      },
+      create: async () => {
+        userCreateCalls += 1;
+      },
+    },
+    Email: { find: async () => [] },
+    ServerConfig: {
+      find: async () => [{ SuperAdmins: [] }],
+      update: async () => {
+        configUpdateCalls += 1;
+      },
+    },
+  };
+
+  const result = await provisionInstanceOnStartup({
+    ogm: {
+      model: (name) => models[name as keyof typeof models],
+    },
+    env: {
+      MULTIFORUM_AUTO_PROVISION: "true",
+      SERVER_CONFIG_NAME: "Community Forum",
+      NODE_ENV: "development",
+      MULTIFORUM_AUTH_PROVIDER: "local-dev",
+      MULTIFORUM_BOOTSTRAP_EMAIL: "admin@example.test",
+      MULTIFORUM_BOOTSTRAP_USERNAME: "admin",
+      MULTIFORUM_BOOTSTRAP_PASSWORD: "local-password",
+      SUPERADMIN_EMAIL: "admin@example.test",
+    },
+    provision: async () => provisionedResult,
+    log: (message) => messages.push(message),
+  });
+
+  assert.deepEqual({ userFindCalls, userCreateCalls, configUpdateCalls }, {
+    userFindCalls: 2,
+    userCreateCalls: 1,
+    configUpdateCalls: 1,
+  });
+  assert.equal(result.status, "provisioned");
+  if (result.status === "provisioned") {
+    assert.deepEqual(result.bootstrapAdmin, {
+      status: "created",
+      username: "admin",
+    });
+  }
+  assert.ok(
+    messages.includes("[startup-provision] Created bootstrap user 'admin'.")
+  );
+  assert.ok(
+    messages.includes(
+      "[startup-provision] Connected bootstrap user 'admin' as a SuperAdmin."
+    )
+  );
+});

--- a/services/startupProvisioning.ts
+++ b/services/startupProvisioning.ts
@@ -3,11 +3,33 @@ import {
   type OgmLike,
   type ProvisionServerDefaultsResult,
 } from "../seedData/provisionServerDefaults.js";
+import {
+  provisionBootstrapAdminFromOgm,
+  type BootstrapAdminResult,
+} from "./bootstrapAdmin.js";
+import {
+  getAuthenticationProvider,
+  getLocalDevBootstrapIdentity,
+} from "./localDevAuth.js";
 
 type ProvisionDefaults = (
   ogm: OgmLike,
   options: { serverName: string; log?: (message: string) => void }
 ) => Promise<ProvisionServerDefaultsResult>;
+
+type ProvisionBootstrapAdmin = (
+  ogm: OgmLike,
+  options: {
+    serverName: string;
+    email: string;
+    username: string;
+    log?: (message: string) => void;
+  }
+) => Promise<BootstrapAdminResult>;
+
+type StartupBootstrapAdminResult =
+  | BootstrapAdminResult
+  | { status: "skipped"; reason: "auth-provider" };
 
 export type StartupProvisioningResult =
   | {
@@ -17,18 +39,15 @@ export type StartupProvisioningResult =
   | {
       status: "provisioned";
       result: ProvisionServerDefaultsResult;
+      bootstrapAdmin: StartupBootstrapAdminResult;
     };
 
 export type StartupProvisioningInput = {
   ogm: OgmLike;
-  env?: Partial<
-    Pick<
-      NodeJS.ProcessEnv,
-      "MULTIFORUM_AUTO_PROVISION" | "SERVER_CONFIG_NAME"
-    >
-  >;
+  env?: NodeJS.ProcessEnv;
   log?: (message: string) => void;
   provision?: ProvisionDefaults;
+  provisionBootstrapAdmin?: ProvisionBootstrapAdmin;
 };
 
 const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -61,5 +80,20 @@ export const provisionInstanceOnStartup = async (
     `[startup-provision] Ready: '${serverName}' has ${result.serverRolesUpserted} server roles and ${result.modServerRolesUpserted} moderator roles.`
   );
 
-  return { status: "provisioned", result };
+  let bootstrapAdmin: StartupBootstrapAdminResult = {
+    status: "skipped",
+    reason: "auth-provider",
+  };
+  if (getAuthenticationProvider(env) === "local-dev") {
+    const identity = getLocalDevBootstrapIdentity(env);
+    const provisionAdmin =
+      input.provisionBootstrapAdmin ?? provisionBootstrapAdminFromOgm;
+    bootstrapAdmin = await provisionAdmin(input.ogm, {
+      serverName,
+      ...identity,
+      log: (message) => log(`[startup-provision] ${message}`),
+    });
+  }
+
+  return { status: "provisioned", result, bootstrapAdmin };
 };


### PR DESCRIPTION
## Summary

- create the configured local-development identity when automatic provisioning runs against an empty user database
- connect that identity to the provisioned ServerConfig as the first SuperAdmin
- reconcile an exact existing identity idempotently while refusing username/email collisions and never injecting a new identity into a non-empty database
- document the bootstrap behavior and its safety boundary

## Verification

- `npm run tsc`
- focused ESLint on changed TypeScript files
- `npm test` — 1,143 passing
- focused c8 coverage — 100% statements, 90.43% branches, 94.44% functions, 100% lines