### PR TITLE
fix(ci): verify public container access

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -173,15 +173,15 @@ jobs:
           docker logs multiforum-neo4j-smoke || true
           docker logs multiforum-backend-smoke || true
 
-      - name: Make the GHCR package public
+      # GITHUB_TOKEN can publish repository-linked packages but cannot change
+      # organization package visibility. An organization owner must make the
+      # package public once; every publication then proves anonymous access.
+      - name: Verify the published image is public
         if: github.event_name != 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.request('PATCH /orgs/{org}/packages/{package_type}/{package_name}', {
-              org: context.repo.owner,
-              package_type: 'container',
-              package_name: context.repo.repo,
-              visibility: 'public',
-            })
+        env:
+          PUBLISHED_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          anonymous_docker_config="$(mktemp -d)"
+          trap 'rm -rf "$anonymous_docker_config"' EXIT
+          DOCKER_CONFIG="$anonymous_docker_config" docker pull "$PUBLISHED_IMAGE"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ The image contains no deployment credentials or functional database defaults.
 Supply the required settings described in
 [Environment variables and running the app](./docs/environment-variables.md).
 
+Maintainers: GHCR creates the package as private on its first publication, and
+the workflow's repository-scoped token cannot change organization package
+visibility. An organization owner must make the package public once in GitHub's
+package settings. Subsequent image runs verify an anonymous pull before they
+pass.
+
 ## Status
 
 This project is in active development.


### PR DESCRIPTION
## Summary

- remove the package-visibility API mutation that always fails with the repository-scoped `GITHUB_TOKEN`
- verify every published digest through an anonymous Docker configuration instead
- document the one-time organization-owner step required when GHCR creates the package

## Context

The first post-merge image run successfully built and pushed both architectures and passed the Neo4j-backed runtime smoke test. Its only failure was a 404 from the organization package administration endpoint while trying to make the package public.

## Validation

- `actionlint`
- `git diff --check`

## Required owner action

Before the main-branch verification can pass, make the `multiforum-backend` GHCR package public once. The current local `gh` token lacks even `read:packages`; refresh it with:

```bash
gh auth refresh -h github.com -s read:packages,write:packages
```

After authorization, the package visibility can be updated through the API or GitHub package settings.