### PR TITLE
feat(auth): validate generic OIDC tokens

### DIFF
--- a/customResolvers/queries/getInstanceSetupStatus.test.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.test.ts
@@ -164,6 +164,34 @@ test("reports missing local development auth settings instead of Auth0 settings"
   ]);
 });
 
+test("reports generic OIDC authentication readiness", () => {
+  const missing = buildInstanceSetupStatus({
+    env: { MULTIFORUM_AUTH_PROVIDER: "oidc" },
+    serverConfig: null,
+  });
+  assert.deepEqual(missing.auth.requiredEnvVarsMissing, [
+    "OIDC_ISSUER_URL",
+    "OIDC_AUDIENCE",
+    "OIDC_JWKS_URL",
+    "OIDC_USERINFO_URL",
+  ]);
+
+  const configured = buildInstanceSetupStatus({
+    env: {
+      MULTIFORUM_AUTH_PROVIDER: "oidc",
+      OIDC_ISSUER_URL: "https://identity.example.test/realms/multiforum",
+      OIDC_AUDIENCE: "multiforum-api",
+      OIDC_JWKS_URL: "https://identity.example.test/realms/multiforum/certs",
+      OIDC_USERINFO_URL:
+        "https://identity.example.test/realms/multiforum/userinfo",
+    },
+    serverConfig: null,
+  });
+  assert.deepEqual(configured.auth.requiredEnvVarsMissing, []);
+  assert.equal(configured.auth.configured, true);
+  assert.equal(configured.auth.enabled, true);
+});
+
 test("resolves the named ServerConfig before building status", async () => {
   const calls: unknown[] = [];
   const ServerConfig = {

--- a/customResolvers/queries/getInstanceSetupStatus.ts
+++ b/customResolvers/queries/getInstanceSetupStatus.ts
@@ -4,6 +4,10 @@ import {
   getLocalDevAuthMissingVariables,
   isLocalDevAuthConfigured,
 } from "../../services/localDevAuth.js";
+import {
+  getOidcAuthMissingVariables,
+  isOidcAuthConfigured,
+} from "../../services/oidcAuth.js";
 
 type Environment = NodeJS.ProcessEnv;
 
@@ -75,9 +79,10 @@ export const buildInstanceSetupStatus = ({
   serverConfig: ServerFeatureConfig | null;
 }): InstanceSetupStatus => {
   const authProvider = getAuthenticationProvider(env);
-  const authMissing =
-    authProvider === "local-dev"
-      ? getLocalDevAuthMissingVariables(env)
+  const authMissing = authProvider === "local-dev"
+    ? getLocalDevAuthMissingVariables(env)
+    : authProvider === "oidc"
+      ? getOidcAuthMissingVariables(env)
       : missingVariables(env, [
           "AUTH0_DOMAIN",
           "AUTH0_CLIENT_ID",
@@ -94,9 +99,10 @@ export const buildInstanceSetupStatus = ({
     "PLUGIN_SECRET_ENCRYPTION_KEY",
   ]);
 
-  const authConfigured =
-    authProvider === "local-dev"
-      ? isLocalDevAuthConfigured(env)
+  const authConfigured = authProvider === "local-dev"
+    ? isLocalDevAuthConfigured(env)
+    : authProvider === "oidc"
+      ? isOidcAuthConfigured(env)
       : authMissing.length === 0;
   const mailConfigured = mailMissing.length === 0;
   const mapsConfigured = mapsMissing.length === 0;

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -7,7 +7,9 @@ below.
 ## Authentication
 
 `MULTIFORUM_AUTH_PROVIDER` selects the authentication provider. Leave it unset
-or set it to `auth0` for the production Auth0 flow. The alternative
+or set it to `auth0` for the production Auth0 flow. The production `oidc`
+provider accepts standards-compatible issuers such as Keycloak or Zitadel. The
+alternative
 `local-dev` provider is a single-identity convenience for local Docker Compose
 evaluation only: server startup rejects it when `NODE_ENV=production`.
 
@@ -31,6 +33,26 @@ Why `AUTH0_AUDIENCE` matters: the Nuxt frontend's server-session SDK
 tokens fall through the audience checks and server-side user lookups are
 rejected — users appear logged in but resolve with no username/profile. The
 value must match the frontend's `NUXT_AUTH0_AUDIENCE`.
+
+### Generic OpenID Connect
+
+Set `MULTIFORUM_AUTH_PROVIDER=oidc` to validate access tokens from a
+standards-compatible OpenID Provider. This backend contract is the foundation
+for generic OIDC frontend sessions; selecting it before the corresponding
+frontend support is deployed will not create login routes.
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OIDC_ISSUER_URL` | Yes | Exact HTTPS issuer identifier expected in the access token's `iss` claim. |
+| `OIDC_AUDIENCE` | Yes | API/resource-server audience required in the access token's `aud` claim. |
+| `OIDC_JWKS_URL` | Yes | HTTPS JSON Web Key Set endpoint used to verify token signatures and key rotation. |
+| `OIDC_USERINFO_URL` | Yes | HTTPS UserInfo endpoint used to resolve the authenticated email. It must return the same `sub` as the access token and `email_verified: true`. |
+
+OIDC access tokens must be RS256-signed, unexpired, and contain a subject. The
+backend validates the signature, issuer, and audience before calling UserInfo,
+then requires the UserInfo subject to match the token. Email addresses that the
+provider has not affirmatively verified are rejected. Endpoint URLs must use
+HTTPS and cannot contain embedded credentials, queries, or fragments.
 
 ### Local development authentication
 

--- a/rules/permission/userDataHelperFunctions.test.ts
+++ b/rules/permission/userDataHelperFunctions.test.ts
@@ -85,6 +85,20 @@ const withLocalAuthEnvironment = async (callback: () => Promise<void>) => {
   }
 };
 
+const withOidcEnvironment = async (callback: () => Promise<void>) => {
+  const previousProvider = process.env.MULTIFORUM_AUTH_PROVIDER;
+  process.env.MULTIFORUM_AUTH_PROVIDER = "oidc";
+  try {
+    await callback();
+  } finally {
+    if (previousProvider === undefined) {
+      delete process.env.MULTIFORUM_AUTH_PROVIDER;
+    } else {
+      process.env.MULTIFORUM_AUTH_PROVIDER = previousProvider;
+    }
+  }
+};
+
 test("resolves a signed local token through the persisted email relationship", async () => {
   await withLocalAuthEnvironment(async () => {
     const token = issueLocalDevToken(
@@ -152,6 +166,115 @@ test("marks an invalid local token on query context without throwing", async () 
     } as unknown as AuthContextForUserLookup;
 
     const result = await setUserDataOnContext({ context });
+    assert.equal(result.username, null);
+    assert.match(
+      context.jwtError?.message ?? "",
+      /authentication token is invalid/i
+    );
+  });
+});
+
+test("resolves a verified OIDC identity through the persisted email", async () => {
+  await withOidcEnvironment(async () => {
+    const context = {
+      ogm: {
+        model(name: string) {
+          if (name === "Email") {
+            return {
+              find: async () => [{ User: { username: "oidc_member" } }],
+            };
+          }
+          if (name === "User") {
+            return {
+              find: async () => [
+                { ModerationProfile: { displayName: "OIDC Member" } },
+              ],
+            };
+          }
+          throw new Error(`Unexpected model ${name}`);
+        },
+      },
+      req: { headers: { authorization: "Bearer oidc-token" } },
+    } as unknown as AuthContextForUserLookup;
+
+    const result = await setUserDataOnContext({
+      context,
+      oidcTokenVerifier: async () => ({
+        email: "member@example.test",
+        subject: "identity-user-1",
+      }),
+    });
+    assert.deepEqual(result, {
+      username: "oidc_member",
+      email: "member@example.test",
+      email_verified: true,
+      data: { ModerationProfile: { displayName: "OIDC Member" } },
+    });
+  });
+});
+
+test("rejects invalid OIDC tokens on mutations", async () => {
+  await withOidcEnvironment(async () => {
+    const context = {
+      ogm: { model: () => ({}) },
+      req: {
+        headers: { authorization: "Bearer invalid-token" },
+        isMutation: true,
+      },
+    } as unknown as AuthContextForUserLookup;
+
+    await assert.rejects(
+      setUserDataOnContext({
+        context,
+        oidcTokenVerifier: async () => {
+          throw new Error("invalid OIDC token");
+        },
+      }),
+      /authentication token is invalid/i
+    );
+  });
+});
+
+test("reports expired OIDC tokens as expired sessions", async () => {
+  await withOidcEnvironment(async () => {
+    const context = {
+      ogm: { model: () => ({}) },
+      req: {
+        headers: { authorization: "Bearer expired-token" },
+        isMutation: true,
+      },
+    } as unknown as AuthContextForUserLookup;
+    const expiredError = new Error("jwt expired");
+    expiredError.name = "TokenExpiredError";
+
+    await assert.rejects(
+      setUserDataOnContext({
+        context,
+        oidcTokenVerifier: async () => {
+          throw expiredError;
+        },
+      }),
+      /session has expired/i
+    );
+  });
+});
+
+test("marks invalid OIDC tokens on query context", async () => {
+  await withOidcEnvironment(async () => {
+    const context = {
+      ogm: { model: () => ({}) },
+      req: {
+        headers: { authorization: "Bearer invalid-token" },
+        isMutation: false,
+      },
+    } as unknown as AuthContextForUserLookup;
+
+    const result = await setUserDataOnContext({
+      context,
+      oidcTokenVerifier: async () => {
+        throw new Error("invalid OIDC token");
+      },
+    });
     assert.equal(result.username, null);
     assert.match(
       context.jwtError?.message ?? "",

--- a/rules/permission/userDataHelperFunctions.ts
+++ b/rules/permission/userDataHelperFunctions.ts
@@ -17,6 +17,7 @@ import {
   getAuthenticationProvider,
   verifyLocalDevToken,
 } from "../../services/localDevAuth.js";
+import { verifyOidcToken } from "../../services/oidcAuth.js";
 
 type CachedUserInfo = {
   email: string | null;
@@ -142,6 +143,7 @@ export type AuthContextForUserLookup = {
 
 type SetUserDataInput = {
   context: AuthContextForUserLookup;
+  oidcTokenVerifier?: typeof verifyOidcToken;
 };
 
 // UserDataOnContext now lives in types/context.ts (single source of truth for
@@ -153,6 +155,7 @@ export const setUserDataOnContext = async (
   input: SetUserDataInput
 ): Promise<UserDataOnContext> => {
   const { context } = input;
+  const oidcTokenVerifier = input.oidcTokenVerifier ?? verifyOidcToken;
 
   // Identity is stable for the lifetime of a single request. graphql-shield
   // invokes this once per rule, and ~40 mutation resolvers call it again
@@ -205,6 +208,31 @@ export const setUserDataOnContext = async (
       try {
         const localIdentity = verifyLocalDevToken(token);
         email = localIdentity.email;
+        emailVerified = true;
+        username = await getUserFromEmail(email, ogm.model("Email"));
+        if (username) {
+          modProfileName = await getModProfileNameFromUsername(username, ogm);
+        }
+      } catch (error) {
+        const isExpired =
+          error instanceof Error && error.name === "TokenExpiredError";
+        const errorMessage = isExpired
+          ? ERROR_MESSAGES.channel.tokenExpired ||
+            "Your session has expired. Please sign in again."
+          : ERROR_MESSAGES.channel.invalidToken ||
+            "Your authentication token is invalid. Please sign in again.";
+
+        if (context.req?.isMutation === true) {
+          throw new Error(errorMessage);
+        }
+        context.jwtError = new Error(errorMessage);
+      }
+    }
+
+    if (!username && !email && authProvider === "oidc") {
+      try {
+        const oidcIdentity = await oidcTokenVerifier(token);
+        email = oidcIdentity.email;
         emailVerified = true;
         username = await getUserFromEmail(email, ogm.model("Email"));
         if (username) {

--- a/services/localDevAuth.test.ts
+++ b/services/localDevAuth.test.ts
@@ -48,6 +48,7 @@ const withProcessEnvironment = <T>(
 test("keeps Auth0 as the backwards-compatible default provider", () => {
   assert.equal(getAuthenticationProvider({}), "auth0");
   assert.equal(getAuthenticationProvider({ MULTIFORUM_AUTH_PROVIDER: "AUTH0" }), "auth0");
+  assert.equal(getAuthenticationProvider({ MULTIFORUM_AUTH_PROVIDER: "OIDC" }), "oidc");
 });
 
 test("rejects unknown authentication providers", () => {
@@ -86,6 +87,23 @@ test("uses process.env when provider helpers omit an explicit environment", () =
 test("accepts the default Auth0 provider without requiring local settings", () => {
   assert.doesNotThrow(() => assertAuthenticationConfiguration({}));
   assert.equal(isLocalDevAuthConfigured({}), false);
+});
+
+test("validates generic OIDC settings at startup", () => {
+  assert.throws(
+    () => assertAuthenticationConfiguration({ MULTIFORUM_AUTH_PROVIDER: "oidc" }),
+    /OIDC_ISSUER_URL/
+  );
+  assert.doesNotThrow(() =>
+    assertAuthenticationConfiguration({
+      MULTIFORUM_AUTH_PROVIDER: "oidc",
+      OIDC_ISSUER_URL: "https://identity.example.test/realms/multiforum",
+      OIDC_AUDIENCE: "multiforum-api",
+      OIDC_JWKS_URL: "https://identity.example.test/realms/multiforum/certs",
+      OIDC_USERINFO_URL:
+        "https://identity.example.test/realms/multiforum/userinfo",
+    })
+  );
 });
 
 test("names missing settings when an enabled local provider is incomplete", () => {

--- a/services/localDevAuth.ts
+++ b/services/localDevAuth.ts
@@ -1,6 +1,7 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { RequestHandler } from "express";
 import jwt, { type JwtPayload } from "jsonwebtoken";
+import { getOidcConfiguration } from "./oidcAuth.js";
 
 const LOCAL_DEV_PROVIDER = "local-dev";
 const TOKEN_ISSUER = "multiforum-local-dev";
@@ -9,7 +10,7 @@ const TOKEN_LIFETIME_SECONDS = 12 * 60 * 60;
 
 type Environment = NodeJS.ProcessEnv;
 
-export type AuthenticationProvider = "auth0" | typeof LOCAL_DEV_PROVIDER;
+export type AuthenticationProvider = "auth0" | "oidc" | typeof LOCAL_DEV_PROVIDER;
 
 export type LocalDevIdentity = {
   email: string;
@@ -31,9 +32,9 @@ export const getAuthenticationProvider = (
   env: Environment = process.env
 ): AuthenticationProvider => {
   const provider = env.MULTIFORUM_AUTH_PROVIDER?.trim().toLowerCase() || "auth0";
-  if (provider !== "auth0" && provider !== LOCAL_DEV_PROVIDER) {
+  if (provider !== "auth0" && provider !== "oidc" && provider !== LOCAL_DEV_PROVIDER) {
     throw new Error(
-      `Unsupported MULTIFORUM_AUTH_PROVIDER '${provider}'. Use 'auth0' or 'local-dev'.`
+      `Unsupported MULTIFORUM_AUTH_PROVIDER '${provider}'. Use 'auth0', 'oidc', or 'local-dev'.`
     );
   }
   return provider;
@@ -97,8 +98,12 @@ const requireLocalDevConfiguration = (env: Environment) => {
 export const assertAuthenticationConfiguration = (
   env: Environment = process.env
 ): void => {
-  if (getAuthenticationProvider(env) === LOCAL_DEV_PROVIDER) {
+  const provider = getAuthenticationProvider(env);
+  if (provider === LOCAL_DEV_PROVIDER) {
     requireLocalDevConfiguration(env);
+  }
+  if (provider === "oidc") {
+    getOidcConfiguration(env);
   }
 };
 

--- a/services/oidcAuth.test.ts
+++ b/services/oidcAuth.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import {
+  getOidcAuthMissingVariables,
+  getOidcConfiguration,
+  isOidcAuthConfigured,
+  verifyOidcToken,
+} from "./oidcAuth.js";
+
+const completeEnvironment = {
+  OIDC_ISSUER_URL: "https://identity.example.test/realms/multiforum",
+  OIDC_AUDIENCE: "multiforum-api",
+  OIDC_JWKS_URL:
+    "https://identity.example.test/realms/multiforum/protocol/openid-connect/certs",
+  OIDC_USERINFO_URL:
+    "https://identity.example.test/realms/multiforum/protocol/openid-connect/userinfo",
+};
+
+test("reports and validates the generic OIDC configuration", () => {
+  assert.deepEqual(getOidcAuthMissingVariables({}), [
+    "OIDC_ISSUER_URL",
+    "OIDC_AUDIENCE",
+    "OIDC_JWKS_URL",
+    "OIDC_USERINFO_URL",
+  ]);
+  assert.deepEqual(getOidcConfiguration(completeEnvironment), {
+    issuerUrl: completeEnvironment.OIDC_ISSUER_URL,
+    audience: completeEnvironment.OIDC_AUDIENCE,
+    jwksUrl: completeEnvironment.OIDC_JWKS_URL,
+    userInfoUrl: completeEnvironment.OIDC_USERINFO_URL,
+  });
+  assert.equal(isOidcAuthConfigured(completeEnvironment), true);
+  assert.equal(
+    isOidcAuthConfigured({ ...completeEnvironment, OIDC_AUDIENCE: "" }),
+    false
+  );
+  assert.throws(
+    () =>
+      getOidcConfiguration({
+        ...completeEnvironment,
+        OIDC_ISSUER_URL: "http://identity.example.test/realms/multiforum",
+      }),
+    /must use HTTPS/
+  );
+  assert.throws(
+    () =>
+      getOidcConfiguration({
+        ...completeEnvironment,
+        OIDC_JWKS_URL: "not a URL",
+      }),
+    /absolute URL/
+  );
+  assert.throws(
+    () =>
+      getOidcConfiguration({
+        ...completeEnvironment,
+        OIDC_USERINFO_URL: "https://user:secret@identity.example.test/userinfo",
+      }),
+    /must not contain credentials/
+  );
+});
+
+test("verifies issuer, audience, signature, subject, and UserInfo identity", async () => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+  const publicJwk = publicKey.export({ format: "jwk" });
+  const keyId = "oidc-test-key";
+  let userInfo = {
+    sub: "identity-user-1",
+    email: "member@example.test",
+    email_verified: true,
+  };
+  let userInfoRequests = 0;
+
+  const server = createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/jwks") {
+      response.end(
+        JSON.stringify({ keys: [{ ...publicJwk, kid: keyId, use: "sig", alg: "RS256" }] })
+      );
+      return;
+    }
+    if (request.url === "/userinfo") {
+      userInfoRequests += 1;
+      if (!request.headers.authorization?.startsWith("Bearer ")) {
+        response.statusCode = 401;
+        response.end(JSON.stringify({ error: "missing_token" }));
+        return;
+      }
+      response.end(JSON.stringify(userInfo));
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const issuer = `http://127.0.0.1:${address.port}`;
+    const env = {
+      NODE_ENV: "test",
+      OIDC_ISSUER_URL: issuer,
+      OIDC_AUDIENCE: "multiforum-api",
+      OIDC_JWKS_URL: `${issuer}/jwks`,
+      OIDC_USERINFO_URL: `${issuer}/userinfo`,
+    };
+    const sign = (overrides: jwt.SignOptions = {}) =>
+      jwt.sign({}, privateKey, {
+        algorithm: "RS256",
+        keyid: keyId,
+        issuer,
+        audience: "multiforum-api",
+        subject: "identity-user-1",
+        jwtid: randomUUID(),
+        expiresIn: "5m",
+        ...overrides,
+      });
+
+    const token = sign();
+    assert.deepEqual(await verifyOidcToken(token, env), {
+      email: "member@example.test",
+      subject: "identity-user-1",
+    });
+    assert.deepEqual(await verifyOidcToken(token, env), {
+      email: "member@example.test",
+      subject: "identity-user-1",
+    });
+    assert.equal(userInfoRequests, 1);
+
+    await assert.rejects(
+      verifyOidcToken(sign({ issuer: `${issuer}/other` }), env),
+      /issuer invalid/
+    );
+    await assert.rejects(
+      verifyOidcToken(sign({ audience: "another-api" }), env),
+      /audience invalid/
+    );
+    const tokenWithoutKeyId = jwt.sign({}, privateKey, {
+      algorithm: "RS256",
+      issuer,
+      audience: "multiforum-api",
+      subject: "identity-user-1",
+      expiresIn: "5m",
+    });
+    await assert.rejects(verifyOidcToken(tokenWithoutKeyId, env), /missing 'kid'/);
+    await assert.rejects(
+      verifyOidcToken(sign({ keyid: "unknown-key" }), env),
+      /Unable to find a signing key/
+    );
+    const tokenWithoutSubject = jwt.sign({}, privateKey, {
+      algorithm: "RS256",
+      keyid: keyId,
+      issuer,
+      audience: "multiforum-api",
+      expiresIn: "5m",
+    });
+    await assert.rejects(verifyOidcToken(tokenWithoutSubject, env), /subject/);
+
+    userInfo = { ...userInfo, sub: "another-user" };
+    await assert.rejects(
+      verifyOidcToken(sign(), env),
+      /subject does not match/
+    );
+    userInfo = { ...userInfo, sub: "identity-user-1", email_verified: false };
+    await assert.rejects(verifyOidcToken(sign(), env), /has not verified/);
+    userInfo = { ...userInfo, email_verified: true, email: "" };
+    await assert.rejects(verifyOidcToken(sign(), env), /email address/);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  }
+});

--- a/services/oidcAuth.ts
+++ b/services/oidcAuth.ts
@@ -1,0 +1,205 @@
+import axios from "axios";
+import jwt from "jsonwebtoken";
+import type {
+  GetPublicKeyOrSecret,
+  JwtHeader,
+  JwtPayload,
+  SigningKeyCallback,
+} from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
+import NodeCache from "node-cache";
+
+type Environment = NodeJS.ProcessEnv;
+
+export type OidcIdentity = {
+  email: string;
+  subject: string;
+};
+
+type OidcConfiguration = {
+  issuerUrl: string;
+  audience: string;
+  jwksUrl: string;
+  userInfoUrl: string;
+};
+
+type OidcUserInfo = {
+  sub?: unknown;
+  email?: unknown;
+  email_verified?: unknown;
+};
+
+export const OIDC_AUTH_ENV_VARS = [
+  "OIDC_ISSUER_URL",
+  "OIDC_AUDIENCE",
+  "OIDC_JWKS_URL",
+  "OIDC_USERINFO_URL",
+] as const;
+
+const jwksClients = new Map<string, jwksClient.JwksClient>();
+const userInfoCache = new NodeCache({ stdTTL: 900, useClones: false });
+
+const hasValue = (env: Environment, name: string): boolean =>
+  Boolean(env[name]?.trim());
+
+export const getOidcAuthMissingVariables = (
+  env: Environment = process.env
+): string[] => OIDC_AUTH_ENV_VARS.filter((name) => !hasValue(env, name));
+
+const validateHttpsUrl = (
+  value: string,
+  name: string,
+  env: Environment
+): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute URL.`);
+  }
+
+  const testLoopbackHttp =
+    env.NODE_ENV === "test" &&
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost");
+  if (parsed.protocol !== "https:" && !testLoopbackHttp) {
+    throw new Error(`${name} must use HTTPS.`);
+  }
+  if (parsed.username || parsed.password || parsed.hash || parsed.search) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment.`);
+  }
+
+  return value;
+};
+
+export const getOidcConfiguration = (
+  env: Environment = process.env
+): OidcConfiguration => {
+  const missing = getOidcAuthMissingVariables(env);
+  if (missing.length > 0) {
+    throw new Error(`OIDC authentication requires: ${missing.join(", ")}.`);
+  }
+
+  return {
+    issuerUrl: validateHttpsUrl(
+      env.OIDC_ISSUER_URL!.trim(),
+      "OIDC_ISSUER_URL",
+      env
+    ),
+    audience: env.OIDC_AUDIENCE!.trim(),
+    jwksUrl: validateHttpsUrl(env.OIDC_JWKS_URL!.trim(), "OIDC_JWKS_URL", env),
+    userInfoUrl: validateHttpsUrl(
+      env.OIDC_USERINFO_URL!.trim(),
+      "OIDC_USERINFO_URL",
+      env
+    ),
+  };
+};
+
+export const isOidcAuthConfigured = (
+  env: Environment = process.env
+): boolean => {
+  try {
+    getOidcConfiguration(env);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const getClient = (jwksUrl: string): jwksClient.JwksClient => {
+  const existing = jwksClients.get(jwksUrl);
+  if (existing) return existing;
+
+  const created = jwksClient({
+    jwksUri: jwksUrl,
+    cache: true,
+    rateLimit: true,
+  });
+  jwksClients.set(jwksUrl, created);
+  return created;
+};
+
+const createKeyResolver = (jwksUrl: string): GetPublicKeyOrSecret =>
+  (header: JwtHeader, callback: SigningKeyCallback): void => {
+    if (!header.kid) {
+      callback(new Error("OIDC token header is missing 'kid'."));
+      return;
+    }
+
+    getClient(jwksUrl).getSigningKey(header.kid, (error, key) => {
+      if (error) {
+        callback(error);
+        return;
+      }
+      callback(null, key?.getPublicKey());
+    });
+  };
+
+const verifyJwt = (
+  token: string,
+  config: OidcConfiguration
+): Promise<JwtPayload> =>
+  new Promise((resolve, reject) => {
+    jwt.verify(
+      token,
+      createKeyResolver(config.jwksUrl),
+      {
+        algorithms: ["RS256"],
+        issuer: config.issuerUrl,
+        audience: config.audience,
+      },
+      (error, decoded) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!decoded || typeof decoded === "string") {
+          reject(new Error("OIDC token payload is invalid."));
+          return;
+        }
+        resolve(decoded);
+      }
+    );
+  });
+
+const fetchVerifiedIdentity = async (
+  token: string,
+  subject: string,
+  userInfoUrl: string
+): Promise<OidcIdentity> => {
+  const cached = userInfoCache.get<OidcIdentity>(token);
+  if (cached) return cached;
+
+  const response = await axios.get<OidcUserInfo>(userInfoUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    timeout: 5_000,
+  });
+  const userInfo = response.data;
+  if (userInfo.sub !== subject) {
+    throw new Error("OIDC UserInfo subject does not match the access token.");
+  }
+  if (typeof userInfo.email !== "string" || !userInfo.email.trim()) {
+    throw new Error("OIDC UserInfo response does not contain an email address.");
+  }
+  if (userInfo.email_verified !== true) {
+    throw new Error("OIDC provider has not verified the email address.");
+  }
+
+  const identity = { email: userInfo.email.trim(), subject };
+  userInfoCache.set(token, identity);
+  return identity;
+};
+
+export const verifyOidcToken = async (
+  token: string,
+  env: Environment = process.env
+): Promise<OidcIdentity> => {
+  const config = getOidcConfiguration(env);
+  const decoded = await verifyJwt(token, config);
+  if (typeof decoded.sub !== "string" || !decoded.sub) {
+    throw new Error("OIDC access token does not contain a subject.");
+  }
+
+  return fetchVerifiedIdentity(token, decoded.sub, config.userInfoUrl);
+};


### PR DESCRIPTION
## Summary

- add a production `oidc` authentication provider alongside Auth0 and local development auth
- validate RS256 access tokens against configured JWKS, issuer, audience, expiry, and subject claims
- bind the access-token subject to UserInfo and require a provider-verified email before resolving the Multiforum user
- expose OIDC readiness through instance setup status and fail fast on invalid startup configuration
- document the backend OIDC deployment contract for standards-compatible providers such as Keycloak and Zitadel

## Security properties

- HTTPS-only provider endpoints outside loopback tests
- exact issuer and audience validation
- RS256 algorithm allow-list and JWKS key rotation support
- UserInfo `sub` equality check and `email_verified: true` requirement
- no provider tokens or environment values exposed through setup status

## Validation

- `pnpm run lint`
- `pnpm run tsc`
- `pnpm test` — 1,295 passed
- focused OIDC verifier coverage — 97.63% statements/lines, 94.64% branches, 100% functions

## Follow-up

This establishes backend token validation first. A stacked frontend PR will add generic OIDC login/session handling and deployment configuration.
