### PR TITLE
ci(self-hosting): publish official backend images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 .git
+.github
+.env
+.env.*
+.DS_Store
+*.log
 coverage
 node_modules
 ts_emitted

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -98,6 +98,8 @@ jobs:
             --name multiforum-neo4j-smoke \
             --network multiforum-image-smoke \
             --env NEO4J_AUTH=neo4j/multiforum-smoke-neo4j \
+            --env 'NEO4J_PLUGINS=["apoc"]' \
+            --env NEO4J_dbms_security_procedures_unrestricted=apoc.* \
             --health-cmd='cypher-shell -u neo4j -p multiforum-smoke-neo4j "RETURN 1"' \
             --health-interval=5s \
             --health-timeout=5s \

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,185 @@
+name: Container image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+concurrency:
+  group: container-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-publish-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            type=ref,event=pr
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and optionally publish image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+
+      - name: Select image for smoke test
+        id: smoke-image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=${IMAGE_NAME}:pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${IMAGE_NAME}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start Neo4j
+        run: |
+          set -euo pipefail
+          docker network create multiforum-image-smoke
+          docker run --detach \
+            --name multiforum-neo4j-smoke \
+            --network multiforum-image-smoke \
+            --env NEO4J_AUTH=neo4j/multiforum-smoke-neo4j \
+            --health-cmd='cypher-shell -u neo4j -p multiforum-smoke-neo4j "RETURN 1"' \
+            --health-interval=5s \
+            --health-timeout=5s \
+            --health-retries=30 \
+            neo4j:5.1.0
+
+      - name: Wait for Neo4j
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            status="$(docker inspect --format='{{.State.Health.Status}}' multiforum-neo4j-smoke)"
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              docker logs multiforum-neo4j-smoke
+              exit 1
+            fi
+            sleep 5
+          done
+          docker logs multiforum-neo4j-smoke
+          exit 1
+
+      - name: Start Multiforum backend image
+        env:
+          SMOKE_IMAGE: ${{ steps.smoke-image.outputs.value }}
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name multiforum-backend-smoke \
+            --network multiforum-image-smoke \
+            --publish 127.0.0.1:4000:4000 \
+            --env NODE_ENV=development \
+            --env ENVIRONMENT=local \
+            --env MULTIFORUM_AUTH_PROVIDER=local-dev \
+            --env MULTIFORUM_AUTO_PROVISION=true \
+            --env MULTIFORUM_BOOTSTRAP_EMAIL=admin@multiforum.local \
+            --env MULTIFORUM_BOOTSTRAP_USERNAME=admin \
+            --env MULTIFORUM_BOOTSTRAP_PASSWORD=multiforum-local-admin \
+            --env SUPERADMIN_EMAIL=admin@multiforum.local \
+            --env SERVER_CONFIG_NAME='Image Smoke Test' \
+            --env NEO4J_URI=bolt://multiforum-neo4j-smoke:7687 \
+            --env NEO4J_USER=neo4j \
+            --env NEO4J_PASSWORD=multiforum-smoke-neo4j \
+            "$SMOKE_IMAGE"
+
+      - name: Verify backend health check
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            status="$(docker inspect --format='{{.State.Health.Status}}' multiforum-backend-smoke)"
+            if [ "$status" = "healthy" ]; then
+              curl --fail --silent --show-error \
+                --header 'content-type: application/json' \
+                --data '{"query":"query ImageSmoke { __typename }"}' \
+                http://127.0.0.1:4000/ >/dev/null
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              docker logs multiforum-backend-smoke
+              exit 1
+            fi
+            sleep 5
+          done
+          docker logs multiforum-backend-smoke
+          exit 1
+
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          docker logs multiforum-neo4j-smoke || true
+          docker logs multiforum-backend-smoke || true
+
+      - name: Make the GHCR package public
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.request('PATCH /orgs/{org}/packages/{package_type}/{package_name}', {
+              org: context.repo.owner,
+              package_type: 'container',
+              package_name: context.repo.repo,
+              visibility: 'public',
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,48 @@
-# Keep the production runtime aligned with .nvmrc and CI.
-FROM node:26.5.1-alpine
+# Keep build and runtime aligned with .nvmrc and CI. The argument also makes
+# deliberate patch-version updates easy to audit in release PRs.
+ARG NODE_VERSION=26.5.1
+ARG PNPM_VERSION=10.28.2
 
-# Set working directory
+FROM node:${NODE_VERSION}-alpine AS build
+
+ARG PNPM_VERSION
+
 WORKDIR /app
 
-# Enable pnpm via corepack (version pinned by package.json "packageManager")
-RUN corepack enable
+# Node 26 images no longer bundle Corepack. Install the exact pnpm release
+# declared by package.json instead of depending on an ambient package manager.
+RUN npm install --global "pnpm@${PNPM_VERSION}"
 
-# Copy dependency metadata and local dependency patches
 COPY package.json pnpm-lock.yaml ./
 COPY patches ./patches
-
-# Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Copy the entire project
 COPY . .
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build \
+  && pnpm prune --prod --ignore-scripts
 
-# Set environment variables via Docker secrets (fallback to defaults)
-ENV ENVIRONMENT development
-ENV NEO4J_URI bolt://localhost:7687
-ENV NEO4J_USERNAME neo4j
-ENV NEO4J_PASSWORD myfearsthey
-ENV SERVER_CONFIG_NAME "Listical"
-ENV GCS_BUCKET_NAME listical-dev
-ENV GOOGLE_APPLICATION_CREDENTIALS /app/config/listical-dev-gcp.json
-ENV GOOGLE_CREDENTIALS_BASE64 ""
-ENV AUTH0_DOMAIN ""
-ENV AUTH0_CLIENT_ID ""
-ENV CYPRESS_ADMIN_TEST_EMAIL ""
-ENV CYPRESS_ADMIN_TEST_USERNAME ""
+FROM node:${NODE_VERSION}-alpine AS runtime
 
-# Build the application
-RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
+LABEL org.opencontainers.image.title="Multiforum Backend" \
+  org.opencontainers.image.description="GraphQL and Neo4j backend for Multiforum" \
+  org.opencontainers.image.licenses="MIT"
 
-# Expose the backend port
+WORKDIR /app
+
+ENV NODE_ENV=production \
+  PORT=4000
+
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+COPY --from=build --chown=node:node /app/package.json ./package.json
+COPY --from=build --chown=node:node /app/ts_emitted ./ts_emitted
+
+USER node
+
 EXPOSE 4000
 
-# Start the application
-CMD ["pnpm", "run", "start"]
+# A TCP check avoids coupling container health to GraphQL introspection or an
+# authenticated application query while still proving the server is listening.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=12 \
+  CMD node -e "const socket=require('net').connect(process.env.PORT||4000,'127.0.0.1');socket.setTimeout(4000);socket.on('connect',()=>{socket.destroy();process.exit(0)});socket.on('timeout',()=>{socket.destroy();process.exit(1)});socket.on('error',()=>process.exit(1))"
+
+CMD ["node", "./ts_emitted/index.js"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,41 @@ Run `nvm use` to select the version in `.nvmrc`, enable pnpm once with
 See [Environment variables and running the app](./docs/environment-variables.md)
 for the configuration needed before starting the server.
 
+## Official container image
+
+Release and main-branch images are published to GitHub Container Registry:
+
+```text
+ghcr.io/gennit-project/multiforum-backend
+```
+
+The supported tags are:
+
+| Tag | Meaning | Recommended use |
+| --- | --- | --- |
+| `1.2.3`, `1.2`, `1` | A semantic-version release | Pin an exact release tag in production |
+| `latest` | The most recent semantic-version release | Evaluation only; it moves on each release |
+| `sha-<commit>` | An immutable build of one Git commit | Auditing or exact rollback |
+| `edge` | The latest successful build from `main` | Development and pre-release testing |
+
+`latest` deliberately follows stable version tags, not `main`. Production
+deployments should pin the full release version or an immutable `sha-` tag.
+
+Pull an image with:
+
+```bash
+docker pull ghcr.io/gennit-project/multiforum-backend:1.2.3
+```
+
+Images support `linux/amd64` and `linux/arm64`, run as a non-root user, and
+include a TCP health check on `PORT` (4000 by default). Each published manifest
+includes OCI source, revision, and version labels together with build
+provenance and an SBOM.
+
+The image contains no deployment credentials or functional database defaults.
+Supply the required settings described in
+[Environment variables and running the app](./docs/environment-variables.md).
+
 ## Status
 
 This project is in active development.


### PR DESCRIPTION
## Summary

- publish `linux/amd64` and `linux/arm64` images to `ghcr.io/gennit-project/multiforum-backend` from `main` and semantic-version tags
- provide stable, edge, semantic-version, and immutable commit-SHA tags with OCI labels, SBOMs, and build provenance
- harden the Dockerfile into a non-root multi-stage runtime image without development defaults or development dependencies
- smoke-test every image against Neo4j and the container health check before making the GHCR package public
- document the image URL, supported tag policy, architecture support, and production pinning guidance

Closes #207

## Validation

- `actionlint` passes with no findings
- workflow YAML parses successfully
- `git diff --check`
- local Docker build verified the pinned Node 26/pnpm install and reached TypeScript compilation; the local Docker VM has 2 GB RAM and was killed with exit 137, below the quick-start documented 6 GB build requirement
- this PR’s container-image job performs the full build and Neo4j-backed runtime smoke test on a GitHub-hosted runner

## Release behavior

- `edge` follows `main`
- `latest` follows stable semantic-version tags, not `main` or prereleases
- production deployments should pin `1.2.3` or `sha-<commit>`

## Owner follow-up after merge

The workflow attempts to set the new GHCR package to public automatically. If organization policy prevents `GITHUB_TOKEN` from changing package visibility, an organization owner will need to make `multiforum-backend` public once in the GitHub Packages settings.