### PR TITLE
chore(typescript): migrate module resolution to nodenext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,10 @@ them; the upgrades must be rejected until Neo4j ships support.
   passes. Worked around with `ts-node.compilerOptions.types: ["node"]` in
   tsconfig.json (scoped to ts-node; the main `tsc` program is untouched). Do not
   remove it or the unit tests crash on load.
-- **tsconfig `ignoreDeprecations: "6.0"`**: silences TS6's deprecation of
-  `moduleResolution: node10`. The real migration is `moduleResolution/module:
-  nodenext` (the code is already ~99% `.js`-extension imports), deferred to avoid
-  interop fallout in a dependency-bump PR.
+- **TypeScript module resolution**: `module` and `moduleResolution` use
+  `nodenext` to match the package's ESM runtime. Relative imports must include
+  the emitted `.js` extension, and CommonJS dependencies may require explicit
+  named imports when their declaration files expose them.
 
 ## Code Style
 - **Imports**: ES modules with .js extensions, grouped (third-party first, then local)
@@ -45,7 +45,7 @@ them; the upgrades must be rejected until Neo4j ships support.
 - **Error Handling**: Early returns, explicit error messages, proper error propagation
 - **GraphQL**: Separate Cypher queries in .cypher files, custom resolvers for complex operations
 - **Conventions**: 
-  - ES2018 target with ESNext modules
+  - ES2018 target with NodeNext modules
   - Use Neo4j GraphQL library and OGM for database operations
   - Follow existing permission system architecture (see README.md)
   - Database sessions use the driver's default (leader) routing. Do NOT switch

--- a/customResolvers/mutations/createDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/createDiscussionWithChannelConnections.ts
@@ -1,7 +1,7 @@
 import type { Driver } from "neo4j-driver";
 import type { GraphQLResolveInfo } from "graphql";
 import { createDiscussionChannelQuery } from "../cypher/cypherQueries.js";
-import { DiscussionCreateInput } from "../../src/generated/graphql";
+import { DiscussionCreateInput } from "../../src/generated/graphql.js";
 import { triggerChannelPluginPipeline, triggerPluginRunsForDownloadableFile } from "../../services/pluginRunner.js";
 import { GraphQLError } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";

--- a/customResolvers/mutations/seedDataForCypressTests.ts
+++ b/customResolvers/mutations/seedDataForCypressTests.ts
@@ -26,7 +26,7 @@ import { createEventsFromInput } from "./createEventWithChannelConnections.js";
 import {
   DiscussionCreateInputWithChannels,
   EventCreateInputWithChannels,
-} from "../../src/generated/graphql";
+} from "../../src/generated/graphql.js";
 import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { GraphQLContext } from "../../types/context.js";

--- a/customResolvers/mutations/undoUpvoteComment.ts
+++ b/customResolvers/mutations/undoUpvoteComment.ts
@@ -1,4 +1,4 @@
-import { User } from "../../src/generated/graphql";
+import { User } from "../../src/generated/graphql.js";
 import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { CommentModel, UserModel } from "../../ogm_types.js";

--- a/customResolvers/mutations/undoUpvoteDiscussionChannel.ts
+++ b/customResolvers/mutations/undoUpvoteDiscussionChannel.ts
@@ -1,4 +1,4 @@
-import { User } from "../../src/generated/graphql";
+import { User } from "../../src/generated/graphql.js";
 import type { GraphQLResolveInfo } from "graphql";
 import type { Driver } from "neo4j-driver";
 import type { DiscussionChannelModel, UserModel } from "../../ogm_types.js";

--- a/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
+++ b/customResolvers/mutations/updateDiscussionWithChannelConnections.ts
@@ -1,6 +1,6 @@
 import type { Driver } from "neo4j-driver";
 import { updateDiscussionChannelQuery, severConnectionBetweenDiscussionAndChannelQuery } from "../cypher/cypherQueries.js";
-import { DiscussionWhere, DiscussionUpdateInput } from "../../src/generated/graphql";
+import { DiscussionWhere, DiscussionUpdateInput } from "../../src/generated/graphql.js";
 import { discussionVersionHistoryHandler } from "../../hooks/discussionVersionHistoryHook.js";
 import { GraphQLError, type GraphQLResolveInfo } from "graphql";
 import { setUserDataOnContext } from "../../rules/permission/userDataHelperFunctions.js";

--- a/customResolvers/mutations/updateEventWithChannelConnections.ts
+++ b/customResolvers/mutations/updateEventWithChannelConnections.ts
@@ -1,7 +1,7 @@
 import type { Driver } from "neo4j-driver";
 import type { GraphQLResolveInfo } from "graphql";
 import { updateEventChannelQuery, severConnectionBetweenEventAndChannelQuery } from "../cypher/cypherQueries.js";
-import { EventWhere, EventUpdateInput } from "../../src/generated/graphql";
+import { EventWhere, EventUpdateInput } from "../../src/generated/graphql.js";
 import { sendBatchEmails } from "../../services/mail/index.js";
 import { createEventUpdateNotificationEmail } from "./shared/emailUtils.js";
 import { buildEventUpdateNotificationPayload } from "../../services/eventUpdateNotifications.js";

--- a/customResolvers/mutations/utils.ts
+++ b/customResolvers/mutations/utils.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { User } from "../../src/generated/graphql";
+import { User } from "../../src/generated/graphql.js";
 import { log } from "mathjs";
 
 export const getAccountAgeInMonths = (createdAt: Date) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,10 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "esnext",                                /* Specify what module code is generated. */
+    "module": "nodenext",                              /* Specify what module code is generated. */
     "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution":         "node",            /* Specify how TypeScript looks up a file from a given module specifier. */
-    "ignoreDeprecations": "6.0",                      /* Silence TS6 deprecation of moduleResolution 'node10'; removal is a TS7 concern to migrate separately. */
+    "moduleResolution": "nodenext",                    /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from 'graphql-tag'
 
 const typeDefinitions = gql`
   enum FilterMode {


### PR DESCRIPTION
## Summary

- switch TypeScript `module` and `moduleResolution` to `nodenext`
- remove the TypeScript 6 `ignoreDeprecations` workaround
- add required `.js` extensions to relative generated-type imports
- use the explicit `gql` named export for NodeNext-compatible CommonJS interop
- update repository guidance to reflect the completed migration

## Verification

- `pnpm run codegen`
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm test` (1,231 passed)

The local environment used Node 24 and emitted the expected engine warning because the project declares Node 26; all checks still passed.

Closes #213