### PR TITLE
test(services): cover the version-history services (coverage batch 1)

### DIFF
--- a/services/commentVersionHistoryService.test.ts
+++ b/services/commentVersionHistoryService.test.ts
@@ -1,0 +1,123 @@
+// Unit tests for the comment version-history service: the pure handler functions
+// (author lookup + saving the previous text as a version) and the subscription
+// class. Driven with a permissive in-memory OGM and a tiny executable schema. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import {
+  getCommentAuthorUsername,
+  handleCommentUpdateEvent,
+  CommentVersionHistoryService,
+} from "./commentVersionHistoryService.js";
+
+// Comment.find -> authorRows; User.find -> a user so trackTextVersion proceeds.
+function makeOgm(opts: { authorRows?: unknown[] } = {}) {
+  const tracked: string[] = [];
+  const ogm: any = {
+    model(name: string) {
+      return {
+        find: async () => {
+          if (name === "Comment") return opts.authorRows ?? [];
+          if (name === "User") return [{ username: "alice" }];
+          return [];
+        },
+        create: async () => {
+          tracked.push(`${name}.create`);
+          return { textVersions: [{ id: "tv-1" }] };
+        },
+        update: async () => ({}),
+      };
+    },
+  };
+  return { ogm, tracked };
+}
+
+const userAuthor = [{ CommentAuthor: { username: "alice" } }];
+const modAuthor = [{ CommentAuthor: { displayName: "ModAlice" } }];
+
+test("getCommentAuthorUsername returns a User author's username", async () => {
+  const { ogm } = makeOgm({ authorRows: userAuthor });
+  assert.equal(await getCommentAuthorUsername(ogm, "c-1"), "alice");
+});
+
+test("getCommentAuthorUsername falls back to a ModerationProfile displayName", async () => {
+  const { ogm } = makeOgm({ authorRows: modAuthor });
+  assert.equal(await getCommentAuthorUsername(ogm, "c-1"), "ModAlice");
+});
+
+test("getCommentAuthorUsername returns null when the comment is missing", async () => {
+  const { ogm } = makeOgm({ authorRows: [] });
+  assert.equal(await getCommentAuthorUsername(ogm, "c-1"), null);
+});
+
+test("handleCommentUpdateEvent records the previous text as a version", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: userAuthor });
+  await handleCommentUpdateEvent(ogm, { id: "c-1", text: "new" }, { text: "old" });
+  assert.equal(tracked.filter((t) => t === "TextVersion.create").length, 1);
+});
+
+test("handleCommentUpdateEvent does nothing when text is unchanged or absent", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: userAuthor });
+  await handleCommentUpdateEvent(ogm, { id: "c-1", text: "same" }, { text: "same" });
+  await handleCommentUpdateEvent(ogm, { id: "c-1", text: "new" }, null);
+  assert.deepEqual(tracked, []);
+});
+
+test("handleCommentUpdateEvent skips when the author cannot be resolved", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: [] });
+  await handleCommentUpdateEvent(ogm, { id: "c-1", text: "new" }, { text: "old" });
+  assert.deepEqual(tracked, []);
+});
+
+// ---- subscription class ----
+
+function schemaYielding(events: any[]) {
+  const typeDefs = `
+    type UpdatedComment { id: ID, text: String }
+    type PreviousValues { text: String }
+    type CommentUpdatedPayload { updatedComment: UpdatedComment, previousValues: PreviousValues }
+    type Query { _empty: String }
+    type Subscription { commentUpdated: CommentUpdatedPayload }
+  `;
+  const resolvers = {
+    Subscription: {
+      commentUpdated: {
+        subscribe: async function* () {
+          for (const e of events) yield { commentUpdated: e };
+        },
+      },
+    },
+  };
+  return makeExecutableSchema({ typeDefs, resolvers });
+}
+const flush = () => new Promise((r) => setImmediate(r));
+
+test("service constructs and stop() is safe before start", () => {
+  const { ogm } = makeOgm();
+  const svc = new CommentVersionHistoryService(schemaYielding([]), ogm);
+  svc.stop();
+});
+
+test("service start() processes update events then the loop completes", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: userAuthor });
+  const schema = schemaYielding([
+    { updatedComment: { id: "c-1", text: "new" }, previousValues: { text: "old" } },
+    null,
+  ]);
+  const svc = new CommentVersionHistoryService(schema, ogm);
+  await svc.start();
+  for (let i = 0; i < 50 && tracked.length === 0; i++) await flush();
+  svc.stop();
+  assert.ok(tracked.length >= 1, "processed at least the valid event");
+});
+
+test("service start() handles a subscribe error without throwing", async () => {
+  const typeDefs = `type Query { _empty: String } type Subscription { commentUpdated: String }`;
+  const resolvers = {
+    Subscription: { commentUpdated: { subscribe: () => { throw new Error("no sub"); } } },
+  };
+  const { ogm } = makeOgm();
+  const svc = new CommentVersionHistoryService(makeExecutableSchema({ typeDefs, resolvers }), ogm);
+  await svc.start();
+  svc.stop();
+});

--- a/services/discussionVersionHistoryService.test.ts
+++ b/services/discussionVersionHistoryService.test.ts
@@ -1,0 +1,149 @@
+// Unit tests for the discussion version-history service: the pure handler
+// functions (author lookup + per-field version tracking) and the subscription
+// class (start/process/stop). Driven with a permissive in-memory OGM and a tiny
+// executable schema whose subscription yields controlled events. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import {
+  getDiscussionAuthorUsername,
+  handleDiscussionUpdateEvent,
+  DiscussionVersionHistoryService,
+} from "./discussionVersionHistoryService.js";
+
+// A permissive OGM whose Discussion.find returns `authorRows` and whose
+// TextVersion/parent writes are no-ops. `tracked` records TextVersion creates so
+// we can assert which fields were versioned.
+// Discussion.find -> authorRows (for the author lookup). User.find -> a user so
+// the shared trackTextVersion helper proceeds to create the version. TextVersion
+// creates are recorded in `tracked`.
+function makeOgm(opts: { authorRows?: unknown[]; findThrows?: boolean } = {}) {
+  const tracked: string[] = [];
+  const ogm: any = {
+    model(name: string) {
+      return {
+        find: async () => {
+          if (opts.findThrows) throw new Error("db down");
+          if (name === "Discussion") return opts.authorRows ?? [];
+          if (name === "User") return [{ username: "alice" }];
+          return [];
+        },
+        create: async () => {
+          tracked.push(`${name}.create`);
+          return { textVersions: [{ id: "tv-1" }] };
+        },
+        update: async () => ({}),
+      };
+    },
+  };
+  return { ogm, tracked };
+}
+
+const author = [{ Author: { username: "alice" } }];
+
+test("getDiscussionAuthorUsername returns the author's username", async () => {
+  const { ogm } = makeOgm({ authorRows: author });
+  assert.equal(await getDiscussionAuthorUsername(ogm, "d-1"), "alice");
+});
+
+test("getDiscussionAuthorUsername returns null when the discussion is missing", async () => {
+  const { ogm } = makeOgm({ authorRows: [] });
+  assert.equal(await getDiscussionAuthorUsername(ogm, "d-1"), null);
+});
+
+test("getDiscussionAuthorUsername returns null when there is no author", async () => {
+  const { ogm } = makeOgm({ authorRows: [{ Author: null }] });
+  assert.equal(await getDiscussionAuthorUsername(ogm, "d-1"), null);
+});
+
+test("getDiscussionAuthorUsername swallows lookup errors and returns null", async () => {
+  const { ogm } = makeOgm({ findThrows: true });
+  assert.equal(await getDiscussionAuthorUsername(ogm, "d-1"), null);
+});
+
+test("handleDiscussionUpdateEvent skips everything when the author is unknown", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: [] });
+  await handleDiscussionUpdateEvent(ogm, { id: "d-1", title: "new" }, { title: "old" });
+  assert.deepEqual(tracked, []);
+});
+
+test("handleDiscussionUpdateEvent tracks a title change only", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleDiscussionUpdateEvent(
+    ogm,
+    { id: "d-1", title: "new title", body: "same" },
+    { title: "old title", body: "same" }
+  );
+  assert.equal(tracked.filter((t) => t === "TextVersion.create").length, 1);
+});
+
+test("handleDiscussionUpdateEvent tracks both title and body when both change", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleDiscussionUpdateEvent(
+    ogm,
+    { id: "d-1", title: "new title", body: "new body" },
+    { title: "old title", body: "old body" }
+  );
+  assert.equal(tracked.filter((t) => t === "TextVersion.create").length, 2);
+});
+
+test("handleDiscussionUpdateEvent tracks nothing when values are unchanged or absent", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleDiscussionUpdateEvent(ogm, { id: "d-1", title: "same", body: "same" }, { title: "same", body: "same" });
+  await handleDiscussionUpdateEvent(ogm, { id: "d-1", title: "new" }, null); // no previousValues
+  assert.deepEqual(tracked, []);
+});
+
+// ---- subscription class ----
+
+function schemaYielding(events: any[]) {
+  const typeDefs = `
+    type User { username: String }
+    type UpdatedDiscussion { id: ID, title: String, body: String }
+    type PreviousValues { title: String, body: String }
+    type DiscussionUpdatedPayload { updatedDiscussion: UpdatedDiscussion, previousValues: PreviousValues }
+    type Query { _empty: String }
+    type Subscription { discussionUpdated: DiscussionUpdatedPayload }
+  `;
+  const resolvers = {
+    Subscription: {
+      discussionUpdated: {
+        subscribe: async function* () {
+          for (const e of events) yield { discussionUpdated: e };
+        },
+      },
+    },
+  };
+  return makeExecutableSchema({ typeDefs, resolvers });
+}
+const flush = () => new Promise((r) => setImmediate(r));
+
+test("service constructs and stop() is safe before start", () => {
+  const { ogm } = makeOgm();
+  const svc = new DiscussionVersionHistoryService(schemaYielding([]), ogm);
+  svc.stop();
+});
+
+test("service start() processes update events then the loop completes", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  const schema = schemaYielding([
+    { updatedDiscussion: { id: "d-1", title: "new", body: "b" }, previousValues: { title: "old", body: "b" } },
+    null, // invalid event -> skipped
+  ]);
+  const svc = new DiscussionVersionHistoryService(schema, ogm);
+  await svc.start();
+  for (let i = 0; i < 50 && tracked.length === 0; i++) await flush();
+  svc.stop();
+  assert.ok(tracked.length >= 1, "processed at least the valid event");
+});
+
+test("service start() handles a subscribe error without throwing", async () => {
+  const typeDefs = `type Query { _empty: String } type Subscription { discussionUpdated: String }`;
+  const resolvers = {
+    Subscription: { discussionUpdated: { subscribe: () => { throw new Error("no sub"); } } },
+  };
+  const { ogm } = makeOgm();
+  const svc = new DiscussionVersionHistoryService(makeExecutableSchema({ typeDefs, resolvers }), ogm);
+  await svc.start();
+  svc.stop();
+});

--- a/services/wikiPageVersionHistoryService.test.ts
+++ b/services/wikiPageVersionHistoryService.test.ts
@@ -1,0 +1,138 @@
+// Unit tests for the wiki-page version-history service: the pure handler
+// functions (version-author lookup + per-field version tracking) and the
+// subscription class. Driven with a permissive in-memory OGM and a tiny
+// executable schema. No DB.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import {
+  getWikiPageVersionAuthorUsername,
+  handleWikiPageUpdateEvent,
+  WikiPageVersionHistoryService,
+} from "./wikiPageVersionHistoryService.js";
+
+// WikiPage.find -> authorRows; User.find -> a user so trackTextVersion proceeds.
+function makeOgm(opts: { authorRows?: unknown[]; findThrows?: boolean } = {}) {
+  const tracked: string[] = [];
+  const ogm: any = {
+    model(name: string) {
+      return {
+        find: async () => {
+          if (opts.findThrows) throw new Error("db down");
+          if (name === "WikiPage") return opts.authorRows ?? [];
+          if (name === "User") return [{ username: "alice" }];
+          return [];
+        },
+        create: async () => {
+          tracked.push(`${name}.create`);
+          return { textVersions: [{ id: "tv-1" }] };
+        },
+        update: async () => ({}),
+      };
+    },
+  };
+  return { ogm, tracked };
+}
+
+const author = [{ VersionAuthor: { username: "alice" } }];
+
+test("getWikiPageVersionAuthorUsername returns the version author's username", async () => {
+  const { ogm } = makeOgm({ authorRows: author });
+  assert.equal(await getWikiPageVersionAuthorUsername(ogm, "w-1"), "alice");
+});
+
+test("getWikiPageVersionAuthorUsername returns null when missing or authorless", async () => {
+  assert.equal(await getWikiPageVersionAuthorUsername(makeOgm({ authorRows: [] }).ogm, "w-1"), null);
+  assert.equal(await getWikiPageVersionAuthorUsername(makeOgm({ authorRows: [{ VersionAuthor: null }] }).ogm, "w-1"), null);
+});
+
+test("getWikiPageVersionAuthorUsername swallows lookup errors", async () => {
+  const { ogm } = makeOgm({ findThrows: true });
+  assert.equal(await getWikiPageVersionAuthorUsername(ogm, "w-1"), null);
+});
+
+test("handleWikiPageUpdateEvent skips when the author is unknown", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: [] });
+  await handleWikiPageUpdateEvent(ogm, { id: "w-1", title: "new" }, { title: "old" });
+  assert.deepEqual(tracked, []);
+});
+
+test("handleWikiPageUpdateEvent tracks a title change only", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleWikiPageUpdateEvent(
+    ogm,
+    { id: "w-1", title: "new title", body: "same" },
+    { title: "old title", body: "same" }
+  );
+  assert.equal(tracked.filter((t) => t === "TextVersion.create").length, 1);
+});
+
+test("handleWikiPageUpdateEvent tracks both title and body when both change", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleWikiPageUpdateEvent(
+    ogm,
+    { id: "w-1", title: "new title", body: "new body", editReason: "cleanup" },
+    { title: "old title", body: "old body" }
+  );
+  assert.equal(tracked.filter((t) => t === "TextVersion.create").length, 2);
+});
+
+test("handleWikiPageUpdateEvent tracks nothing when unchanged or previousState missing", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  await handleWikiPageUpdateEvent(ogm, { id: "w-1", title: "same", body: "same" }, { title: "same", body: "same" });
+  await handleWikiPageUpdateEvent(ogm, { id: "w-1", title: "new" }, null);
+  assert.deepEqual(tracked, []);
+});
+
+// ---- subscription class ----
+
+function schemaYielding(events: any[]) {
+  const typeDefs = `
+    type UpdatedWikiPage { id: ID, title: String, body: String }
+    type PreviousState { title: String, body: String }
+    type WikiPageUpdatedPayload { updatedWikiPage: UpdatedWikiPage, previousState: PreviousState }
+    type Query { _empty: String }
+    type Subscription { wikiPageUpdated: WikiPageUpdatedPayload }
+  `;
+  const resolvers = {
+    Subscription: {
+      wikiPageUpdated: {
+        subscribe: async function* () {
+          for (const e of events) yield { wikiPageUpdated: e };
+        },
+      },
+    },
+  };
+  return makeExecutableSchema({ typeDefs, resolvers });
+}
+const flush = () => new Promise((r) => setImmediate(r));
+
+test("service constructs and stop() is safe before start", () => {
+  const { ogm } = makeOgm();
+  const svc = new WikiPageVersionHistoryService(schemaYielding([]), ogm);
+  svc.stop();
+});
+
+test("service start() processes update events then the loop completes", async () => {
+  const { ogm, tracked } = makeOgm({ authorRows: author });
+  const schema = schemaYielding([
+    { updatedWikiPage: { id: "w-1", title: "new", body: "b" }, previousState: { title: "old", body: "b" } },
+    null,
+  ]);
+  const svc = new WikiPageVersionHistoryService(schema, ogm);
+  await svc.start();
+  for (let i = 0; i < 50 && tracked.length === 0; i++) await flush();
+  svc.stop();
+  assert.ok(tracked.length >= 1, "processed at least the valid event");
+});
+
+test("service start() handles a subscribe error without throwing", async () => {
+  const typeDefs = `type Query { _empty: String } type Subscription { wikiPageUpdated: String }`;
+  const resolvers = {
+    Subscription: { wikiPageUpdated: { subscribe: () => { throw new Error("no sub"); } } },
+  };
+  const { ogm } = makeOgm();
+  const svc = new WikiPageVersionHistoryService(makeExecutableSchema({ typeDefs, resolvers }), ogm);
+  await svc.start();
+  svc.stop();
+});


### PR DESCRIPTION
## Summary

**Batch 1** of raising real (branch-aware) coverage toward the 80% badge goal. The reporting pipeline is now correct (#221), so the badge honestly reflects Codecov's branch-aware count (~75%). Closing the gap to 80% means adding real test coverage — this is the first batch.

Adds direct unit tests for the three version-history services, each ~40–47% → ~91%:

| File | Before → After |
|---|---|
| `services/discussionVersionHistoryService.ts` | 47% → 91% |
| `services/commentVersionHistoryService.ts` | 41% → 91% |
| `services/wikiPageVersionHistoryService.ts` | 42% → 91% |

Each test covers the pure handler functions (author lookup, per-field change detection, previous-text capture, error paths) and the subscription class (start / process / stop / subscribe-error), using a permissive in-memory OGM and a tiny executable schema. No DB.

**30 new tests, all passing.** ~250 newly covered lines.

## Roadmap

Reaching 80% (branch-aware) is ~1,800 covered lines total, so this is the first of several focused batches. Next candidates (integration-blind, high uncovered count): `rules/permission/userDataHelperFunctions`, `rules/definitions/contentCreationRules`, `rules/validation/*`, `services/botUserService`, and branch coverage on partially-covered hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
