### PR TITLE
feat(search): back channel search with @fulltext index

### DIFF
--- a/customResolvers/queries/getSortedChannels.ts
+++ b/customResolvers/queries/getSortedChannels.ts
@@ -2,6 +2,10 @@ import type { Driver, Record as Neo4jRecord } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";
 import { logger } from "../../logger.js";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";
+import {
+  CHANNEL_FULLTEXT_INDEX,
+  buildChannelFulltextQuery,
+} from "../../services/channelFulltext.js";
 
 type Input = {
   driver: Driver;
@@ -33,26 +37,37 @@ const getSortedChannelsResolver = (input: Input) => {
     const loggedInUsername = context?.user?.username || null;
     const session = driver.session();
 
+    // Turn the raw search term into a Lucene query. When it comes back empty
+    // (no searchable characters, or no search term at all) we take the
+    // unfiltered path and match every channel, exactly as the old
+    // `$searchInput = ""` branch did.
+    const fulltextQuery = buildChannelFulltextQuery(searchInput);
+
+    // The full-text branch drives the scan from the Lucene index and yields a
+    // relevance score; the unfiltered branch scans the label and scores every
+    // channel equally (0) so the two paths share the rest of the query.
+    const matchClause = fulltextQuery
+      ? `CALL db.index.fulltext.queryNodes($fulltextIndex, $fulltextQuery) YIELD node AS c, score`
+      : `MATCH (c:Channel)
+         WITH c, 0.0 AS score`;
+
     try {
       const result = await session.run(
         `
-        // Match channels that match the search input
-        MATCH (c:Channel)
-        WHERE $searchInput = "" 
-          OR toLower(c.uniqueName) CONTAINS toLower($searchInput)
-          OR toLower(c.description) CONTAINS toLower($searchInput)
-        
+        // Select the candidate channels (full-text search or all channels)
+        ${matchClause}
+
         // Optional match to tags for filtering
         OPTIONAL MATCH (c)-[:HAS_TAG]->(t:Tag)
-        WITH c, COLLECT(DISTINCT t) AS tags
+        WITH c, score, COLLECT(DISTINCT t) AS tags
         WHERE SIZE($tags) = 0 OR ANY(tag IN tags WHERE tag.text IN $tags)
-        
+
         // Count DiscussionChannels based on countDownloads flag
         CALL {
           WITH c
           MATCH (c)<-[:POSTED_IN_CHANNEL]-(dc:DiscussionChannel)
           MATCH (dc)-[:POSTED_IN_CHANNEL]->(d:Discussion)
-          WHERE CASE 
+          WHERE CASE
             WHEN $countDownloads IS NULL THEN (d.hasDownload IS NULL OR d.hasDownload = false)
             WHEN $countDownloads = true THEN d.hasDownload = true
             WHEN $countDownloads = false THEN (d.hasDownload IS NULL OR d.hasDownload = false)
@@ -60,7 +75,7 @@ const getSortedChannelsResolver = (input: Input) => {
           END
           RETURN COUNT(DISTINCT dc) AS validDiscussionChannelsCount
         }
-        
+
         // Count EventChannels with valid endTime
         CALL {
           WITH c
@@ -69,12 +84,15 @@ const getSortedChannelsResolver = (input: Input) => {
           WHERE e.endTime > datetime()
           RETURN COUNT(DISTINCT ec) AS eventChannelsCount
         }
-        
+
         OPTIONAL MATCH (favUser:User {username: $loggedInUsername})-[:DEFAULT_FAVORITES_CHANNELS]->(c)
-        
-        // Collect tags again for the final output
-        WITH c, tags, validDiscussionChannelsCount, eventChannelsCount, COUNT(DISTINCT favUser) > 0 AS isFavorited
-        
+
+        // Collect tags again for the final output. Order by relevance score
+        // (highest first) with uniqueName as a stable tiebreak so results are
+        // deterministic; collect/unwind below preserve this order.
+        WITH c, score, tags, validDiscussionChannelsCount, eventChannelsCount, COUNT(DISTINCT favUser) > 0 AS isFavorited
+        ORDER BY score DESC, c.uniqueName ASC
+
         // Aggregate channel count
         WITH collect({
           uniqueName: c.uniqueName,
@@ -86,11 +104,11 @@ const getSortedChannelsResolver = (input: Input) => {
           EventChannelsAggregate: { count: eventChannelsCount },
           DiscussionChannelsAggregate: { count: validDiscussionChannelsCount }
         }) AS channels, COUNT(c) AS aggregateChannelCount
-        
+
         // Paginate results
         UNWIND channels AS channel
-        RETURN 
-          channel, 
+        RETURN
+          channel,
           aggregateChannelCount
         SKIP toInteger($offset)
         LIMIT toInteger($limit)
@@ -99,9 +117,10 @@ const getSortedChannelsResolver = (input: Input) => {
           limit,
           offset,
           tags,
-          searchInput,
           countDownloads,
           loggedInUsername,
+          fulltextIndex: CHANNEL_FULLTEXT_INDEX,
+          fulltextQuery,
         }
       );
 

--- a/services/channelFulltext.test.ts
+++ b/services/channelFulltext.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildChannelFulltextQuery,
+  CHANNEL_FULLTEXT_INDEX,
+  CHANNEL_FULLTEXT_CREATE_CYPHER,
+} from "./channelFulltext.js";
+
+test("appends a prefix wildcard so partial terms match longer tokens", () => {
+  // "dog" should still match a "dogs" token, preserving the old CONTAINS feel.
+  assert.equal(buildChannelFulltextQuery("dog"), "dog*");
+});
+
+test("ANDs multiple whitespace-separated terms, each wildcarded", () => {
+  assert.equal(buildChannelFulltextQuery("all about"), "all* AND about*");
+});
+
+test("collapses surrounding and interior whitespace", () => {
+  assert.equal(buildChannelFulltextQuery("  cat   meetup  "), "cat* AND meetup*");
+});
+
+test("escapes Lucene metacharacters so input is matched literally", () => {
+  // The trailing "*" is the wildcard we add; the interior specials are escaped.
+  assert.equal(buildChannelFulltextQuery("c++"), "c\\+\\+*");
+  assert.equal(buildChannelFulltextQuery("a:b"), "a\\:b*");
+  assert.equal(buildChannelFulltextQuery("(foo)"), "\\(foo\\)*");
+});
+
+test("returns an empty string for blank or whitespace-only input", () => {
+  // Callers use this to fall back to the unfiltered (match-all) path.
+  assert.equal(buildChannelFulltextQuery(""), "");
+  assert.equal(buildChannelFulltextQuery("   "), "");
+});
+
+test("index name and generated CREATE statement stay in sync", () => {
+  assert.equal(CHANNEL_FULLTEXT_INDEX, "channelFulltext");
+  assert.equal(
+    CHANNEL_FULLTEXT_CREATE_CYPHER,
+    "CREATE FULLTEXT INDEX channelFulltext IF NOT EXISTS FOR (n:Channel) ON EACH [n.uniqueName, n.description]"
+  );
+});

--- a/services/channelFulltext.ts
+++ b/services/channelFulltext.ts
@@ -1,0 +1,46 @@
+// Shared definitions for the Channel full-text search index.
+//
+// The index itself is declared in `typeDefs.ts` via the `@neo4j/graphql`
+// `@fulltext` directive and created on startup by `ensureSchemaConstraints`
+// (which runs `assertIndexesAndConstraints({ create: true })`). The directive
+// generates exactly `CREATE FULLTEXT INDEX channelFulltext IF NOT EXISTS FOR
+// (n:Channel) ON EACH [n.uniqueName, n.description]`.
+//
+// The constants below let application code (the `getSortedChannels` resolver)
+// and the integration-test harness reference that same index by name without
+// re-parsing the SDL. Keep `CHANNEL_FULLTEXT_INDEX` in sync with the
+// `indexName` argument on the `@fulltext` directive in `typeDefs.ts`.
+
+export const CHANNEL_FULLTEXT_INDEX = "channelFulltext";
+
+// The fields the index covers. Kept alongside the name purely for the harness's
+// standalone CREATE statement; production derives these from the directive.
+export const CHANNEL_FULLTEXT_FIELDS = ["uniqueName", "description"] as const;
+
+// Mirrors the statement the `@fulltext` directive emits. Used by the
+// integration-test harness, which wires resolvers directly and therefore does
+// not run the OGM's schema-constraint bootstrap. Production never uses this.
+export const CHANNEL_FULLTEXT_CREATE_CYPHER = `CREATE FULLTEXT INDEX ${CHANNEL_FULLTEXT_INDEX} IF NOT EXISTS FOR (n:Channel) ON EACH [${CHANNEL_FULLTEXT_FIELDS.map(
+  (f) => `n.${f}`
+).join(", ")}]`;
+
+// Lucene query-syntax metacharacters. User input must be escaped so a stray
+// character (e.g. a `-` or `:`) is matched literally instead of being parsed as
+// a query operator, which would throw or silently change the search.
+const LUCENE_SPECIAL_CHARS = /[+\-&|!(){}[\]^"~*?:\\/]/g;
+
+// Builds a Lucene query string for the channel full-text index that reproduces
+// the old `CONTAINS` typeahead feel: each whitespace-separated term is escaped
+// and given a trailing `*` so a partial term ("dog") still matches a longer
+// token ("dogs"). Terms are AND-ed so multi-word input narrows results, the way
+// a single substring scan used to. Returns "" when the input has no searchable
+// characters, letting callers fall back to the unfiltered path.
+export function buildChannelFulltextQuery(searchInput: string): string {
+  return searchInput
+    .trim()
+    .split(/\s+/)
+    .map((term) => term.replace(LUCENE_SPECIAL_CHARS, "\\$&"))
+    .filter((term) => term.length > 0)
+    .map((term) => `${term}*`)
+    .join(" AND ");
+}

--- a/tests/integration/imageModerationHarness.ts
+++ b/tests/integration/imageModerationHarness.ts
@@ -15,6 +15,7 @@ import { Neo4jContainer, StartedNeo4jContainer } from "@testcontainers/neo4j";
 import neo4j, { Driver } from "neo4j-driver";
 import jwt from "jsonwebtoken";
 import getCustomResolvers from "../../customResolvers.js";
+import { CHANNEL_FULLTEXT_CREATE_CYPHER } from "../../services/channelFulltext.js";
 
 let container: StartedNeo4jContainer | undefined;
 let driver: Driver | undefined;
@@ -45,6 +46,19 @@ export async function startImageModEnv(): Promise<ImageModEnv> {
 
   const { ogm, resolvers } = getCustomResolvers(driver);
   await ogm.init();
+
+  // Production creates full-text indexes on startup via ensureSchemaConstraints
+  // (the OGM's assertIndexesAndConstraints). This harness wires resolvers
+  // directly and skips that bootstrap, so create the channel search index here
+  // — getSortedChannels' search path queries it by name. It survives resetDb
+  // (which only deletes nodes) and updates transactionally as rows are seeded.
+  const indexSession = driver.session();
+  try {
+    await indexSession.run(CHANNEL_FULLTEXT_CREATE_CYPHER);
+    await indexSession.run("CALL db.awaitIndexes(30000)");
+  } finally {
+    await indexSession.close();
+  }
 
   return { driver, ogm, resolvers };
 }

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -523,7 +523,16 @@ const typeDefinitions = gql`
       @settable(onCreate: false, onUpdate: false)
   }
 
-  type Channel {
+  # Full-text (Lucene) index over the channel's searchable text fields. Backs the
+  # search in getSortedChannels; created on startup by ensureSchemaConstraints.
+  # The indexName must stay in sync with CHANNEL_FULLTEXT_INDEX in
+  # services/channelFulltext.ts.
+  type Channel
+    @fulltext(
+      indexes: [
+        { indexName: "channelFulltext", fields: ["uniqueName", "description"] }
+      ]
+    ) {
     uniqueName: String! @unique
     createdAt: DateTime! @timestamp(operations: [CREATE])
     displayName: String


### PR DESCRIPTION
## Summary

Replaces the unindexed, case-insensitive `CONTAINS` substring scan in channel search with a Neo4j full-text (Lucene) index exposed via the `@neo4j/graphql` v5 `@fulltext` directive. This gives channel search an actual index (no more full label scan that degrades linearly with channel count) plus relevance ranking.

Closes #208

## Changes

- **`typeDefs.ts`** — Declare a `@fulltext` index over `Channel.uniqueName` + `Channel.description` using the v5 `indexName` syntax. The index is created on startup by the existing `ensureSchemaConstraints` bootstrap (`assertIndexesAndConstraints({ create: true })`) — no new startup wiring needed.
- **`services/channelFulltext.ts`** (new) — Single source of truth for the index name, a mirrored `CREATE FULLTEXT INDEX` statement (for the test harness), and `buildChannelFulltextQuery()`, which escapes Lucene metacharacters and appends a `*` prefix wildcard per term (AND-ed) so partial input like `"dog"` still matches `"dogs"`, preserving the old typeahead behavior.
- **`customResolvers/queries/getSortedChannels.ts`** — Swap the `toLower(...) CONTAINS toLower(...)` branch for a `CALL db.index.fulltext.queryNodes(...)` path that yields a relevance `score`. Empty search still matches all channels. Results are now ordered `BY score DESC, c.uniqueName ASC` — an intentional improvement (relevance ranking + deterministic ordering).
- **`tests/integration/imageModerationHarness.ts`** — The harness wires resolvers directly and skips the schema-constraint bootstrap, so it now creates the index + `db.awaitIndexes()` after `ogm.init()`.

## Acceptance criteria

- [x] Add `@fulltext` index declaration to `typeDefs.ts` for Channel search fields
- [x] Ensure the index is created on startup (reuses the existing constraint bootstrap)
- [x] Replace the `CONTAINS toLower(...)` branch in `getSortedChannels.ts`
- [x] Confirm behavior parity for existing search tests

## Verification

- `pnpm run codegen` + `pnpm run tsc` — clean
- **1147 unit tests pass**, including a new `services/channelFulltext.test.ts` covering escaping / prefix / empty-input
- Integration tests pass, including parity cases: `"dog"→dogs`, `"vroom"→cars`, `"cat"→cats` across `uniqueName` and `description`

## Note

The `@fulltext` directive also generates an incidental top-level `channelsFulltextChannelFulltext` query (read-only, permission-allowed under `Query: { "*": allow }`, consistent with public Channel reads). The `getSortedChannels` resolver itself uses raw Cypher against the index rather than this generated field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)