### PR TITLE
fix(ci): merge coverage into one report before uploading to Codecov

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -112,33 +112,28 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: pnpm run coverage:startup-provisioning
 
-      - name: Upload unit coverage to Codecov
-        uses: codecov/codecov-action@v5
+      # Coverage is NOT uploaded to Codecov here. Each test job saves its lcov as
+      # an artifact; the `coverage-report` job merges all of them into one report
+      # and does a single Codecov upload. Uploading the pieces separately (unit +
+      # shards, under flags) let Codecov's cross-upload combination lose real
+      # coverage — a line covered by one shard but 0 in the others didn't reliably
+      # count as covered, and mismatched file lists inflated the denominator.
+      - name: Save unit coverage report
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          # Upload ONLY the remapped lcov. Without this, the uploader also
-          # auto-discovers c8's raw coverage/tmp/*.json V8 files and sends them;
-          # Codecov ingests those un-remapped, inflating the line denominator and
-          # diluting covered lines (~7pt badge undercount vs the true merged %).
-          disable_search: true
-          flags: unit
-          fail_ci_if_error: false
-          verbose: true
+          name: coverage-unit
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Upload source-mapped startup provisioning coverage to Codecov
+      - name: Save startup-provisioning coverage report
         if: needs.changes.outputs.code == 'true'
-        uses: codecov/codecov-action@v5
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/startup-provisioning/lcov.info
-          # See the unit upload above: only send the specified lcov, never the
-          # raw c8 coverage/tmp/*.json files the uploader would otherwise sweep up.
-          disable_search: true
-          flags: unit
-          name: startup-provisioning
-          fail_ci_if_error: false
-          verbose: true
+          name: coverage-startup
+          path: coverage/startup-provisioning/lcov.info
+          if-no-files-found: error
+          retention-days: 1
 
       # codegen and tsc already ran above, which covers the first two commands
       # in the build script. Complete the remaining asset-copy step without
@@ -191,18 +186,50 @@ jobs:
           SHARD: ${{ matrix.shard }}
           SHARD_TOTAL: 4
 
-      # Each shard uploads under the `integration` flag with a distinct name;
-      # Codecov unions the shards (and merges with the unit upload), so a line
-      # covered by any shard or the unit suite counts as covered.
-      - name: Upload integration coverage to Codecov
+      # Save this shard's lcov as an artifact; coverage-report merges all shards
+      # with the unit report and does the single Codecov upload (see that job).
+      - name: Save integration shard ${{ matrix.shard }} coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration-${{ matrix.shard }}
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge every test job's lcov into ONE report and upload it to Codecov once.
+  # This reproduces the local `coverage:merged` number: a line covered by ANY
+  # job counts as covered, over a single consistent file list. Runs whenever the
+  # unit job succeeded — including docs-only PRs (integration is skipped then, so
+  # only the unit report is merged) — so the required Codecov status still posts.
+  coverage-report:
+    needs: [unit-tests, integration-tests]
+    if: ${{ always() && needs.unit-tests.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      # Downloads every coverage-* artifact from this run into subfolders under
+      # coverage-artifacts/ (unit, startup, and each integration shard that ran).
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage-artifacts
+          pattern: coverage-*
+
+      - name: Merge coverage reports
+        run: node build_scripts/mergeLcov.js --dir coverage-artifacts --out coverage/merged.lcov
+
+      - name: Upload merged coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          # See the unit upload: only send the shard's remapped lcov, not the raw
-          # c8 coverage/tmp/*.json files the uploader would otherwise sweep up.
+          files: ./coverage/merged.lcov
           disable_search: true
-          flags: integration
-          name: integration-shard-${{ matrix.shard }}
           fail_ci_if_error: false
           verbose: true

--- a/build_scripts/mergeLcov.js
+++ b/build_scripts/mergeLcov.js
@@ -1,0 +1,131 @@
+// Merge multiple lcov.info reports into one by unioning per-file coverage.
+//
+// Why this exists: CI produces coverage in several pieces (the unit suite, a
+// source-mapped startup-provisioning supplement, and N integration shards).
+// Uploading those pieces to Codecov separately and letting Codecov stitch them
+// together under flags loses real coverage — a line covered by one shard but
+// "not covered" (0) in the others does not reliably come out as covered in
+// Codecov's cross-upload/flag combination, and mismatched file lists inflate the
+// denominator. Merging here first — a line covered by ANY report counts as
+// covered — reproduces the single-process `coverage:merged` number, which we
+// then upload to Codecov as ONE report.
+//
+// Usage: node build_scripts/mergeLcov.js --dir <artifacts-dir> --out <file>
+//   Recursively finds every lcov.info under <artifacts-dir> and writes the
+//   merged report to <out>.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const getArg = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+const dir = getArg("--dir", "coverage-artifacts");
+const out = getArg("--out", "coverage/merged.lcov");
+
+// Recursively collect every lcov.info under `dir`.
+function findLcov(root) {
+  const found = [];
+  const walk = (d) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name === "lcov.info" || e.name.endsWith(".lcov")) found.push(p);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+// Per file: line hits, function hits, branch hits — each unioned by max.
+// value `-` (branch not evaluated) is kept only until a numeric value appears.
+function makeRecord() {
+  return { da: new Map(), fn: new Map(), fnda: new Map(), brda: new Map() };
+}
+const files = new Map();
+const recordFor = (sf) => {
+  if (!files.has(sf)) files.set(sf, makeRecord());
+  return files.get(sf);
+};
+
+const maxHit = (prev, next) => (prev === undefined ? next : Math.max(prev, next));
+const mergeBranch = (prev, tokenIsDash, value) => {
+  if (prev === undefined) return tokenIsDash ? "-" : value;
+  if (prev === "-") return tokenIsDash ? "-" : value;
+  return tokenIsDash ? prev : Math.max(prev, value);
+};
+
+const inputs = findLcov(dir);
+for (const input of inputs) {
+  const text = fs.readFileSync(input, "utf8");
+  let cur = null;
+  for (const raw of text.split("\n")) {
+    const line = raw.trimEnd();
+    if (line.startsWith("SF:")) {
+      cur = recordFor(line.slice(3));
+    } else if (!cur) {
+      continue;
+    } else if (line.startsWith("DA:")) {
+      const [ln, cnt] = line.slice(3).split(",");
+      cur.da.set(Number(ln), maxHit(cur.da.get(Number(ln)), Number(cnt)));
+    } else if (line.startsWith("FN:")) {
+      const idx = line.indexOf(",");
+      cur.fn.set(line.slice(idx + 1), Number(line.slice(3, idx)));
+    } else if (line.startsWith("FNDA:")) {
+      const idx = line.indexOf(",");
+      const name = line.slice(idx + 1);
+      cur.fnda.set(name, maxHit(cur.fnda.get(name), Number(line.slice(5, idx))));
+    } else if (line.startsWith("BRDA:")) {
+      const parts = line.slice(5).split(",");
+      const key = parts.slice(0, 3).join(",");
+      const isDash = parts[3] === "-";
+      cur.brda.set(key, mergeBranch(cur.brda.get(key), isDash, Number(parts[3])));
+    } else if (line === "end_of_record") {
+      cur = null;
+    }
+  }
+}
+
+const outLines = [];
+for (const [sf, d] of files) {
+  outLines.push("TN:");
+  outLines.push(`SF:${sf}`);
+  for (const [name, ln] of d.fn) outLines.push(`FN:${ln},${name}`);
+  for (const [name, c] of d.fnda) outLines.push(`FNDA:${c},${name}`);
+  outLines.push(`FNF:${d.fn.size}`);
+  outLines.push(`FNH:${[...d.fnda.values()].filter((c) => c > 0).length}`);
+  for (const [key, v] of d.brda) outLines.push(`BRDA:${key},${v === "-" ? "-" : v}`);
+  outLines.push(`BRF:${d.brda.size}`);
+  outLines.push(`BRH:${[...d.brda.values()].filter((v) => v !== "-" && v > 0).length}`);
+  for (const ln of [...d.da.keys()].sort((a, b) => a - b)) {
+    outLines.push(`DA:${ln},${d.da.get(ln)}`);
+  }
+  outLines.push(`LF:${d.da.size}`);
+  outLines.push(`LH:${[...d.da.values()].filter((c) => c > 0).length}`);
+  outLines.push("end_of_record");
+}
+
+fs.mkdirSync(path.dirname(out), { recursive: true });
+fs.writeFileSync(out, outLines.join("\n") + "\n");
+
+const totalLines = [...files.values()].reduce((n, d) => n + d.da.size, 0);
+const hitLines = [...files.values()].reduce(
+  (n, d) => n + [...d.da.values()].filter((c) => c > 0).length,
+  0
+);
+console.log(
+  `Merged ${inputs.length} lcov file(s) from ${dir} -> ${out}: ` +
+    `${files.size} source files, ${hitLines}/${totalLines} lines covered ` +
+    `(${totalLines ? ((hitLines / totalLines) * 100).toFixed(2) : "0"}%)`
+);
+if (inputs.length === 0) {
+  console.error(`WARNING: no lcov files found under ${dir}`);
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,20 +18,17 @@ coverage:
         threshold: 0%
         informational: false
 
-# Coverage is uploaded from two CI jobs under separate flags and merged by
-# Codecov: `unit` (fast `pnpm test`) and `integration` (Testcontainers Neo4j).
-# A line covered by either suite counts as covered for the project total.
-# carryforward keeps the last known coverage for a flag if a run doesn't upload
-# it (e.g. a flaky container run), so it doesn't spuriously drop the total.
-flags:
-  unit:
-    carryforward: true
-  integration:
-    carryforward: true
+# Coverage arrives as ONE already-merged report (the `coverage-report` CI job
+# runs build_scripts/mergeLcov.js over the unit + integration-shard lcovs and
+# uploads the union). We deliberately do NOT use flags: uploading the pieces
+# separately let Codecov's cross-flag/cross-upload combination lose real coverage
+# (a line covered by one shard but 0 in the others didn't reliably count) and
+# inflate the denominator via mismatched file lists. One merged upload == the
+# local `coverage:merged` number.
 
 # Comment settings for PR coverage reports
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,files"
   behavior: default
   require_changes: false
   require_base: false


### PR DESCRIPTION
## Summary

Follow-up to #218. The badge only moved 70% → 73% because the real problem wasn't the raw V8 files (Codecov was ignoring those) — it's that **CI uploads coverage in 6 separate pieces** (unit + startup-provisioning + 4 integration shards) and lets **Codecov combine them across flags, which is lossy**. A line covered by one shard but `0` in the others doesn't reliably count as covered, and the mismatched per-upload file lists inflate the denominator.

**Evidence** (Codecov vs my single-process local merge of the *same* data, folders untouched by any new tests):

| Folder | Local covered | Codecov covered | Lost |
|---|---|---|---|
| customResolvers | 16,214 | 15,305 | −909 |
| rules | 3,537 | 3,381 | −156 |

Plus denominator inflated to 38,761 vs a true 36,752.

## Fix

Merge the pieces **before** Codecov sees them:
- Each test job saves its `lcov.info` as a build artifact (no Codecov upload).
- A new **`coverage-report`** job merges them all with `build_scripts/mergeLcov.js` — union semantics (**covered by any job ⇒ covered**) over one consistent file list — and does a **single** Codecov upload.
- `codecov.yml`: drop the `unit`/`integration` flags + carryforward (one flagless merged upload now; leftover carryforward would re-introduce the loss).
- `coverage-report` runs whenever `unit-tests` succeeds, including docs-only PRs (integration skipped → only the unit report merged), so the required Codecov status still posts.

## Validation

- `mergeLcov.js` is dependency-free and validated two ways: (1) its output matches c8's single-process combined report exactly, and (2) a hand-crafted union case (line covered in file A ∪ line covered in file B ⇒ both covered).
- Full unit suite green: **1,231 tests, 0 failures**.
- Local single-process `coverage:merged` (the number this reproduces): **79.86%** (29,352 / 36,752).

## Expected result

Badge **~73% → ~80%** — matching the honest `coverage:merged` number. Note it lands right at 80% (79.86%); if Codecov's badge rounds that down to 79%, a small additional test batch will clear it with margin — happy to add that as a quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
