### PR TITLE
fix(ci): upload merged coverage under flags; merge raw c8 data

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -112,25 +112,27 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: pnpm run coverage:startup-provisioning
 
-      # Coverage is NOT uploaded to Codecov here. Each test job saves its lcov as
-      # an artifact; the `coverage-report` job merges all of them into one report
-      # and does a single Codecov upload. Uploading the pieces separately (unit +
-      # shards, under flags) let Codecov's cross-upload combination lose real
-      # coverage — a line covered by one shard but 0 in the others didn't reliably
-      # count as covered, and mismatched file lists inflated the denominator.
-      - name: Save unit coverage report
+      # Coverage is NOT uploaded to Codecov here. Each test job saves its RAW c8
+      # coverage (coverage/tmp/*.json) as an artifact; the `coverage-report` job
+      # runs a single `c8 report` over all of them, so every file is counted once
+      # — reproducing the local `coverage:merged` number. (Merging the finished
+      # lcovs instead let all:true's per-run line-count differences inflate the
+      # denominator; merging the raw data avoids that.)
+      - name: Save unit coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-unit
-          path: coverage/lcov.info
+          name: cov-v8-unit
+          path: coverage/tmp
           if-no-files-found: error
           retention-days: 1
 
+      # The startup-provisioning supplement is source-mapped via tsc (not ts-node)
+      # and produced as a standalone lcov; carry it as-is and union it in at the end.
       - name: Save startup-provisioning coverage report
         if: needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-startup
+          name: cov-lcov-startup
           path: coverage/startup-provisioning/lcov.info
           if-no-files-found: error
           retention-days: 1
@@ -186,21 +188,29 @@ jobs:
           SHARD: ${{ matrix.shard }}
           SHARD_TOTAL: 4
 
-      # Save this shard's lcov as an artifact; coverage-report merges all shards
-      # with the unit report and does the single Codecov upload (see that job).
-      - name: Save integration shard ${{ matrix.shard }} coverage report
+      # Save this shard's RAW c8 coverage; coverage-report runs one c8 report over
+      # every shard's data plus the unit data (see that job).
+      - name: Save integration shard ${{ matrix.shard }} coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-integration-${{ matrix.shard }}
-          path: coverage/lcov.info
+          name: cov-v8-integration-${{ matrix.shard }}
+          path: coverage/tmp
           if-no-files-found: error
           retention-days: 1
 
-  # Merge every test job's lcov into ONE report and upload it to Codecov once.
-  # This reproduces the local `coverage:merged` number: a line covered by ANY
-  # job counts as covered, over a single consistent file list. Runs whenever the
-  # unit job succeeded — including docs-only PRs (integration is skipped then, so
-  # only the unit report is merged) — so the required Codecov status still posts.
+  # Combine every test job's RAW coverage into ONE report and upload it to
+  # Codecov. `c8 report` over all the shards' + unit's v8 data counts each file
+  # exactly once, reproducing the local `coverage:merged` number (a line covered
+  # by ANY job counts as covered). Runs whenever the unit job succeeded —
+  # including docs-only PRs (integration skipped → only the unit data) — so the
+  # required Codecov status still posts.
+  #
+  # The merged report is uploaded under BOTH the `unit` and `integration` flags
+  # (the same complete report each). Codecov keeps carrying a flag forward once
+  # it has seen it, and the project total is built from flags — a flag-less
+  # upload does NOT replace that carried-forward total. Refreshing both flags
+  # with the complete merged coverage every commit makes the project total equal
+  # the merged number regardless of carry-forward.
   coverage-report:
     needs: [unit-tests, integration-tests]
     if: ${{ always() && needs.unit-tests.result == 'success' }}
@@ -209,27 +219,68 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
-      # Downloads every coverage-* artifact from this run into subfolders under
-      # coverage-artifacts/ (unit, startup, and each integration shard that ran).
+      # c8 (and the .c8rc.json all:true source scan) needs the dependencies.
+      - name: Clean install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Downloads every cov-* artifact from this run into subfolders under
+      # coverage-artifacts/ (unit v8, each integration shard's v8, and startup).
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
           path: coverage-artifacts
-          pattern: coverage-*
+          pattern: cov-*
 
-      - name: Merge coverage reports
-        run: node build_scripts/mergeLcov.js --dir coverage-artifacts --out coverage/merged.lcov
+      - name: Merge coverage into one report
+        run: |
+          set -euo pipefail
+          # Gather every shard's + the unit run's raw v8 json into one temp dir.
+          # Prefix by source dir so identically-named files never collide.
+          mkdir -p combined-tmp merge-src
+          i=0
+          for d in coverage-artifacts/cov-v8-*; do
+            [ -d "$d" ] || continue
+            find "$d" -name '*.json' -print0 | while IFS= read -r -d '' f; do
+              cp "$f" "combined-tmp/${i}-$(basename "$f")"
+            done
+            i=$((i + 1))
+          done
+          echo "Combined $(ls combined-tmp | wc -l) coverage data files."
+          # One c8 report over all of it → the single-process merged lcov.
+          NODE_OPTIONS=--max-old-space-size=6144 pnpm exec c8 report \
+            --temp-directory=combined-tmp --reporter=lcov --reports-dir=coverage-main
+          cp coverage-main/lcov.info merge-src/main.lcov
+          # Union in the source-mapped startup-provisioning supplement, if present.
+          if [ -f coverage-artifacts/cov-lcov-startup/lcov.info ]; then
+            cp coverage-artifacts/cov-lcov-startup/lcov.info merge-src/startup.lcov
+          fi
+          node build_scripts/mergeLcov.js --dir merge-src --out coverage/merged.lcov
 
-      - name: Upload merged coverage to Codecov
+      - name: Upload merged coverage to Codecov (unit flag)
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/merged.lcov
           disable_search: true
+          flags: unit
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload merged coverage to Codecov (integration flag)
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/merged.lcov
+          disable_search: true
+          flags: integration
           fail_ci_if_error: false
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,17 +18,23 @@ coverage:
         threshold: 0%
         informational: false
 
-# Coverage arrives as ONE already-merged report (the `coverage-report` CI job
-# runs build_scripts/mergeLcov.js over the unit + integration-shard lcovs and
-# uploads the union). We deliberately do NOT use flags: uploading the pieces
-# separately let Codecov's cross-flag/cross-upload combination lose real coverage
-# (a line covered by one shard but 0 in the others didn't reliably count) and
-# inflate the denominator via mismatched file lists. One merged upload == the
-# local `coverage:merged` number.
+# The `coverage-report` CI job builds ONE merged report (c8 report over every
+# job's raw coverage == the local `coverage:merged` number) and uploads that SAME
+# complete report under both flags below. We do NOT upload partial per-suite
+# reports: Codecov's cross-upload combination lost real coverage (a line covered
+# by one shard but 0 in the others didn't reliably count) and inflated the
+# denominator. Both flags carry the full merged coverage, so the project total
+# equals the merged number; carryforward just preserves the last good value if a
+# run fails to upload.
+flags:
+  unit:
+    carryforward: true
+  integration:
+    carryforward: true
 
 # Comment settings for PR coverage reports
 comment:
-  layout: "reach,diff,files"
+  layout: "reach,diff,flags,files"
   behavior: default
   require_changes: false
   require_base: false


### PR DESCRIPTION
## Summary

Follow-up to #218 and #219. The badge was still stuck at ~70% because of **two remaining bugs** — this fixes both. Each is confirmed against the CI logs and Codecov's commit history.

### Bug 1 — flag-less uploads don't become the project total

Codecov keeps **carrying a flag forward** once it has seen it, and the project total is built from flags. #219 removed the `unit`/`integration` flags and uploaded flag-less, so the merged report never replaced the carried-forward total — the badge kept showing the old value. (Confirmed: a commit whose parent chain includes #219's flag-less 76.5% upload still carried forward **70%**.)

**Fix:** upload the merged report under **both** the `unit` and `integration` flags (the same complete report each), so both are refreshed with full coverage every commit and the project total equals the merged number regardless of carryforward.

### Bug 2 — merging finished lcovs inflated the denominator

#219 merged the *finished* lcovs. Because `all: true` makes each run count a file's lines slightly differently, the union took the **superset** (38,761 lines) and capped coverage at ~76.5%.

**Fix:** each job uploads its **raw** c8 coverage (`coverage/tmp`); `coverage-report` runs a single `c8 report` over all of it — counting each file **once**, exactly like the local `coverage:merged`. The tsc-source-mapped startup-provisioning lcov is unioned in at the end.

## Expected result

The merge reproduces `coverage:merged` — **~80.2%** (29.5k / 36.8k) with the correct denominator — uploaded under both flags. Badge should finally move **70% → 80%**.

## Validation

- Reproduced the merge flow locally (c8 report over combined unit+integration v8 → `mergeLcov.js`): correct ~36.8k denominator.
- `mergeLcov.js` validated against c8's single-process report and a hand-crafted union case.
- Full unit suite green via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
