### PR TITLE
feat(auth): filter notification reads in generated Cypher

### DIFF
--- a/docs/authorization-directive-spike.md
+++ b/docs/authorization-directive-spike.md
@@ -1,0 +1,71 @@
+# `@authorization` read-path spike
+
+Issue: [#211](https://github.com/gennit-project/multiforum-backend/issues/211)
+
+## Scope
+
+This spike migrates notification read ownership from a field-level
+`graphql-shield` rule to an `@neo4j/graphql` v5 filter:
+
+- `Notification` has an inverse `User` relationship over `HAS_NOTIFICATION`.
+- `READ` and `AGGREGATE` operations filter that relationship by the verified
+  application username.
+- `User.Notifications` is now open in shield because ownership is enforced in
+  the generated Cypher. Notification mutations remain denied by shield.
+
+This protects every generated read path, including the root `notifications`
+and `notificationsAggregate` queries. Previously, shield protected traversal
+through `User.Notifications`, but the generated root queries inherited the
+public `Query.*` rule.
+
+## Identity wiring
+
+The provider JWT cannot be passed through unchanged. Auth0's `sub` identifies
+the Auth0 principal, while graph ownership is keyed by `User.username`; local
+development and mock providers also have different verification paths.
+
+The Apollo context therefore reuses `setUserDataOnContext`, the existing
+provider-aware verifier and username lookup, and passes this minimal decoded
+payload to Neo4j GraphQL:
+
+```ts
+{ jwt: { sub: verifiedApplicationUsername } }
+```
+
+Neo4j GraphQL documents decoded `context.jwt` as the extension point for custom
+decoding. Shield reuses the populated `context.user`, so requests that need
+shield rules do not repeat the username lookup.
+
+## Verification and generated query behavior
+
+The focused tests execute the generated resolver with a capturing driver. They
+verify that authenticated notification reads compile a `HAS_NOTIFICATION`
+traversal and username predicate into Cypher, and that requests without a
+decoded identity compile with `isAuthenticated = false`. Schema generation and
+the existing permission tests provide compatibility coverage for the rest of
+the middleware stack.
+
+## Findings and recommendation
+
+**Go, incrementally, for owner-scoped node types.** A type-level filter can
+replace shield rules that only determine which nodes a caller may see. It also
+covers root, nested, and aggregate reads consistently and filters before
+pagination and counts.
+
+Broader migration should account for these constraints:
+
+1. Auth identity must be normalized to graph identifiers before translation.
+   This spike resolves that once per authenticated request. Measure the added
+   lookup cost on public read-heavy traffic before migrating many types.
+2. Filter rules intentionally return fewer nodes instead of shield-style field
+   errors. Client behavior should be checked wherever an authorization error is
+   currently part of the contract.
+3. `@authorization` does not protect subscription events. Each migrated type
+   needs a separate `@subscriptionsAuthorization` design, or its generated
+   subscriptions must be disabled, before shield can be retired broadly.
+4. Mutation validation and custom error messages remain in shield. This spike
+   does not justify removing the patched dependency yet.
+
+The recommended next slice is another owner-scoped read type with a stable
+username relationship. Role- and permission-based types should wait until the
+identity lookup cost and subscription policy have been resolved.

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,8 @@ import {
   assertAuthenticationConfiguration,
   createLocalDevTokenHandler,
 } from "./services/localDevAuth.js";
+import { getNeo4jAuthorizationJwt } from "./services/neo4jAuthorization.js";
+import { setUserDataOnContext } from "./rules/permission/userDataHelperFunctions.js";
 import { logCriticalError, errorHandlingPlugin } from "./errorHandling.js";
 import type { GraphQLSchema } from "graphql";
 import type { Ogm, GraphQLRequest, GraphQLContext } from "./types/context.js";
@@ -290,11 +292,23 @@ async function initializeServer() {
             });
           }
 
-          return {
+          const context: GraphQLContext = {
             driver,
             req,
             ogm,
           };
+
+          // @neo4j/graphql accepts a decoded identity in context.jwt. Reuse the
+          // application's existing provider-aware verification and username
+          // lookup so authorization predicates compare graph usernames rather
+          // than Auth0 subjects. graphql-shield reuses context.user, avoiding
+          // duplicate identity lookups later in the same request.
+          if (req.headers.authorization) {
+            context.user = await setUserDataOnContext({ context });
+            context.jwt = getNeo4jAuthorizationJwt(context.user);
+          }
+
+          return context;
         },
       })
     );

--- a/permissions.ts
+++ b/permissions.ts
@@ -264,8 +264,11 @@ const permissionRules: IRules = {
       FavoriteChannels: isAccountOwner,
       OwnedDownloads: isAccountOwner,
 
-      // Notifications - only the account owner may list their own notifications
-      Notifications: isAccountOwner,
+      // Notification ownership is filtered inside the generated Cypher by the
+      // Notification @authorization rule. Keeping this field open in shield is
+      // intentional: otherwise shield would reject after the database query and
+      // defeat filter semantics (empty list instead of an authorization error).
+      Notifications: allow,
 
       // Other private fields
       Email: isAccountOwner,

--- a/services/neo4jAuthorization.test.ts
+++ b/services/neo4jAuthorization.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getNeo4jAuthorizationJwt } from "./neo4jAuthorization.js";
+
+test("maps a verified application username to the Neo4j JWT subject", () => {
+  assert.deepEqual(
+    getNeo4jAuthorizationJwt({
+      username: "alice",
+      email: "alice@example.com",
+      email_verified: true,
+      data: null,
+    }),
+    { sub: "alice" }
+  );
+});
+
+test("does not authenticate a missing application user", () => {
+  assert.equal(getNeo4jAuthorizationJwt(undefined), undefined);
+  assert.equal(
+    getNeo4jAuthorizationJwt({
+      username: null,
+      email: null,
+      email_verified: false,
+      data: null,
+    }),
+    undefined
+  );
+});

--- a/services/neo4jAuthorization.ts
+++ b/services/neo4jAuthorization.ts
@@ -1,0 +1,19 @@
+import type {
+  Neo4jAuthorizationJwt,
+  UserDataOnContext,
+} from "../types/context.js";
+
+/**
+ * Convert the application's verified user identity into the decoded JWT shape
+ * consumed by @neo4j/graphql. Auth0's `sub` is not the graph username, so the
+ * original provider token cannot be used directly for relationship filters.
+ */
+export const getNeo4jAuthorizationJwt = (
+  user: UserDataOnContext | undefined
+): Neo4jAuthorizationJwt | undefined => {
+  if (!user?.username) {
+    return undefined;
+  }
+
+  return { sub: user.username };
+};

--- a/tests/notificationAuthorization.test.ts
+++ b/tests/notificationAuthorization.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Neo4jGraphQL } from "@neo4j/graphql";
+import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
+import typeDefs from "../typeDefs.js";
+
+type CapturedQuery = {
+  cypher: string;
+  params: Record<string, unknown>;
+};
+
+const createCapturingDriver = (capture: CapturedQuery): Driver => {
+  const summary = {
+    counters: { updates: () => ({}) },
+  };
+  const transaction = {
+    run: async (cypher: string, params: Record<string, unknown>) => {
+      if (cypher.includes("dbms.components")) {
+        return { records: [["5.26.0", "enterprise"]], summary };
+      }
+
+      capture.cypher = cypher;
+      capture.params = params;
+      return { records: [], summary };
+    },
+  };
+  const session = {
+    executeRead: async (
+      work: (tx: typeof transaction) => Promise<{ records: unknown[] }>
+    ) => work(transaction),
+    executeWrite: async (
+      work: (tx: typeof transaction) => Promise<{ records: unknown[] }>
+    ) => work(transaction),
+    lastBookmarks: () => [],
+    close: async () => undefined,
+  };
+
+  return {
+    session: () => session,
+    executeQueryBookmarkManager: undefined,
+  } as unknown as Driver;
+};
+
+test("Notification reads compile ownership into Cypher", async () => {
+  const capture: CapturedQuery = { cypher: "", params: {} };
+  const driver = createCapturingDriver(capture);
+  const schema = await new Neo4jGraphQL({ typeDefs, driver }).getSchema();
+
+  const result = await graphql({
+    schema,
+    source: `query { notifications { id text } }`,
+    contextValue: {
+      driver,
+      jwt: { sub: "alice" },
+    },
+  });
+
+  assert.deepEqual(result.errors, undefined);
+  assert.deepEqual(JSON.parse(JSON.stringify(result.data)), {
+    notifications: [],
+  });
+  assert.match(capture.cypher, /HAS_NOTIFICATION/);
+  assert.match(capture.cypher, /username/);
+  assert.deepEqual(capture.params.jwt, { sub: "alice" });
+  assert.equal(capture.params.isAuthenticated, true);
+});
+
+test("Notification reads without an identity compile a fail-closed predicate", async () => {
+  const capture: CapturedQuery = { cypher: "", params: {} };
+  const driver = createCapturingDriver(capture);
+  const schema = await new Neo4jGraphQL({ typeDefs, driver }).getSchema();
+
+  const result = await graphql({
+    schema,
+    source: `query { notifications { id } }`,
+    contextValue: { driver },
+  });
+
+  assert.deepEqual(result.errors, undefined);
+  assert.deepEqual(JSON.parse(JSON.stringify(result.data)), {
+    notifications: [],
+  });
+  assert.equal(capture.params.isAuthenticated, false);
+});

--- a/typeDefs.ts
+++ b/typeDefs.ts
@@ -197,7 +197,11 @@ const typeDefinitions = gql`
     Discussions: [Discussion!]! @relationship(type: "HAS_ALBUM", direction: IN)
   }
 
-  type Notification {
+  type Notification
+    @authorization(filter: [{
+      operations: [READ, AGGREGATE]
+      where: { node: { User: { username: "$jwt.sub" } } }
+    }]) {
     id: ID! @id
     createdAt: DateTime! @timestamp(operations: [CREATE])
     read: Boolean
@@ -208,6 +212,9 @@ const typeDefinitions = gql`
     # on the thank-you note (show on profile / ignore) straight from the bell.
     ScratchpadEntry: ScratchpadEntry
       @relationship(type: "NOTIFICATION_FOR_SCRATCHPAD_ENTRY", direction: OUT)
+    # Inverse of User.Notifications. The authorization filter uses this edge so
+    # ownership is enforced in the generated Cypher before rows are returned.
+    User: User @relationship(type: "HAS_NOTIFICATION", direction: IN)
   }
 
   type Message {

--- a/types/context.ts
+++ b/types/context.ts
@@ -42,6 +42,15 @@ export type UserDataOnContext = {
 };
 
 /**
+ * Minimal decoded identity passed to @neo4j/graphql authorization rules.
+ * `sub` is the application username, not the identity-provider subject: graph
+ * ownership relationships are keyed by username in this schema.
+ */
+export type Neo4jAuthorizationJwt = {
+  sub: string;
+};
+
+/**
  * The Express request as seen by GraphQL resolvers and permission rules. A few
  * fields are attached by the context factory / permission layer at runtime.
  */
@@ -65,5 +74,6 @@ export type GraphQLContext = {
   ogm: Ogm;
   req?: GraphQLRequest;
   user?: UserDataOnContext;
+  jwt?: Neo4jAuthorizationJwt;
   jwtError?: Error;
 };


### PR DESCRIPTION
## Summary

- migrate Notification READ and AGGREGATE ownership filtering from graphql-shield into an @neo4j/graphql relationship-aware authorization predicate
- normalize the existing verified application identity into decoded context.jwt data for generated Cypher
- cover root, nested, and aggregate notification reads while keeping mutation authorization in shield
- document the spike findings, limitations, and recommendation for incremental migration

## Verification

- pnpm run lint
- pnpm run tsc
- pnpm test (1,265 passing)
- focused authorization tests under Node 26.3.0

## Findings

This is a go for incremental owner-scoped read migrations. Broader work should remain sliced because filter semantics differ from shield errors, authenticated requests currently need username normalization, and subscriptions require a separate authorization policy.

Closes #211